### PR TITLE
Fix/standalone preview node size

### DIFF
--- a/web/pano_editor.js
+++ b/web/pano_editor.js
@@ -10128,12 +10128,21 @@ function installEditorButton(nodeType, nodeData, matchType, buttonText) {
 
 function installStandalonePreviewNode(nodeType) {
   if (!nodeType?.prototype) return;
-  const prev = nodeType.prototype.onNodeCreated;
-  nodeType.prototype.onNodeCreated = function () {
-    const r = prev ? prev.apply(this, arguments) : undefined;
+  const ensurePreviewSize = function () {
     if (!Array.isArray(this.size) || this.size[0] < 100 || this.size[1] < 100) {
       this.size = [360, 260];
     }
+  };
+  const prev = nodeType.prototype.onNodeCreated;
+  nodeType.prototype.onNodeCreated = function () {
+    const r = prev ? prev.apply(this, arguments) : undefined;
+    ensurePreviewSize.call(this);
+    return r;
+  };
+  const prevConfigure = nodeType.prototype.onConfigure;
+  nodeType.prototype.onConfigure = function () {
+    const r = prevConfigure ? prevConfigure.apply(this, arguments) : undefined;
+    ensurePreviewSize.call(this);
     return r;
   };
 }

--- a/web/pano_editor.js
+++ b/web/pano_editor.js
@@ -10126,9 +10126,15 @@ function installEditorButton(nodeType, nodeData, matchType, buttonText) {
 }
 
 function installStandalonePreviewNode(nodeType) {
-  if (!Array.isArray(nodeType?.prototype?.size) || nodeType.prototype.size[0] < 100 || nodeType.prototype.size[1] < 100) {
-    nodeType.prototype.size = [360, 260];
-  }
+  if (!nodeType?.prototype) return;
+  const prev = nodeType.prototype.onNodeCreated;
+  nodeType.prototype.onNodeCreated = function () {
+    const r = prev ? prev.apply(this, arguments) : undefined;
+    if (!Array.isArray(this.size) || this.size[0] < 100 || this.size[1] < 100) {
+      this.size = [360, 260];
+    }
+    return r;
+  };
 }
 
 function installStandalonePreviewInstance(node) {

--- a/web/pano_editor.js
+++ b/web/pano_editor.js
@@ -10029,6 +10029,7 @@ function showEditor(node, type, options = {}) {
 }
 
 function installEditorButton(nodeType, nodeData, matchType, buttonText) {
+  if (!nodeType?.prototype) return;
   const cleanupPreviewBindings = (node) => {
     try { node.__panoDomRestore?.(); } catch { }
     try { node.__panoLegacyRestore?.(); } catch { }


### PR DESCRIPTION
Fix TypeError in beforeRegisterNodeDef reported in #20.

installStandalonePreviewNode was setting nodeType.prototype.size directly, but LiteGraph's size is a setter that only works on instances — so it threw a TypeError on  every startup and the default size was never applied. Moved the size initialization to onNodeCreated and onConfigure so it runs on instances instead. Also added a   nodeType.prototype guard to installEditorButton for consistency.