### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
 ## Nodes
 
 - `Panorama Stickers`: Place, scale, and rotate sticker images onto an ERP canvas and output a composited conditioning panorama.
-- `Panorama Cutout`: Extract a framed perspective view from an ERP image using a saved camera/frame state.
+- `Panorama Cutout`: Compose and extract a framed perspective view from an ERP image with interactive camera, aspect-ratio, and roll controls.
 - `Panorama Preview`: Show an interactive panorama preview inside ComfyUI without duplicating the default image preview.
 - `Panorama Seam Prep`: Shift an ERP seam into the center and generate hard / blurred vertical seam masks for seam-focused inpainting.
 
@@ -47,6 +47,11 @@ https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
   - [LTX-2.3_360vr_distilled_3stage.json](./example_workflows/LTX-2.3_360vr_distilled_3stage.json)
 
 ## Changelog
+
+### 1.4.0
+
+- Rebuilt the Panorama Cutout Frame view as an interactive crop-style camera editor.
+- Added direct camera framing, aspect-ratio, orientation, and roll controls while keeping the Panorama view state independent.
 
 ### 1.3.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "panorama-stickers"
 description = "A ComfyUI node set and frontend extension for interactive 360 panorama workflows."
-version = "1.3.3"
+version = "1.4.0"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)


### PR DESCRIPTION
## Summary

- bump the package version from 1.3.3 to 1.4.0
- update the Panorama Cutout description to mention its interactive camera controls
- add a short 1.4.0 changelog entry for the rebuilt crop-style Frame editor

## Why

The Cutout Frame redesign adds user-facing camera framing, aspect-ratio, orientation, and Roll controls. This is a feature release rather than a patch-only change, so the minor version advances to 1.4.0.

## Validation

- parsed `pyproject.toml` with Python `tomllib` and confirmed `project.version == "1.4.0"`
- `git diff --check`
