### PR TITLE
Bump version to 1.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "panorama-stickers"
 description = "A ComfyUI node set and frontend extension for interactive 360 panorama workflows."
-version = "1.3.2"
+version = "1.3.3"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
## Summary

- bump the package version from 1.3.2 to 1.3.3 after merging the Panorama Stickers editor loading recovery changes

## Validation

- parsed `pyproject.toml` with Python `tomllib`
- confirmed `project.version` is `1.3.3`
- `git diff --check` passed
