### PR TITLE
v1.5.0のリリース準備とノードUIの安定化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ComfyUI Panorama Stickers
 
+[![English](https://img.shields.io/badge/README-English-3b82f6.svg)](./README.md)
+[![日本語](https://img.shields.io/badge/README-日本語-e11d48.svg)](./README_JA.md)
+[![中文](https://img.shields.io/badge/README-中文-16a34a.svg)](./README_ZH.md)
+
 [![LoRA 4B](https://img.shields.io/badge/LoRA-4B-f0b429.svg)](https://huggingface.co/nomadoor/flux-2-klein-4B-360-erp-outpaint-lora)
 [![LoRA 9B](https://img.shields.io/badge/LoRA-9B-f59e0b.svg)](https://huggingface.co/nomadoor/flux-2-klein-9B-360-erp-outpaint-lora)
 [![Guide](https://img.shields.io/badge/Guide-English-3b82f6.svg)](https://comfyui.nomadoor.net/en/notes/panorama-stickers/)
@@ -30,7 +34,7 @@ https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
 - v1.2.0 demo: https://gyazo.com/d4c2517589d7c96d27942af76a1ead27
 - v1.3.0 demo: https://gyazo.com/3da5973bb661df8fb1d11dd1e71a2b1f
 - v1.4.0 demo: https://gyazo.com/26ceba6dcc3516ce6b8c461fcfde4dad
-- v1.5.0 demo: 
+- v1.5.0 demo: https://gyazo.com/954d9a4acee41a13e6aebfcb125b9a48
 
 ## Nodes
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,19 @@ https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
 
 - v1.2.0 demo: https://gyazo.com/d4c2517589d7c96d27942af76a1ead27
 - v1.3.0 demo: https://gyazo.com/3da5973bb661df8fb1d11dd1e71a2b1f
+- v1.4.0 demo: https://gyazo.com/26ceba6dcc3516ce6b8c461fcfde4dad
+- v1.5.0 demo: 
 
 ## Nodes
 
-- `Panorama Stickers`: Place, scale, and rotate sticker images onto an ERP canvas and output a composited conditioning panorama.
-- `Panorama Cutout`: Compose and extract a framed perspective view from an ERP image with interactive camera, aspect-ratio, and roll controls.
-- `Panorama Preview`: Show an interactive panorama preview inside ComfyUI without duplicating the default image preview.
+- `Panorama Stickers`: Place and adjust sticker images on an ERP canvas, then output the composited panorama.
+- `Panorama Cutout`: Compose and extract a framed perspective view from an ERP image.
+- `Panorama Preview`: Inspect still or animated ERP inputs in an interactive panorama viewer.
 - `Panorama Seam Prep`: Shift an ERP seam into the center and generate hard / blurred vertical seam masks for seam-focused inpainting.
+
+### On-node panorama controls
+
+`Panorama Stickers`, `Panorama Cutout`, and `Panorama Preview` now include lightweight on-node UIs for completing common interactions without opening the Full Editor. Both the legacy canvas and Node 2.0 are supported.
 
 ## Workflow
 
@@ -47,6 +53,11 @@ https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
   - [LTX-2.3_360vr_distilled_3stage.json](./example_workflows/LTX-2.3_360vr_distilled_3stage.json)
 
 ## Changelog
+
+### 1.5.0
+
+- Added lightweight on-node UIs to `Panorama Cutout`, `Panorama Preview`, and `Panorama Stickers`, allowing common interactions to be completed without opening the Full Editor.
+- Improved preview performance and reliability across the legacy canvas and Node 2.0.
 
 ### 1.4.0
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,108 @@
+# ComfyUI Panorama Stickers
+
+[![English](https://img.shields.io/badge/README-English-3b82f6.svg)](./README.md)
+[![日本語](https://img.shields.io/badge/README-日本語-e11d48.svg)](./README_JA.md)
+[![中文](https://img.shields.io/badge/README-中文-16a34a.svg)](./README_ZH.md)
+
+[![LoRA 4B](https://img.shields.io/badge/LoRA-4B-f0b429.svg)](https://huggingface.co/nomadoor/flux-2-klein-4B-360-erp-outpaint-lora)
+[![LoRA 9B](https://img.shields.io/badge/LoRA-9B-f59e0b.svg)](https://huggingface.co/nomadoor/flux-2-klein-9B-360-erp-outpaint-lora)
+[![ガイド](https://img.shields.io/badge/Guide-日本語-3b82f6.svg)](https://comfyui.nomadoor.net/ja/notes/panorama-stickers/)
+
+ComfyUI Panorama Stickersは、ComfyUI上で360度正距円筒図法（ERP）パノラマを扱うための小規模なノードセット兼フロントエンド拡張です。インタラクティブなプレビュー、フレーム付き切り抜き、画像合成に対応しています。
+
+FLUX.2 Kleinのパノラマworkflowを中心に開発しており、4B・9Bの両方で利用できます。
+
+このworkflowは、以下のFLUX.2 Klein 360 ERP outpaint LoRAを支援するために作成しました。
+
+- [nomadoor/flux-2-klein-4B-360-erp-outpaint-lora](https://huggingface.co/nomadoor/flux-2-klein-4B-360-erp-outpaint-lora)
+- [nomadoor/flux-2-klein-9B-360-erp-outpaint-lora](https://huggingface.co/nomadoor/flux-2-klein-9B-360-erp-outpaint-lora)
+
+詳しい使い方はこちらです。
+
+- English: [comfyui.nomadoor.net/en/notes/panorama-stickers/](https://comfyui.nomadoor.net/en/notes/panorama-stickers/)
+- 日本語: [comfyui.nomadoor.net/ja/notes/panorama-stickers/](https://comfyui.nomadoor.net/ja/notes/panorama-stickers/)
+- 中文: [comfyui.nomadoor.net/zh/notes/panorama-stickers/](https://comfyui.nomadoor.net/zh/notes/panorama-stickers/)
+
+## インストール
+
+- ComfyUI Managerからインストールしてください。
+
+## デモ
+
+https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
+
+- v1.2.0 demo: https://gyazo.com/d4c2517589d7c96d27942af76a1ead27
+- v1.3.0 demo: https://gyazo.com/3da5973bb661df8fb1d11dd1e71a2b1f
+- v1.4.0 demo: https://gyazo.com/26ceba6dcc3516ce6b8c461fcfde4dad
+- v1.5.0 demo: https://gyazo.com/954d9a4acee41a13e6aebfcb125b9a48
+
+## ノード
+
+- `Panorama Stickers`: ERPキャンバス上へステッカー画像を配置・調整し、合成済みパノラマを出力します。
+- `Panorama Cutout`: ERP画像からフレーム付きの透視投影ビューを構成して切り出します。
+- `Panorama Preview`: 静止画または動画のERP入力を、インタラクティブなパノラマビューアーで確認します。
+- `Panorama Seam Prep`: ERPの継ぎ目を中央へ移動し、継ぎ目のinpainting用にハード／ぼかし付きの縦マスクを生成します。
+
+### ノード上パノラマ操作
+
+`Panorama Stickers`、`Panorama Cutout`、`Panorama Preview`には、Full Editorを開かずに一般的な操作を完結できる軽量なノード上UIがあります。Legacy canvasとNode 2.0の両方に対応しています。
+
+## Workflow
+
+- パノラマ静止画workflow
+  - [flux-2-klein-4B-360-erp-outpaint.json](./example_workflows/flux-2-klein-4B-360-erp-outpaint.json)
+  - [flux-2-klein-9B-360-erp-outpaint.json](./example_workflows/flux-2-klein-9B-360-erp-outpaint.json)
+- 360度パノラマ動画workflow
+  - モデル作者が作成した[LTX2.3_360vr](https://civitai.com/models/2327337/360-degree-panoramic-shot-ltx-23) LoRAを使うことで、テキストから360度パノラマ動画を生成できます。
+  - [LTX-2.3_360vr_distilled_3stage.json](./example_workflows/LTX-2.3_360vr_distilled_3stage.json)
+
+## 更新履歴
+
+### 1.5.0
+
+- `Panorama Cutout`、`Panorama Preview`、`Panorama Stickers`に軽量なノード上UIを追加し、Full Editorを開かずに一般的な操作を完結できるようにしました。
+- Legacy canvasとNode 2.0の両方で、プレビューのパフォーマンスと信頼性を改善しました。
+
+### 1.4.0
+
+- Panorama CutoutのFrame viewを、インタラクティブなcrop形式のcamera editorとして再構築しました。
+- Panorama viewの状態を独立させたまま、camera framing、aspect ratio、orientation、rollを直接操作できるようにしました。
+
+### 1.3.0
+
+- 動画に対応しました。
+- 180度パノラマに対応しました。
+- リファクタリングによりパフォーマンスを大幅に改善しました。
+
+### 1.2.0
+
+- モーダルパノラマeditorにPaint／Maskツールを追加しました。
+
+### 1.1.0
+
+- パノラマ描画をWebGL優先のpipelineへ移行しました。
+- `Panorama Cutout`で生成した画像を`Panorama Stickers`でパノラマへ再合成できるようにしました。
+
+## ToDo
+
+- 外部upscaling用にパノラマを複数画像へ分割し、処理後に再結合するツールを追加する。
+- 入力画像からcamera intrinsicsを自動推定する。
+- 3D sceneに対応する。
+- Huginと連携する。
+
+## 謝辞
+
+このプロジェクトは、特に以下の[ProGamerGov](https://github.com/ProGamerGov)氏の成果から一部影響を受けています。
+
+- [ProGamerGov/ComfyUI_pytorch360convert](https://github.com/ProGamerGov/ComfyUI_pytorch360convert)
+- [ProGamerGov/html-360-viewer](https://github.com/ProGamerGov/html-360-viewer)
+
+## 便利なツール
+
+ERP画像をブラウザ上ですばやくパノラマ表示したい場合は、こちらのviewerが便利です。
+
+- [html-360-viewer demo](https://progamergov.github.io/html-360-viewer/)
+
+## ライセンス
+
+MIT

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,0 +1,108 @@
+# ComfyUI Panorama Stickers
+
+[![English](https://img.shields.io/badge/README-English-3b82f6.svg)](./README.md)
+[![日本語](https://img.shields.io/badge/README-日本語-e11d48.svg)](./README_JA.md)
+[![中文](https://img.shields.io/badge/README-中文-16a34a.svg)](./README_ZH.md)
+
+[![LoRA 4B](https://img.shields.io/badge/LoRA-4B-f0b429.svg)](https://huggingface.co/nomadoor/flux-2-klein-4B-360-erp-outpaint-lora)
+[![LoRA 9B](https://img.shields.io/badge/LoRA-9B-f59e0b.svg)](https://huggingface.co/nomadoor/flux-2-klein-9B-360-erp-outpaint-lora)
+[![指南](https://img.shields.io/badge/Guide-中文-3b82f6.svg)](https://comfyui.nomadoor.net/zh/notes/panorama-stickers/)
+
+ComfyUI Panorama Stickers 是一套小型 ComfyUI 节点与前端扩展，用于在 ComfyUI 中处理 360° 等距柱状投影（ERP）全景图，包括交互式预览、带画框的透视裁切和图像合成。
+
+本项目围绕 FLUX.2 Klein 全景图 workflow 开发，可用于 4B 和 9B 两种版本。
+
+此 workflow 旨在配合以下 FLUX.2 Klein 360 ERP outpaint LoRA 使用：
+
+- [nomadoor/flux-2-klein-4B-360-erp-outpaint-lora](https://huggingface.co/nomadoor/flux-2-klein-4B-360-erp-outpaint-lora)
+- [nomadoor/flux-2-klein-9B-360-erp-outpaint-lora](https://huggingface.co/nomadoor/flux-2-klein-9B-360-erp-outpaint-lora)
+
+详细使用说明：
+
+- English: [comfyui.nomadoor.net/en/notes/panorama-stickers/](https://comfyui.nomadoor.net/en/notes/panorama-stickers/)
+- 日本語: [comfyui.nomadoor.net/ja/notes/panorama-stickers/](https://comfyui.nomadoor.net/ja/notes/panorama-stickers/)
+- 中文: [comfyui.nomadoor.net/zh/notes/panorama-stickers/](https://comfyui.nomadoor.net/zh/notes/panorama-stickers/)
+
+## 安装
+
+- 通过 ComfyUI Manager 安装。
+
+## 演示
+
+https://github.com/user-attachments/assets/bf74e953-8ceb-4c7f-afa2-1c805f12c7af
+
+- v1.2.0 demo: https://gyazo.com/d4c2517589d7c96d27942af76a1ead27
+- v1.3.0 demo: https://gyazo.com/3da5973bb661df8fb1d11dd1e71a2b1f
+- v1.4.0 demo: https://gyazo.com/26ceba6dcc3516ce6b8c461fcfde4dad
+- v1.5.0 demo: https://gyazo.com/954d9a4acee41a13e6aebfcb125b9a48
+
+## 节点
+
+- `Panorama Stickers`：在 ERP 画布上放置和调整贴图，并输出合成后的全景图。
+- `Panorama Cutout`：从 ERP 图像构建并提取带画框的透视视图。
+- `Panorama Preview`：通过交互式全景查看器预览静态或动态 ERP 输入。
+- `Panorama Seam Prep`：将 ERP 接缝移至中心，并生成用于接缝局部 inpainting 的硬边／模糊竖向遮罩。
+
+### 节点内全景控制
+
+`Panorama Stickers`、`Panorama Cutout` 和 `Panorama Preview` 现已提供轻量级节点内 UI，无需打开 Full Editor 即可完成常用操作。Legacy canvas 和 Node 2.0 均受支持。
+
+## Workflow
+
+- 全景静态图 workflow
+  - [flux-2-klein-4B-360-erp-outpaint.json](./example_workflows/flux-2-klein-4B-360-erp-outpaint.json)
+  - [flux-2-klein-9B-360-erp-outpaint.json](./example_workflows/flux-2-klein-9B-360-erp-outpaint.json)
+- 360° 全景视频 workflow
+  - 使用该模型作者制作的 [LTX2.3_360vr](https://civitai.com/models/2327337/360-degree-panoramic-shot-ltx-23) LoRA，可以通过文本生成 360° 全景视频。
+  - [LTX-2.3_360vr_distilled_3stage.json](./example_workflows/LTX-2.3_360vr_distilled_3stage.json)
+
+## 更新日志
+
+### 1.5.0
+
+- 为 `Panorama Cutout`、`Panorama Preview` 和 `Panorama Stickers` 添加轻量级节点内 UI，无需打开 Full Editor 即可完成常用操作。
+- 改善了 Legacy canvas 和 Node 2.0 中预览的性能与可靠性。
+
+### 1.4.0
+
+- 将 Panorama Cutout 的 Frame view 重构为交互式裁切风格的 camera editor。
+- 在保持 Panorama view 状态独立的同时，加入直接调整 camera framing、aspect ratio、orientation 和 roll 的功能。
+
+### 1.3.0
+
+- 添加视频支持。
+- 添加 180° 全景支持。
+- 通过重构大幅提升性能。
+
+### 1.2.0
+
+- 在模态全景 editor 中加入 Paint／Mask 工具。
+
+### 1.1.0
+
+- 将全景渲染切换为 WebGL 优先 pipeline。
+- 支持通过 `Panorama Stickers` 将 `Panorama Cutout` 生成的图像重新合成至全景图。
+
+## ToDo
+
+- 添加将全景图拆分为多张图像以便外部 upscaling，并在处理后重新合并的工具。
+- 根据输入图像自动估算 camera intrinsics。
+- 添加 3D scene 支持。
+- 添加 Hugin 集成。
+
+## 致谢
+
+本项目部分受到 [ProGamerGov](https://github.com/ProGamerGov) 以下项目的启发：
+
+- [ProGamerGov/ComfyUI_pytorch360convert](https://github.com/ProGamerGov/ComfyUI_pytorch360convert)
+- [ProGamerGov/html-360-viewer](https://github.com/ProGamerGov/html-360-viewer)
+
+## 实用工具
+
+如果需要在浏览器中快速将 ERP 图像作为全景图预览，可以使用此查看器：
+
+- [html-360-viewer demo](https://progamergov.github.io/html-360-viewer/)
+
+## 许可证
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "panorama-stickers"
 description = "A ComfyUI node set and frontend extension for interactive 360 panorama workflows."
-version = "1.4.0"
+version = "1.5.0"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)

--- a/tests/pano_dom_widget_lifecycle.test.mjs
+++ b/tests/pano_dom_widget_lifecycle.test.mjs
@@ -2,9 +2,23 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  assignFreshDomWidgetRenderIdentity,
   removeTrackedDomWidget,
   trackDomWidgetRemoval,
 } from "../web_src/pano_dom_widget_lifecycle.js";
+
+test("restored DOM widgets receive a fresh Node 2.0 render identity", () => {
+  const first = assignFreshDomWidgetRenderIdentity({ name: "preview", type: "preview" });
+  const restored = assignFreshDomWidgetRenderIdentity({ name: "preview", type: "preview" });
+  const firstType = first.type;
+
+  assignFreshDomWidgetRenderIdentity(first);
+
+  assert.notEqual(restored.type, firstType);
+  assert.equal(first.type, firstType);
+  assert.match(first.type, /^preview:pano-/);
+  assert.match(restored.type, /^preview:pano-/);
+});
 
 test("tracked DOM widget removal unregisters once and keeps widget values aligned", () => {
   let removeCalls = 0;

--- a/tests/pano_sticker_affordance.test.mjs
+++ b/tests/pano_sticker_affordance.test.mjs
@@ -63,7 +63,7 @@ test("shared sticker hit descriptor owns modal-compatible hover cursors", () => 
   assert.deepEqual(hitStickerSelectionAffordance(geometry, geometry.center), { kind: "move", cursor: "default" });
 });
 
-test("shared sticker handles use the modal circle sizes and white rotation stem", () => {
+test("shared sticker handles use compact circle sizes and a white rotation stem", () => {
   const ctx = recordingContext();
   const geometry = {
     corners: [{ x: 0, y: 0 }, { x: 10, y: 0 }, { x: 10, y: 10 }, { x: 0, y: 10 }],
@@ -73,7 +73,7 @@ test("shared sticker handles use the modal circle sizes and white rotation stem"
 
   drawStickerSelectionHandles(ctx, geometry, { accent: "#0070f3" });
 
-  assert.deepEqual(ctx.arcs.map((arc) => arc.radius), [6.5, 6.5, 6.5, 6.5, 10]);
+  assert.deepEqual(ctx.arcs.map((arc) => arc.radius), [5.5, 5.5, 5.5, 5.5, 8]);
   assert.deepEqual(ctx.arcs.map((arc) => arc.color), Array(5).fill("#0070f3"));
   assert.deepEqual(ctx.lines, [{
     points: [{ x: 5, y: 0 }, { x: 5, y: -30 }],

--- a/tests/pano_sticker_geometry.test.mjs
+++ b/tests/pano_sticker_geometry.test.mjs
@@ -66,6 +66,10 @@ test("sticker geometry is centered, ordered, and exposes modal-compatible handle
   assert.ok(geom.corners[0].x < geom.corners[1].x);
   assert.ok(geom.corners[0].y < geom.corners[3].y);
   assert.ok(geom.rotateHandle.y < geom.rotateStemBase.y);
+  assert.ok(Math.abs(Math.hypot(
+    geom.rotateHandle.x - geom.rotateStemBase.x,
+    geom.rotateHandle.y - geom.rotateStemBase.y,
+  ) - 24) < 1e-9);
   assert.deepEqual(hitStickerGeometry(geom, geom.center), { kind: "move", cursor: "default" });
   assert.deepEqual(hitStickerGeometry(geom, geom.corners[0]), { kind: "scale", cornerIndex: 0, cursor: "nwse-resize" });
   assert.deepEqual(hitStickerGeometry(geom, geom.corners[1]), { kind: "scale", cornerIndex: 1, cursor: "nesw-resize" });

--- a/tests/pano_stickers_node_surface_contract.test.mjs
+++ b/tests/pano_stickers_node_surface_contract.test.mjs
@@ -254,7 +254,10 @@ test("Stickers canvas wires selection and direct transform gestures through the 
   assert.match(editor, /drawStickerSelectionBoundary\(/);
   assert.match(editor, /hitStickerSelectionAffordance\(/);
   assert.doesNotMatch(editor, /STICKER_NODE_ROTATE_HANDLE_OFFSET_PX/);
-  assert.match(editor, /rotateHandle:\s*\{[\s\S]*?\*\s*30/);
+  const stickerGeometryStart = editor.indexOf("function buildSceneItemGeom(item) {");
+  const stickerGeometryEnd = editor.indexOf("\n  function ", stickerGeometryStart + 1);
+  const stickerGeometry = editor.slice(stickerGeometryStart, stickerGeometryEnd);
+  assert.match(stickerGeometry, /const rotateHandle\s*=\s*\{\s*x:\s*rotateStemBase\.x\s*\+\s*\(handleDx\s*\/\s*handleLen\)\s*\*\s*30,\s*y:\s*rotateStemBase\.y\s*\+\s*\(handleDy\s*\/\s*handleLen\)\s*\*\s*30,/);
   assert.match(runtime, /nodeSurfaceSession\.apply\(\{\s*type:\s*"select-sticker"/);
   assert.match(runtime, /nodeSurfaceSession\.beginGesture\(\)/);
   assert.match(runtime, /type:\s*"set-transform"/);

--- a/tests/pano_stickers_node_surface_contract.test.mjs
+++ b/tests/pano_stickers_node_surface_contract.test.mjs
@@ -253,6 +253,8 @@ test("Stickers canvas wires selection and direct transform gestures through the 
   assert.match(editor, /drawStickerSelectionHandles\(/);
   assert.match(editor, /drawStickerSelectionBoundary\(/);
   assert.match(editor, /hitStickerSelectionAffordance\(/);
+  assert.doesNotMatch(editor, /STICKER_NODE_ROTATE_HANDLE_OFFSET_PX/);
+  assert.match(editor, /rotateHandle:\s*\{[\s\S]*?\*\s*30/);
   assert.match(runtime, /nodeSurfaceSession\.apply\(\{\s*type:\s*"select-sticker"/);
   assert.match(runtime, /nodeSurfaceSession\.beginGesture\(\)/);
   assert.match(runtime, /type:\s*"set-transform"/);

--- a/web/panorama_suite.js
+++ b/web/panorama_suite.js
@@ -7,49 +7,49 @@ import { api as bn } from "../../scripts/api.js";
 * @license MIT
 **/
 // @__NO_SIDE_EFFECTS__
-function tc(e) {
+function nc(e) {
   const t = /* @__PURE__ */ Object.create(null);
   for (const n of e.split(",")) t[n] = 1;
   return (n) => n in t;
 }
 const kt = {}, da = [], wr = () => {
-}, Bh = () => !1, Qs = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && // uppercase letter
-(e.charCodeAt(2) > 122 || e.charCodeAt(2) < 97), el = (e) => e.startsWith("onUpdate:"), xn = Object.assign, nc = (e, t) => {
+}, Yh = () => !1, Qs = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && // uppercase letter
+(e.charCodeAt(2) > 122 || e.charCodeAt(2) < 97), el = (e) => e.startsWith("onUpdate:"), xn = Object.assign, rc = (e, t) => {
   const n = e.indexOf(t);
   n > -1 && e.splice(n, 1);
-}, Fb = Object.prototype.hasOwnProperty, ht = (e, t) => Fb.call(e, t), Xe = Array.isArray, ha = (e) => _o(e) === "[object Map]", Gh = (e) => _o(e) === "[object Set]", ld = (e) => _o(e) === "[object Date]", Ze = (e) => typeof e == "function", Vt = (e) => typeof e == "string", kr = (e) => typeof e == "symbol", yt = (e) => e !== null && typeof e == "object", Kh = (e) => (yt(e) || Ze(e)) && Ze(e.then) && Ze(e.catch), Wh = Object.prototype.toString, _o = (e) => Wh.call(e), Rb = (e) => _o(e).slice(8, -1), Yh = (e) => _o(e) === "[object Object]", rc = (e) => Vt(e) && e !== "NaN" && e[0] !== "-" && "" + parseInt(e, 10) === e, eo = /* @__PURE__ */ tc(
+}, $b = Object.prototype.hasOwnProperty, ht = (e, t) => $b.call(e, t), Xe = Array.isArray, ha = (e) => _o(e) === "[object Map]", qh = (e) => _o(e) === "[object Set]", ud = (e) => _o(e) === "[object Date]", Ze = (e) => typeof e == "function", Vt = (e) => typeof e == "string", kr = (e) => typeof e == "symbol", yt = (e) => e !== null && typeof e == "object", Xh = (e) => (yt(e) || Ze(e)) && Ze(e.then) && Ze(e.catch), Jh = Object.prototype.toString, _o = (e) => Jh.call(e), jb = (e) => _o(e).slice(8, -1), Zh = (e) => _o(e) === "[object Object]", ic = (e) => Vt(e) && e !== "NaN" && e[0] !== "-" && "" + parseInt(e, 10) === e, eo = /* @__PURE__ */ nc(
   // the leading comma is intentional so empty string "" is also included
   ",key,ref,ref_for,ref_key,onVnodeBeforeMount,onVnodeMounted,onVnodeBeforeUpdate,onVnodeUpdated,onVnodeBeforeUnmount,onVnodeUnmounted"
 ), tl = (e) => {
   const t = /* @__PURE__ */ Object.create(null);
   return ((n) => t[n] || (t[n] = e(n)));
-}, Lb = /-\w/g, Pn = tl(
-  (e) => e.replace(Lb, (t) => t.slice(1).toUpperCase())
-), zb = /\B([A-Z])/g, Ti = tl(
-  (e) => e.replace(zb, "-$1").toLowerCase()
+}, Vb = /-\w/g, Pn = tl(
+  (e) => e.replace(Vb, (t) => t.slice(1).toUpperCase())
+), Hb = /\B([A-Z])/g, Ti = tl(
+  (e) => e.replace(Hb, "-$1").toLowerCase()
 ), nl = tl((e) => e.charAt(0).toUpperCase() + e.slice(1)), Xl = tl(
   (e) => e ? `on${nl(e)}` : ""
 ), mr = (e, t) => !Object.is(e, t), bs = (e, ...t) => {
   for (let n = 0; n < e.length; n++)
     e[n](...t);
-}, qh = (e, t, n, r = !1) => {
+}, Qh = (e, t, n, r = !1) => {
   Object.defineProperty(e, t, {
     configurable: !0,
     enumerable: !1,
     writable: r,
     value: n
   });
-}, ic = (e) => {
+}, ac = (e) => {
   const t = parseFloat(e);
   return isNaN(t) ? e : t;
 };
-let ud;
-const rl = () => ud || (ud = typeof globalThis < "u" ? globalThis : typeof self < "u" ? self : typeof window < "u" ? window : typeof global < "u" ? global : {});
+let cd;
+const rl = () => cd || (cd = typeof globalThis < "u" ? globalThis : typeof self < "u" ? self : typeof window < "u" ? window : typeof global < "u" ? global : {});
 function Bt(e) {
   if (Xe(e)) {
     const t = {};
     for (let n = 0; n < e.length; n++) {
-      const r = e[n], a = Vt(r) ? Hb(r) : Bt(r);
+      const r = e[n], a = Vt(r) ? Kb(r) : Bt(r);
       if (a)
         for (const o in a)
           t[o] = a[o];
@@ -58,12 +58,12 @@ function Bt(e) {
   } else if (Vt(e) || yt(e))
     return e;
 }
-const $b = /;(?![^(]*\))/g, jb = /:([^]+)/, Vb = /\/\*[^]*?\*\//g;
-function Hb(e) {
+const Ub = /;(?![^(]*\))/g, Bb = /:([^]+)/, Gb = /\/\*[^]*?\*\//g;
+function Kb(e) {
   const t = {};
-  return e.replace(Vb, "").split($b).forEach((n) => {
+  return e.replace(Gb, "").split(Ub).forEach((n) => {
     if (n) {
-      const r = n.split(jb);
+      const r = n.split(Bb);
       r.length > 1 && (t[r[0].trim()] = r[1].trim());
     }
   }), t;
@@ -82,26 +82,26 @@ function ft(e) {
       e[n] && (t += n + " ");
   return t.trim();
 }
-const Ub = "itemscope,allowfullscreen,formnovalidate,ismap,nomodule,novalidate,readonly", Bb = /* @__PURE__ */ tc(Ub);
-function Xh(e) {
+const Wb = "itemscope,allowfullscreen,formnovalidate,ismap,nomodule,novalidate,readonly", Yb = /* @__PURE__ */ nc(Wb);
+function ep(e) {
   return !!e || e === "";
 }
-function Gb(e, t) {
+function qb(e, t) {
   if (e.length !== t.length) return !1;
   let n = !0;
   for (let r = 0; n && r < e.length; r++)
-    n = ac(e[r], t[r]);
+    n = oc(e[r], t[r]);
   return n;
 }
-function ac(e, t) {
+function oc(e, t) {
   if (e === t) return !0;
-  let n = ld(e), r = ld(t);
+  let n = ud(e), r = ud(t);
   if (n || r)
     return n && r ? e.getTime() === t.getTime() : !1;
   if (n = kr(e), r = kr(t), n || r)
     return e === t;
   if (n = Xe(e), r = Xe(t), n || r)
-    return n && r ? Gb(e, t) : !1;
+    return n && r ? qb(e, t) : !1;
   if (n = yt(e), r = yt(t), n || r) {
     if (!n || !r)
       return !1;
@@ -110,20 +110,20 @@ function ac(e, t) {
       return !1;
     for (const c in e) {
       const f = e.hasOwnProperty(c), h = t.hasOwnProperty(c);
-      if (f && !h || !f && h || !ac(e[c], t[c]))
+      if (f && !h || !f && h || !oc(e[c], t[c]))
         return !1;
     }
   }
   return String(e) === String(t);
 }
-const Jh = (e) => !!(e && e.__v_isRef === !0), ct = (e) => Vt(e) ? e : e == null ? "" : Xe(e) || yt(e) && (e.toString === Wh || !Ze(e.toString)) ? Jh(e) ? ct(e.value) : JSON.stringify(e, Zh, 2) : String(e), Zh = (e, t) => Jh(t) ? Zh(e, t.value) : ha(t) ? {
+const tp = (e) => !!(e && e.__v_isRef === !0), ct = (e) => Vt(e) ? e : e == null ? "" : Xe(e) || yt(e) && (e.toString === Jh || !Ze(e.toString)) ? tp(e) ? ct(e.value) : JSON.stringify(e, np, 2) : String(e), np = (e, t) => tp(t) ? np(e, t.value) : ha(t) ? {
   [`Map(${t.size})`]: [...t.entries()].reduce(
     (n, [r, a], o) => (n[Jl(r, o) + " =>"] = a, n),
     {}
   )
-} : Gh(t) ? {
+} : qh(t) ? {
   [`Set(${t.size})`]: [...t.values()].map((n) => Jl(n))
-} : kr(t) ? Jl(t) : yt(t) && !Xe(t) && !Yh(t) ? String(t) : t, Jl = (e, t = "") => {
+} : kr(t) ? Jl(t) : yt(t) && !Xe(t) && !Zh(t) ? String(t) : t, Jl = (e, t = "") => {
   var n;
   return (
     // Symbol.description in es2019+ so we need to cast here to pass
@@ -137,7 +137,7 @@ const Jh = (e) => !!(e && e.__v_isRef === !0), ct = (e) => Vt(e) ? e : e == null
 * @license MIT
 **/
 let On;
-class Kb {
+class Xb {
   // TODO isolatedDeclarations "__v_skip"
   constructor(t = !1) {
     this.detached = t, this._active = !0, this._on = 0, this.effects = [], this.cleanups = [], this._isPaused = !1, this.__v_skip = !0, this.parent = On, !t && On && (this.index = (On.scopes || (On.scopes = [])).push(
@@ -217,12 +217,12 @@ class Kb {
     }
   }
 }
-function Wb() {
+function Jb() {
   return On;
 }
 let Mt;
 const Zl = /* @__PURE__ */ new WeakSet();
-class Qh {
+class rp {
   constructor(t) {
     this.fn = t, this.deps = void 0, this.depsTail = void 0, this.flags = 5, this.next = void 0, this.cleanup = void 0, this.scheduler = void 0, On && On.active && On.effects.push(this);
   }
@@ -236,25 +236,25 @@ class Qh {
    * @internal
    */
   notify() {
-    this.flags & 2 && !(this.flags & 32) || this.flags & 8 || tp(this);
+    this.flags & 2 && !(this.flags & 32) || this.flags & 8 || ap(this);
   }
   run() {
     if (!(this.flags & 1))
       return this.fn();
-    this.flags |= 2, cd(this), np(this);
+    this.flags |= 2, fd(this), op(this);
     const t = Mt, n = rr;
     Mt = this, rr = !0;
     try {
       return this.fn();
     } finally {
-      rp(this), Mt = t, rr = n, this.flags &= -3;
+      sp(this), Mt = t, rr = n, this.flags &= -3;
     }
   }
   stop() {
     if (this.flags & 1) {
       for (let t = this.deps; t; t = t.nextDep)
-        lc(t);
-      this.deps = this.depsTail = void 0, cd(this), this.onStop && this.onStop(), this.flags &= -2;
+        uc(t);
+      this.deps = this.depsTail = void 0, fd(this), this.onStop && this.onStop(), this.flags &= -2;
     }
   }
   trigger() {
@@ -270,19 +270,19 @@ class Qh {
     return Nu(this);
   }
 }
-let ep = 0, to, no;
-function tp(e, t = !1) {
+let ip = 0, to, no;
+function ap(e, t = !1) {
   if (e.flags |= 8, t) {
     e.next = no, no = e;
     return;
   }
   e.next = to, to = e;
 }
-function oc() {
-  ep++;
-}
 function sc() {
-  if (--ep > 0)
+  ip++;
+}
+function lc() {
+  if (--ip > 0)
     return;
   if (no) {
     let t = no;
@@ -307,63 +307,63 @@ function sc() {
   }
   if (e) throw e;
 }
-function np(e) {
+function op(e) {
   for (let t = e.deps; t; t = t.nextDep)
     t.version = -1, t.prevActiveLink = t.dep.activeLink, t.dep.activeLink = t;
 }
-function rp(e) {
+function sp(e) {
   let t, n = e.depsTail, r = n;
   for (; r; ) {
     const a = r.prevDep;
-    r.version === -1 ? (r === n && (n = a), lc(r), Yb(r)) : t = r, r.dep.activeLink = r.prevActiveLink, r.prevActiveLink = void 0, r = a;
+    r.version === -1 ? (r === n && (n = a), uc(r), Zb(r)) : t = r, r.dep.activeLink = r.prevActiveLink, r.prevActiveLink = void 0, r = a;
   }
   e.deps = t, e.depsTail = n;
 }
 function Nu(e) {
   for (let t = e.deps; t; t = t.nextDep)
-    if (t.dep.version !== t.version || t.dep.computed && (ip(t.dep.computed) || t.dep.version !== t.version))
+    if (t.dep.version !== t.version || t.dep.computed && (lp(t.dep.computed) || t.dep.version !== t.version))
       return !0;
   return !!e._dirty;
 }
-function ip(e) {
+function lp(e) {
   if (e.flags & 4 && !(e.flags & 16) || (e.flags &= -17, e.globalVersion === lo) || (e.globalVersion = lo, !e.isSSR && e.flags & 128 && (!e.deps && !e._dirty || !Nu(e))))
     return;
   e.flags |= 2;
   const t = e.dep, n = Mt, r = rr;
   Mt = e, rr = !0;
   try {
-    np(e);
+    op(e);
     const a = e.fn(e._value);
     (t.version === 0 || mr(a, e._value)) && (e.flags |= 128, e._value = a, t.version++);
   } catch (a) {
     throw t.version++, a;
   } finally {
-    Mt = n, rr = r, rp(e), e.flags &= -3;
+    Mt = n, rr = r, sp(e), e.flags &= -3;
   }
 }
-function lc(e, t = !1) {
+function uc(e, t = !1) {
   const { dep: n, prevSub: r, nextSub: a } = e;
   if (r && (r.nextSub = a, e.prevSub = void 0), a && (a.prevSub = r, e.nextSub = void 0), n.subs === e && (n.subs = r, !r && n.computed)) {
     n.computed.flags &= -5;
     for (let o = n.computed.deps; o; o = o.nextDep)
-      lc(o, !0);
+      uc(o, !0);
   }
   !t && !--n.sc && n.map && n.map.delete(n.key);
 }
-function Yb(e) {
+function Zb(e) {
   const { prevDep: t, nextDep: n } = e;
   t && (t.nextDep = n, e.prevDep = void 0), n && (n.prevDep = t, e.nextDep = void 0);
 }
 let rr = !0;
-const ap = [];
+const up = [];
 function Br() {
-  ap.push(rr), rr = !1;
+  up.push(rr), rr = !1;
 }
 function Gr() {
-  const e = ap.pop();
+  const e = up.pop();
   rr = e === void 0 ? !0 : e;
 }
-function cd(e) {
+function fd(e) {
   const { cleanup: t } = e;
   if (e.cleanup = void 0, t) {
     const n = Mt;
@@ -376,12 +376,12 @@ function cd(e) {
   }
 }
 let lo = 0;
-class qb {
+class Qb {
   constructor(t, n) {
     this.sub = t, this.dep = n, this.version = n.version, this.nextDep = this.prevDep = this.nextSub = this.prevSub = this.prevActiveLink = void 0;
   }
 }
-class uc {
+class cc {
   // TODO isolatedDeclarations "__v_skip"
   constructor(t) {
     this.computed = t, this.version = 0, this.activeLink = void 0, this.subs = void 0, this.map = void 0, this.key = void 0, this.sc = 0, this.__v_skip = !0;
@@ -391,7 +391,7 @@ class uc {
       return;
     let n = this.activeLink;
     if (n === void 0 || n.sub !== Mt)
-      n = this.activeLink = new qb(Mt, this), Mt.deps ? (n.prevDep = Mt.depsTail, Mt.depsTail.nextDep = n, Mt.depsTail = n) : Mt.deps = Mt.depsTail = n, op(n);
+      n = this.activeLink = new Qb(Mt, this), Mt.deps ? (n.prevDep = Mt.depsTail, Mt.depsTail.nextDep = n, Mt.depsTail = n) : Mt.deps = Mt.depsTail = n, cp(n);
     else if (n.version === -1 && (n.version = this.version, n.nextDep)) {
       const r = n.nextDep;
       r.prevDep = n.prevDep, n.prevDep && (n.prevDep.nextDep = r), n.prevDep = Mt.depsTail, n.nextDep = void 0, Mt.depsTail.nextDep = n, Mt.depsTail = n, Mt.deps === n && (Mt.deps = r);
@@ -402,22 +402,22 @@ class uc {
     this.version++, lo++, this.notify(t);
   }
   notify(t) {
-    oc();
+    sc();
     try {
       for (let n = this.subs; n; n = n.prevSub)
         n.sub.notify() && n.sub.dep.notify();
     } finally {
-      sc();
+      lc();
     }
   }
 }
-function op(e) {
+function cp(e) {
   if (e.dep.sc++, e.sub.flags & 4) {
     const t = e.dep.computed;
     if (t && !e.dep.subs) {
       t.flags |= 20;
       for (let r = t.deps; r; r = r.nextDep)
-        op(r);
+        cp(r);
     }
     const n = e.dep.subs;
     n !== e && (e.prevSub = n, n && (n.nextSub = e)), e.dep.subs = e;
@@ -435,7 +435,7 @@ function mn(e, t, n) {
     let r = Mu.get(e);
     r || Mu.set(e, r = /* @__PURE__ */ new Map());
     let a = r.get(n);
-    a || (r.set(n, a = new uc()), a.map = r, a.key = n), a.track();
+    a || (r.set(n, a = new cc()), a.map = r, a.key = n), a.track();
   }
 }
 function jr(e, t, n, r, a, o) {
@@ -447,10 +447,10 @@ function jr(e, t, n, r, a, o) {
   const f = (h) => {
     h && h.trigger();
   };
-  if (oc(), t === "clear")
+  if (sc(), t === "clear")
     c.forEach(f);
   else {
-    const h = Xe(e), g = h && rc(n);
+    const h = Xe(e), g = h && ic(n);
     if (h && n === "length") {
       const v = Number(r);
       c.forEach((x, S) => {
@@ -469,7 +469,7 @@ function jr(e, t, n, r, a, o) {
           break;
       }
   }
-  sc();
+  lc();
 }
 function Qi(e) {
   const t = /* @__PURE__ */ dt(e);
@@ -481,7 +481,7 @@ function il(e) {
 function dr(e, t) {
   return /* @__PURE__ */ Kr(e) ? _a(/* @__PURE__ */ xi(e) ? ir(t) : t) : ir(t);
 }
-const Xb = {
+const ey = {
   __proto__: null,
   [Symbol.iterator]() {
     return Ql(this, Symbol.iterator, (e) => dr(this, e));
@@ -560,10 +560,10 @@ const Xb = {
     return La(this, "push", e);
   },
   reduce(e, ...t) {
-    return fd(this, "reduce", e, t);
+    return dd(this, "reduce", e, t);
   },
   reduceRight(e, ...t) {
-    return fd(this, "reduceRight", e, t);
+    return dd(this, "reduceRight", e, t);
   },
   shift() {
     return La(this, "shift");
@@ -598,10 +598,10 @@ function Ql(e, t, n) {
     return o.done || (o.value = n(o.value)), o;
   }), a;
 }
-const Jb = Array.prototype;
+const ty = Array.prototype;
 function Er(e, t, n, r, a, o) {
   const c = il(e), f = c !== e && !/* @__PURE__ */ Yn(e), h = c[t];
-  if (h !== Jb[t]) {
+  if (h !== ty[t]) {
     const x = h.apply(e, o);
     return f ? ir(x) : x;
   }
@@ -614,7 +614,7 @@ function Er(e, t, n, r, a, o) {
   const v = h.call(c, g, r);
   return f && a ? a(v) : v;
 }
-function fd(e, t, n, r) {
+function dd(e, t, n, r) {
   const a = il(e), o = a !== e && !/* @__PURE__ */ Yn(e);
   let c = n, f = !1;
   a !== e && (o ? (f = r.length === 0, c = function(g, v, x) {
@@ -629,22 +629,22 @@ function eu(e, t, n) {
   const r = /* @__PURE__ */ dt(e);
   mn(r, "iterate", uo);
   const a = r[t](...n);
-  return (a === -1 || a === !1) && /* @__PURE__ */ dc(n[0]) ? (n[0] = /* @__PURE__ */ dt(n[0]), r[t](...n)) : a;
+  return (a === -1 || a === !1) && /* @__PURE__ */ hc(n[0]) ? (n[0] = /* @__PURE__ */ dt(n[0]), r[t](...n)) : a;
 }
 function La(e, t, n = []) {
-  Br(), oc();
+  Br(), sc();
   const r = (/* @__PURE__ */ dt(e))[t].apply(e, n);
-  return sc(), Gr(), r;
+  return lc(), Gr(), r;
 }
-const Zb = /* @__PURE__ */ tc("__proto__,__v_isRef,__isVue"), sp = new Set(
+const ny = /* @__PURE__ */ nc("__proto__,__v_isRef,__isVue"), fp = new Set(
   /* @__PURE__ */ Object.getOwnPropertyNames(Symbol).filter((e) => e !== "arguments" && e !== "caller").map((e) => Symbol[e]).filter(kr)
 );
-function Qb(e) {
+function ry(e) {
   kr(e) || (e = String(e));
   const t = /* @__PURE__ */ dt(this);
   return mn(t, "has", e), t.hasOwnProperty(e);
 }
-class lp {
+class dp {
   constructor(t = !1, n = !1) {
     this._isReadonly = t, this._isShallow = n;
   }
@@ -658,16 +658,16 @@ class lp {
     if (n === "__v_isShallow")
       return o;
     if (n === "__v_raw")
-      return r === (a ? o ? uy : dp : o ? fp : cp).get(t) || // receiver is not the reactive proxy, but has the same prototype
+      return r === (a ? o ? hy : gp : o ? mp : pp).get(t) || // receiver is not the reactive proxy, but has the same prototype
       // this means the receiver is a user proxy of the reactive proxy
       Object.getPrototypeOf(t) === Object.getPrototypeOf(r) ? t : void 0;
     const c = Xe(t);
     if (!a) {
       let h;
-      if (c && (h = Xb[n]))
+      if (c && (h = ey[n]))
         return h;
       if (n === "hasOwnProperty")
-        return Qb;
+        return ry;
     }
     const f = Reflect.get(
       t,
@@ -677,22 +677,22 @@ class lp {
       // its class methods
       /* @__PURE__ */ yn(t) ? t : r
     );
-    if ((kr(n) ? sp.has(n) : Zb(n)) || (a || mn(t, "get", n), o))
+    if ((kr(n) ? fp.has(n) : ny(n)) || (a || mn(t, "get", n), o))
       return f;
     if (/* @__PURE__ */ yn(f)) {
-      const h = c && rc(n) ? f : f.value;
+      const h = c && ic(n) ? f : f.value;
       return a && yt(h) ? /* @__PURE__ */ Cu(h) : h;
     }
     return yt(f) ? a ? /* @__PURE__ */ Cu(f) : /* @__PURE__ */ ka(f) : f;
   }
 }
-class up extends lp {
+class hp extends dp {
   constructor(t = !1) {
     super(!1, t);
   }
   set(t, n, r, a) {
     let o = t[n];
-    const c = Xe(t) && rc(n);
+    const c = Xe(t) && ic(n);
     if (!this._isShallow) {
       const g = /* @__PURE__ */ Kr(o);
       if (!/* @__PURE__ */ Yn(r) && !/* @__PURE__ */ Kr(r) && (o = /* @__PURE__ */ dt(o), r = /* @__PURE__ */ dt(r)), !c && /* @__PURE__ */ yn(o) && !/* @__PURE__ */ yn(r))
@@ -714,7 +714,7 @@ class up extends lp {
   }
   has(t, n) {
     const r = Reflect.has(t, n);
-    return (!kr(n) || !sp.has(n)) && mn(t, "has", n), r;
+    return (!kr(n) || !fp.has(n)) && mn(t, "has", n), r;
   }
   ownKeys(t) {
     return mn(
@@ -724,7 +724,7 @@ class up extends lp {
     ), Reflect.ownKeys(t);
   }
 }
-class ey extends lp {
+class iy extends dp {
   constructor(t = !1) {
     super(!0, t);
   }
@@ -735,9 +735,9 @@ class ey extends lp {
     return !0;
   }
 }
-const ty = /* @__PURE__ */ new up(), ny = /* @__PURE__ */ new ey(), ry = /* @__PURE__ */ new up(!0);
+const ay = /* @__PURE__ */ new hp(), oy = /* @__PURE__ */ new iy(), sy = /* @__PURE__ */ new hp(!0);
 const Au = (e) => e, qo = (e) => Reflect.getPrototypeOf(e);
-function iy(e, t, n) {
+function ly(e, t, n) {
   return function(...r) {
     const a = this.__v_raw, o = /* @__PURE__ */ dt(a), c = ha(o), f = e === "entries" || e === Symbol.iterator && c, h = e === "keys" && c, g = a[e](...r), v = n ? Au : t ? _a : ir;
     return !t && mn(
@@ -765,7 +765,7 @@ function Xo(e) {
     return e === "delete" ? !1 : e === "clear" ? void 0 : this;
   };
 }
-function ay(e, t) {
+function uy(e, t) {
   const n = {
     get(a) {
       const o = this.__v_raw, c = /* @__PURE__ */ dt(o), f = /* @__PURE__ */ dt(a);
@@ -833,26 +833,26 @@ function ay(e, t) {
     "entries",
     Symbol.iterator
   ].forEach((a) => {
-    n[a] = iy(a, e, t);
+    n[a] = ly(a, e, t);
   }), n;
 }
-function cc(e, t) {
-  const n = ay(e, t);
+function fc(e, t) {
+  const n = uy(e, t);
   return (r, a, o) => a === "__v_isReactive" ? !e : a === "__v_isReadonly" ? e : a === "__v_raw" ? r : Reflect.get(
     ht(n, a) && a in r ? n : r,
     a,
     o
   );
 }
-const oy = {
-  get: /* @__PURE__ */ cc(!1, !1)
-}, sy = {
-  get: /* @__PURE__ */ cc(!1, !0)
-}, ly = {
-  get: /* @__PURE__ */ cc(!0, !1)
+const cy = {
+  get: /* @__PURE__ */ fc(!1, !1)
+}, fy = {
+  get: /* @__PURE__ */ fc(!1, !0)
+}, dy = {
+  get: /* @__PURE__ */ fc(!0, !1)
 };
-const cp = /* @__PURE__ */ new WeakMap(), fp = /* @__PURE__ */ new WeakMap(), dp = /* @__PURE__ */ new WeakMap(), uy = /* @__PURE__ */ new WeakMap();
-function cy(e) {
+const pp = /* @__PURE__ */ new WeakMap(), mp = /* @__PURE__ */ new WeakMap(), gp = /* @__PURE__ */ new WeakMap(), hy = /* @__PURE__ */ new WeakMap();
+function py(e) {
   switch (e) {
     case "Object":
     case "Array":
@@ -866,43 +866,43 @@ function cy(e) {
       return 0;
   }
 }
-function fy(e) {
-  return e.__v_skip || !Object.isExtensible(e) ? 0 : cy(Rb(e));
+function my(e) {
+  return e.__v_skip || !Object.isExtensible(e) ? 0 : py(jb(e));
 }
 // @__NO_SIDE_EFFECTS__
 function ka(e) {
-  return /* @__PURE__ */ Kr(e) ? e : fc(
+  return /* @__PURE__ */ Kr(e) ? e : dc(
     e,
     !1,
-    ty,
-    oy,
-    cp
+    ay,
+    cy,
+    pp
   );
 }
 // @__NO_SIDE_EFFECTS__
-function dy(e) {
-  return fc(
+function gy(e) {
+  return dc(
     e,
     !1,
-    ry,
     sy,
-    fp
+    fy,
+    mp
   );
 }
 // @__NO_SIDE_EFFECTS__
 function Cu(e) {
-  return fc(
+  return dc(
     e,
     !0,
-    ny,
-    ly,
-    dp
+    oy,
+    dy,
+    gp
   );
 }
-function fc(e, t, n, r, a) {
+function dc(e, t, n, r, a) {
   if (!yt(e) || e.__v_raw && !(t && e.__v_isReactive))
     return e;
-  const o = fy(e);
+  const o = my(e);
   if (o === 0)
     return e;
   const c = a.get(e);
@@ -927,7 +927,7 @@ function Yn(e) {
   return !!(e && e.__v_isShallow);
 }
 // @__NO_SIDE_EFFECTS__
-function dc(e) {
+function hc(e) {
   return e ? !!e.__v_raw : !1;
 }
 // @__NO_SIDE_EFFECTS__
@@ -935,8 +935,8 @@ function dt(e) {
   const t = e && e.__v_raw;
   return t ? /* @__PURE__ */ dt(t) : e;
 }
-function hy(e) {
-  return !ht(e, "__v_skip") && Object.isExtensible(e) && qh(e, "__v_skip", !0), e;
+function by(e) {
+  return !ht(e, "__v_skip") && Object.isExtensible(e) && Qh(e, "__v_skip", !0), e;
 }
 const ir = (e) => yt(e) ? /* @__PURE__ */ ka(e) : e, _a = (e) => yt(e) ? /* @__PURE__ */ Cu(e) : e;
 // @__NO_SIDE_EFFECTS__
@@ -945,14 +945,14 @@ function yn(e) {
 }
 // @__NO_SIDE_EFFECTS__
 function vn(e) {
-  return py(e, !1);
+  return yy(e, !1);
 }
-function py(e, t) {
-  return /* @__PURE__ */ yn(e) ? e : new my(e, t);
+function yy(e, t) {
+  return /* @__PURE__ */ yn(e) ? e : new vy(e, t);
 }
-class my {
+class vy {
   constructor(t, n) {
-    this.dep = new uc(), this.__v_isRef = !0, this.__v_isShallow = !1, this._rawValue = n ? t : /* @__PURE__ */ dt(t), this._value = n ? t : ir(t), this.__v_isShallow = n;
+    this.dep = new cc(), this.__v_isRef = !0, this.__v_isShallow = !1, this._rawValue = n ? t : /* @__PURE__ */ dt(t), this._value = n ? t : ir(t), this.__v_isShallow = n;
   }
   get value() {
     return this.dep.track(), this._value;
@@ -965,19 +965,19 @@ class my {
 function pt(e) {
   return /* @__PURE__ */ yn(e) ? e.value : e;
 }
-const gy = {
+const _y = {
   get: (e, t, n) => t === "__v_raw" ? e : pt(Reflect.get(e, t, n)),
   set: (e, t, n, r) => {
     const a = e[t];
     return /* @__PURE__ */ yn(a) && !/* @__PURE__ */ yn(n) ? (a.value = n, !0) : Reflect.set(e, t, n, r);
   }
 };
-function hp(e) {
-  return /* @__PURE__ */ xi(e) ? e : new Proxy(e, gy);
+function bp(e) {
+  return /* @__PURE__ */ xi(e) ? e : new Proxy(e, _y);
 }
-class by {
+class xy {
   constructor(t, n, r) {
-    this.fn = t, this.setter = n, this._value = void 0, this.dep = new uc(this), this.__v_isRef = !0, this.deps = void 0, this.depsTail = void 0, this.flags = 16, this.globalVersion = lo - 1, this.next = void 0, this.effect = this, this.__v_isReadonly = !n, this.isSSR = r;
+    this.fn = t, this.setter = n, this._value = void 0, this.dep = new cc(this), this.__v_isRef = !0, this.deps = void 0, this.depsTail = void 0, this.flags = 16, this.globalVersion = lo - 1, this.next = void 0, this.effect = this, this.__v_isReadonly = !n, this.isSSR = r;
   }
   /**
    * @internal
@@ -985,30 +985,30 @@ class by {
   notify() {
     if (this.flags |= 16, !(this.flags & 8) && // avoid infinite self recursion
     Mt !== this)
-      return tp(this, !0), !0;
+      return ap(this, !0), !0;
   }
   get value() {
     const t = this.dep.track();
-    return ip(this), t && (t.version = this.dep.version), this._value;
+    return lp(this), t && (t.version = this.dep.version), this._value;
   }
   set value(t) {
     this.setter && this.setter(t);
   }
 }
 // @__NO_SIDE_EFFECTS__
-function yy(e, t, n = !1) {
+function Sy(e, t, n = !1) {
   let r, a;
-  return Ze(e) ? r = e : (r = e.get, a = e.set), new by(r, a, n);
+  return Ze(e) ? r = e : (r = e.get, a = e.set), new xy(r, a, n);
 }
 const Jo = {}, Ds = /* @__PURE__ */ new WeakMap();
 let bi;
-function vy(e, t = !1, n = bi) {
+function wy(e, t = !1, n = bi) {
   if (n) {
     let r = Ds.get(n);
     r || Ds.set(n, r = []), r.push(e);
   }
 }
-function _y(e, t, n = kt) {
+function ky(e, t, n = kt) {
   const { immediate: r, deep: a, once: o, scheduler: c, augmentJob: f, call: h } = n, g = (I) => a ? I : /* @__PURE__ */ Yn(I) || a === !1 || a === 0 ? Vr(I, 1) : Vr(I);
   let v, x, S, M, b = !1, O = !1;
   if (/* @__PURE__ */ yn(e) ? (x = () => e.value, b = /* @__PURE__ */ Yn(e)) : /* @__PURE__ */ xi(e) ? (x = () => g(e), b = !0) : Xe(e) ? (O = !0, b = e.some((I) => /* @__PURE__ */ xi(I) || /* @__PURE__ */ Yn(I)), x = () => e.map((I) => {
@@ -1038,8 +1038,8 @@ function _y(e, t, n = kt) {
     const I = x, R = a === !0 ? 1 / 0 : a;
     x = () => Vr(I(), R);
   }
-  const j = Wb(), z = () => {
-    v.stop(), j && j.active && nc(j.effects, v);
+  const j = Jb(), z = () => {
+    v.stop(), j && j.active && rc(j.effects, v);
   };
   if (o && t) {
     const I = t;
@@ -1074,7 +1074,7 @@ function _y(e, t, n = kt) {
       } else
         v.run();
   };
-  return f && f($), v = new Qh(x), v.scheduler = c ? () => c($, !1) : $, M = (I) => vy(I, !1, v), S = v.onStop = () => {
+  return f && f($), v = new rp(x), v.scheduler = c ? () => c($, !1) : $, M = (I) => wy(I, !1, v), S = v.onStop = () => {
     const I = Ds.get(v);
     if (I) {
       if (h)
@@ -1093,11 +1093,11 @@ function Vr(e, t = 1 / 0, n) {
   else if (Xe(e))
     for (let r = 0; r < e.length; r++)
       Vr(e[r], t, n);
-  else if (Gh(e) || ha(e))
+  else if (qh(e) || ha(e))
     e.forEach((r) => {
       Vr(r, t, n);
     });
-  else if (Yh(e)) {
+  else if (Zh(e)) {
     for (const r in e)
       Vr(e[r], t, n);
     for (const r of Object.getOwnPropertySymbols(e))
@@ -1120,7 +1120,7 @@ function xo(e, t, n, r) {
 function Nr(e, t, n, r) {
   if (Ze(e)) {
     const a = xo(e, t, n, r);
-    return a && Kh(a) && a.catch((o) => {
+    return a && Xh(a) && a.catch((o) => {
       al(o, t, n);
     }), a;
   }
@@ -1154,9 +1154,9 @@ function al(e, t, n, r = !0) {
       return;
     }
   }
-  xy(e, n, a, r, c);
+  Ny(e, n, a, r, c);
 }
-function xy(e, t, n, r = !0, a = !1) {
+function Ny(e, t, n, r = !0, a = !1) {
   if (a)
     throw e;
   console.error(e);
@@ -1165,13 +1165,13 @@ const Mn = [];
 let fr = -1;
 const pa = [];
 let ni = null, sa = 0;
-const pp = /* @__PURE__ */ Promise.resolve();
+const yp = /* @__PURE__ */ Promise.resolve();
 let Os = null;
-function hc(e) {
-  const t = Os || pp;
+function pc(e) {
+  const t = Os || yp;
   return e ? t.then(this ? e.bind(this) : e) : t;
 }
-function Sy(e) {
+function My(e) {
   let t = fr + 1, n = Mn.length;
   for (; t < n; ) {
     const r = t + n >>> 1, a = Mn[r], o = co(a);
@@ -1179,20 +1179,20 @@ function Sy(e) {
   }
   return t;
 }
-function pc(e) {
+function mc(e) {
   if (!(e.flags & 1)) {
     const t = co(e), n = Mn[Mn.length - 1];
     !n || // fast path when the job id is larger than the tail
-    !(e.flags & 2) && t >= co(n) ? Mn.push(e) : Mn.splice(Sy(t), 0, e), e.flags |= 1, mp();
+    !(e.flags & 2) && t >= co(n) ? Mn.push(e) : Mn.splice(My(t), 0, e), e.flags |= 1, vp();
   }
 }
-function mp() {
-  Os || (Os = pp.then(bp));
+function vp() {
+  Os || (Os = yp.then(xp));
 }
-function wy(e) {
-  Xe(e) ? pa.push(...e) : ni && e.id === -1 ? ni.splice(sa + 1, 0, e) : e.flags & 1 || (pa.push(e), e.flags |= 1), mp();
+function Py(e) {
+  Xe(e) ? pa.push(...e) : ni && e.id === -1 ? ni.splice(sa + 1, 0, e) : e.flags & 1 || (pa.push(e), e.flags |= 1), vp();
 }
-function dd(e, t, n = fr + 1) {
+function hd(e, t, n = fr + 1) {
   for (; n < Mn.length; n++) {
     const r = Mn[n];
     if (r && r.flags & 2) {
@@ -1202,7 +1202,7 @@ function dd(e, t, n = fr + 1) {
     }
   }
 }
-function gp(e) {
+function _p(e) {
   if (pa.length) {
     const t = [...new Set(pa)].sort(
       (n, r) => co(n) - co(r)
@@ -1219,7 +1219,7 @@ function gp(e) {
   }
 }
 const co = (e) => e.id == null ? e.flags & 2 ? -1 : 1 / 0 : e.id;
-function bp(e) {
+function xp(e) {
   try {
     for (fr = 0; fr < Mn.length; fr++) {
       const t = Mn[fr];
@@ -1234,25 +1234,25 @@ function bp(e) {
       const t = Mn[fr];
       t && (t.flags &= -2);
     }
-    fr = -1, Mn.length = 0, gp(), Os = null, (Mn.length || pa.length) && bp();
+    fr = -1, Mn.length = 0, _p(), Os = null, (Mn.length || pa.length) && xp();
   }
 }
-let jn = null, yp = null;
+let jn = null, Sp = null;
 function Fs(e) {
   const t = jn;
-  return jn = e, yp = e && e.type.__scopeId || null, t;
+  return jn = e, Sp = e && e.type.__scopeId || null, t;
 }
-function vp(e, t = jn, n) {
+function wp(e, t = jn, n) {
   if (!t || e._n)
     return e;
   const r = (...a) => {
-    r._d && kd(-1);
+    r._d && Nd(-1);
     const o = Fs(t);
     let c;
     try {
       c = e(...a);
     } finally {
-      Fs(o), r._d && kd(1);
+      Fs(o), r._d && Nd(1);
     }
     return c;
   };
@@ -1292,7 +1292,7 @@ function hi(e, t, n, r) {
     ]), Gr());
   }
 }
-function ky(e, t) {
+function Ay(e, t) {
   if (gn) {
     let n = gn.provides;
     const r = gn.parent && gn.parent.provides;
@@ -1300,7 +1300,7 @@ function ky(e, t) {
   }
 }
 function ys(e, t, n = !1) {
-  const r = wv();
+  const r = Pv();
   if (r || ma) {
     let a = ma ? ma._context.provides : r ? r.parent == null || r.ce ? r.vnode.appContext && r.vnode.appContext.provides : r.parent.provides : void 0;
     if (a && e in a)
@@ -1309,16 +1309,16 @@ function ys(e, t, n = !1) {
       return n && Ze(t) ? t.call(r && r.proxy) : t;
   }
 }
-const Ny = /* @__PURE__ */ Symbol.for("v-scx"), My = () => ys(Ny);
+const Cy = /* @__PURE__ */ Symbol.for("v-scx"), Ty = () => ys(Cy);
 function wi(e, t, n) {
-  return _p(e, t, n);
+  return kp(e, t, n);
 }
-function _p(e, t, n = kt) {
+function kp(e, t, n = kt) {
   const { immediate: r, deep: a, flush: o, once: c } = n, f = xn({}, n), h = t && r || !t && o !== "post";
   let g;
   if (ho) {
     if (o === "sync") {
-      const M = My();
+      const M = Ty();
       g = M.__watcherHandles || (M.__watcherHandles = []);
     } else if (!h) {
       const M = () => {
@@ -1332,21 +1332,21 @@ function _p(e, t, n = kt) {
   o === "post" ? f.scheduler = (M) => {
     Dn(M, v && v.suspense);
   } : o !== "sync" && (x = !0, f.scheduler = (M, b) => {
-    b ? M() : pc(M);
+    b ? M() : mc(M);
   }), f.augmentJob = (M) => {
     t && (M.flags |= 4), x && (M.flags |= 2, v && (M.id = v.uid, M.i = v));
   };
-  const S = _y(e, t, f);
+  const S = ky(e, t, f);
   return ho && (g ? g.push(S) : h && S()), S;
 }
-function Py(e, t, n) {
-  const r = this.proxy, a = Vt(e) ? e.includes(".") ? xp(r, e) : () => r[e] : e.bind(r, r);
+function Iy(e, t, n) {
+  const r = this.proxy, a = Vt(e) ? e.includes(".") ? Np(r, e) : () => r[e] : e.bind(r, r);
   let o;
   Ze(t) ? o = t : (o = t.handler, n = t);
-  const c = So(this), f = _p(a, o.bind(r), n);
+  const c = So(this), f = kp(a, o.bind(r), n);
   return c(), f;
 }
-function xp(e, t) {
+function Np(e, t) {
   const n = t.split(".");
   return () => {
     let r = e;
@@ -1355,14 +1355,14 @@ function xp(e, t) {
     return r;
   };
 }
-const Ay = /* @__PURE__ */ Symbol("_vte"), Cy = (e) => e.__isTeleport, Ty = /* @__PURE__ */ Symbol("_leaveCb");
-function mc(e, t) {
-  e.shapeFlag & 6 && e.component ? (e.transition = t, mc(e.component.subTree, t)) : e.shapeFlag & 128 ? (e.ssContent.transition = t.clone(e.ssContent), e.ssFallback.transition = t.clone(e.ssFallback)) : e.transition = t;
+const Ey = /* @__PURE__ */ Symbol("_vte"), Dy = (e) => e.__isTeleport, Oy = /* @__PURE__ */ Symbol("_leaveCb");
+function gc(e, t) {
+  e.shapeFlag & 6 && e.component ? (e.transition = t, gc(e.component.subTree, t)) : e.shapeFlag & 128 ? (e.ssContent.transition = t.clone(e.ssContent), e.ssFallback.transition = t.clone(e.ssFallback)) : e.transition = t;
 }
-function Sp(e) {
+function Mp(e) {
   e.ids = [e.ids[0] + e.ids[2]++ + "-", 0, 0];
 }
-function hd(e, t) {
+function pd(e, t) {
   let n;
   return !!((n = Object.getOwnPropertyDescriptor(e, t)) && !n.configurable);
 }
@@ -1384,9 +1384,9 @@ function ro(e, t, n, r, a = !1) {
     r.shapeFlag & 512 && r.type.__asyncResolved && r.component.subTree.component && ro(e, t, n, r.component.subTree);
     return;
   }
-  const o = r.shapeFlag & 4 ? cl(r.component) : r.el, c = a ? null : o, { i: f, r: h } = e, g = t && t.r, v = f.refs === kt ? f.refs = {} : f.refs, x = f.setupState, S = /* @__PURE__ */ dt(x), M = x === kt ? Bh : (O) => hd(v, O) ? !1 : ht(S, O), b = (O, j) => !(j && hd(v, j));
+  const o = r.shapeFlag & 4 ? cl(r.component) : r.el, c = a ? null : o, { i: f, r: h } = e, g = t && t.r, v = f.refs === kt ? f.refs = {} : f.refs, x = f.setupState, S = /* @__PURE__ */ dt(x), M = x === kt ? Yh : (O) => pd(v, O) ? !1 : ht(S, O), b = (O, j) => !(j && pd(v, j));
   if (g != null && g !== h) {
-    if (pd(t), Vt(g))
+    if (md(t), Vt(g))
       v[g] = null, M(g) && (x[g] = null);
     else if (/* @__PURE__ */ yn(g)) {
       const O = t;
@@ -1402,7 +1402,7 @@ function ro(e, t, n, r, a = !1) {
         if (e.f) {
           const P = O ? M(h) ? x[h] : v[h] : b() || !e.k ? h.value : v[e.k];
           if (a)
-            Xe(P) && nc(P, o);
+            Xe(P) && rc(P, o);
           else if (Xe(P))
             P.includes(o) || P.push(o);
           else if (O)
@@ -1419,24 +1419,24 @@ function ro(e, t, n, r, a = !1) {
         };
         P.id = -1, Rs.set(e, P), Dn(P, n);
       } else
-        pd(e), z();
+        md(e), z();
     }
   }
 }
-function pd(e) {
+function md(e) {
   const t = Rs.get(e);
   t && (t.flags |= 8, Rs.delete(e));
 }
 rl().requestIdleCallback;
 rl().cancelIdleCallback;
-const io = (e) => !!e.type.__asyncLoader, wp = (e) => e.type.__isKeepAlive;
-function Iy(e, t) {
-  kp(e, "a", t);
+const io = (e) => !!e.type.__asyncLoader, Pp = (e) => e.type.__isKeepAlive;
+function Fy(e, t) {
+  Ap(e, "a", t);
 }
-function Ey(e, t) {
-  kp(e, "da", t);
+function Ry(e, t) {
+  Ap(e, "da", t);
 }
-function kp(e, t, n = gn) {
+function Ap(e, t, n = gn) {
   const r = e.__wdc || (e.__wdc = () => {
     let a = n;
     for (; a; ) {
@@ -1449,10 +1449,10 @@ function kp(e, t, n = gn) {
   if (ol(t, r, n), n) {
     let a = n.parent;
     for (; a && a.parent; )
-      wp(a.parent.vnode) && Dy(r, t, n, a), a = a.parent;
+      Pp(a.parent.vnode) && Ly(r, t, n, a), a = a.parent;
   }
 }
-function Dy(e, t, n, r) {
+function Ly(e, t, n, r) {
   const a = ol(
     t,
     e,
@@ -1460,8 +1460,8 @@ function Dy(e, t, n, r) {
     !0
     /* prepend */
   );
-  Np(() => {
-    nc(r[t], a);
+  Cp(() => {
+    rc(r[t], a);
   }, n);
 }
 function ol(e, t, n = gn, r = !1) {
@@ -1476,26 +1476,26 @@ function ol(e, t, n = gn, r = !1) {
 }
 const qr = (e) => (t, n = gn) => {
   (!ho || e === "sp") && ol(e, (...r) => t(...r), n);
-}, Oy = qr("bm"), gc = qr("m"), Fy = qr(
+}, zy = qr("bm"), bc = qr("m"), $y = qr(
   "bu"
-), Ry = qr("u"), sl = qr(
+), jy = qr("u"), sl = qr(
   "bum"
-), Np = qr("um"), Ly = qr(
+), Cp = qr("um"), Vy = qr(
   "sp"
-), zy = qr("rtg"), $y = qr("rtc");
-function jy(e, t = gn) {
+), Hy = qr("rtg"), Uy = qr("rtc");
+function By(e, t = gn) {
   ol("ec", e, t);
 }
-const Vy = "components", Mp = /* @__PURE__ */ Symbol.for("v-ndc");
-function Hy(e) {
-  return Vt(e) ? Uy(Vy, e, !1) || e : e || Mp;
+const Gy = "components", Tp = /* @__PURE__ */ Symbol.for("v-ndc");
+function Ky(e) {
+  return Vt(e) ? Wy(Gy, e, !1) || e : e || Tp;
 }
-function Uy(e, t, n = !0, r = !1) {
+function Wy(e, t, n = !0, r = !1) {
   const a = jn || gn;
   if (a) {
     const o = a.type;
     {
-      const f = Av(
+      const f = Ev(
         o,
         !1
       );
@@ -1505,13 +1505,13 @@ function Uy(e, t, n = !0, r = !1) {
     const c = (
       // local registration
       // check instance[type] first which is resolved for options API
-      md(a[e] || o[e], t) || // global registration
-      md(a.appContext[e], t)
+      gd(a[e] || o[e], t) || // global registration
+      gd(a.appContext[e], t)
     );
     return !c && r ? o : c;
   }
 }
-function md(e, t) {
+function gd(e, t) {
   return e && (e[t] || e[Pn(t)] || e[nl(Pn(t))]);
 }
 function jt(e, t, n, r) {
@@ -1550,7 +1550,7 @@ function jt(e, t, n, r) {
     a = [];
   return a;
 }
-const Tu = (e) => e ? Wp(e) ? cl(e) : Tu(e.parent) : null, ao = (
+const Tu = (e) => e ? Jp(e) ? cl(e) : Tu(e.parent) : null, ao = (
   // Move PURE marker to new line to workaround compiler discarding it
   // due to type annotation
   /* @__PURE__ */ xn(/* @__PURE__ */ Object.create(null), {
@@ -1565,14 +1565,14 @@ const Tu = (e) => e ? Wp(e) ? cl(e) : Tu(e.parent) : null, ao = (
     $root: (e) => Tu(e.root),
     $host: (e) => e.ce,
     $emit: (e) => e.emit,
-    $options: (e) => Ap(e),
+    $options: (e) => Ep(e),
     $forceUpdate: (e) => e.f || (e.f = () => {
-      pc(e.update);
+      mc(e.update);
     }),
-    $nextTick: (e) => e.n || (e.n = hc.bind(e.proxy)),
-    $watch: (e) => Py.bind(e)
+    $nextTick: (e) => e.n || (e.n = pc.bind(e.proxy)),
+    $watch: (e) => Iy.bind(e)
   })
-), tu = (e, t) => e !== kt && !e.__isScriptSetup && ht(e, t), By = {
+), tu = (e, t) => e !== kt && !e.__isScriptSetup && ht(e, t), Yy = {
   get({ _: e }, t) {
     if (t === "__v_skip")
       return !0;
@@ -1633,16 +1633,16 @@ const Tu = (e) => e ? Wp(e) ? cl(e) : Tu(e.parent) : null, ao = (
     return n.get != null ? e._.accessCache[t] = 0 : ht(n, "value") && this.set(e, t, n.value, null), Reflect.defineProperty(e, t, n);
   }
 };
-function gd(e) {
+function bd(e) {
   return Xe(e) ? e.reduce(
     (t, n) => (t[n] = null, t),
     {}
   ) : e;
 }
 let Iu = !0;
-function Gy(e) {
-  const t = Ap(e), n = e.proxy, r = e.ctx;
-  Iu = !1, t.beforeCreate && bd(t.beforeCreate, e, "bc");
+function qy(e) {
+  const t = Ep(e), n = e.proxy, r = e.ctx;
+  Iu = !1, t.beforeCreate && yd(t.beforeCreate, e, "bc");
   const {
     // state
     data: a,
@@ -1676,7 +1676,7 @@ function Gy(e) {
     directives: J,
     filters: de
   } = t;
-  if (g && Ky(g, r, null), c)
+  if (g && Xy(g, r, null), c)
     for (const A in c) {
       const xe = c[A];
       Ze(xe) && (r[A] = xe.bind(n));
@@ -1700,18 +1700,18 @@ function Gy(e) {
     }
   if (f)
     for (const A in f)
-      Pp(f[A], r, n, A);
+      Ip(f[A], r, n, A);
   if (h) {
     const A = Ze(h) ? h.call(n) : h;
     Reflect.ownKeys(A).forEach((xe) => {
-      ky(xe, A[xe]);
+      Ay(xe, A[xe]);
     });
   }
-  v && bd(v, e, "c");
+  v && yd(v, e, "c");
   function we(A, xe) {
     Xe(xe) ? xe.forEach((Ae) => A(Ae.bind(n))) : xe && A(xe.bind(n));
   }
-  if (we(Oy, x), we(gc, S), we(Fy, M), we(Ry, b), we(Iy, O), we(Ey, j), we(jy, se), we($y, G), we(zy, H), we(sl, P), we(Np, I), we(Ly, ie), Xe(T))
+  if (we(zy, x), we(bc, S), we($y, M), we(jy, b), we(Fy, O), we(Ry, j), we(By, se), we(Uy, G), we(Hy, H), we(sl, P), we(Cp, I), we(Vy, ie), Xe(T))
     if (T.length) {
       const A = e.exposed || (e.exposed = {});
       T.forEach((xe) => {
@@ -1722,9 +1722,9 @@ function Gy(e) {
         });
       });
     } else e.exposed || (e.exposed = {});
-  R && e.render === wr && (e.render = R), q != null && (e.inheritAttrs = q), re && (e.components = re), J && (e.directives = J), ie && Sp(e);
+  R && e.render === wr && (e.render = R), q != null && (e.inheritAttrs = q), re && (e.components = re), J && (e.directives = J), ie && Mp(e);
 }
-function Ky(e, t, n = wr) {
+function Xy(e, t, n = wr) {
   Xe(e) && (e = Eu(e));
   for (const r in e) {
     const a = e[r];
@@ -1741,15 +1741,15 @@ function Ky(e, t, n = wr) {
     }) : t[r] = o;
   }
 }
-function bd(e, t, n) {
+function yd(e, t, n) {
   Nr(
     Xe(e) ? e.map((r) => r.bind(t.proxy)) : e.bind(t.proxy),
     t,
     n
   );
 }
-function Pp(e, t, n, r) {
-  let a = r.includes(".") ? xp(n, r) : () => n[r];
+function Ip(e, t, n, r) {
+  let a = r.includes(".") ? Np(n, r) : () => n[r];
   if (Vt(e)) {
     const o = t[e];
     Ze(o) && wi(a, o);
@@ -1757,13 +1757,13 @@ function Pp(e, t, n, r) {
     wi(a, e.bind(n));
   else if (yt(e))
     if (Xe(e))
-      e.forEach((o) => Pp(o, t, n, r));
+      e.forEach((o) => Ip(o, t, n, r));
     else {
       const o = Ze(e.handler) ? e.handler.bind(n) : t[e.handler];
       Ze(o) && wi(a, o, e);
     }
 }
-function Ap(e) {
+function Ep(e) {
   const t = e.type, { mixins: n, extends: r } = t, {
     mixins: a,
     optionsCache: o,
@@ -1781,15 +1781,15 @@ function Ls(e, t, n, r = !1) {
   );
   for (const c in t)
     if (!(r && c === "expose")) {
-      const f = Wy[c] || n && n[c];
+      const f = Jy[c] || n && n[c];
       e[c] = f ? f(e[c], t[c]) : t[c];
     }
   return e;
 }
-const Wy = {
-  data: yd,
-  props: vd,
-  emits: vd,
+const Jy = {
+  data: vd,
+  props: _d,
+  emits: _d,
   // objects
   methods: Ya,
   computed: Ya,
@@ -1812,12 +1812,12 @@ const Wy = {
   components: Ya,
   directives: Ya,
   // watch
-  watch: qy,
+  watch: Qy,
   // provide / inject
-  provide: yd,
-  inject: Yy
+  provide: vd,
+  inject: Zy
 };
-function yd(e, t) {
+function vd(e, t) {
   return t ? e ? function() {
     return xn(
       Ze(e) ? e.call(this, this) : e,
@@ -1825,7 +1825,7 @@ function yd(e, t) {
     );
   } : t : e;
 }
-function Yy(e, t) {
+function Zy(e, t) {
   return Ya(Eu(e), Eu(t));
 }
 function Eu(e) {
@@ -1843,14 +1843,14 @@ function Nn(e, t) {
 function Ya(e, t) {
   return e ? xn(/* @__PURE__ */ Object.create(null), e, t) : t;
 }
-function vd(e, t) {
+function _d(e, t) {
   return e ? Xe(e) && Xe(t) ? [.../* @__PURE__ */ new Set([...e, ...t])] : xn(
     /* @__PURE__ */ Object.create(null),
-    gd(e),
-    gd(t ?? {})
+    bd(e),
+    bd(t ?? {})
   ) : t;
 }
-function qy(e, t) {
+function Qy(e, t) {
   if (!e) return t;
   if (!t) return e;
   const n = xn(/* @__PURE__ */ Object.create(null), e);
@@ -1858,11 +1858,11 @@ function qy(e, t) {
     n[r] = Nn(e[r], t[r]);
   return n;
 }
-function Cp() {
+function Dp() {
   return {
     app: null,
     config: {
-      isNativeTag: Bh,
+      isNativeTag: Yh,
       performance: !1,
       globalProperties: {},
       optionMergeStrategies: {},
@@ -1879,20 +1879,20 @@ function Cp() {
     emitsCache: /* @__PURE__ */ new WeakMap()
   };
 }
-let Xy = 0;
-function Jy(e, t) {
+let ev = 0;
+function tv(e, t) {
   return function(r, a = null) {
     Ze(r) || (r = xn({}, r)), a != null && !yt(a) && (a = null);
-    const o = Cp(), c = /* @__PURE__ */ new WeakSet(), f = [];
+    const o = Dp(), c = /* @__PURE__ */ new WeakSet(), f = [];
     let h = !1;
     const g = o.app = {
-      _uid: Xy++,
+      _uid: ev++,
       _component: r,
       _props: a,
       _container: null,
       _context: o,
       _instance: null,
-      version: Tv,
+      version: Ov,
       get config() {
         return o.config;
       },
@@ -1943,13 +1943,13 @@ function Jy(e, t) {
   };
 }
 let ma = null;
-const Zy = (e, t) => t === "modelValue" || t === "model-value" ? e.modelModifiers : e[`${t}Modifiers`] || e[`${Pn(t)}Modifiers`] || e[`${Ti(t)}Modifiers`];
-function Qy(e, t, ...n) {
+const nv = (e, t) => t === "modelValue" || t === "model-value" ? e.modelModifiers : e[`${t}Modifiers`] || e[`${Pn(t)}Modifiers`] || e[`${Ti(t)}Modifiers`];
+function rv(e, t, ...n) {
   if (e.isUnmounted) return;
   const r = e.vnode.props || kt;
   let a = n;
-  const o = t.startsWith("update:"), c = o && Zy(r, t.slice(7));
-  c && (c.trim && (a = n.map((v) => Vt(v) ? v.trim() : v)), c.number && (a = n.map(ic)));
+  const o = t.startsWith("update:"), c = o && nv(r, t.slice(7));
+  c && (c.trim && (a = n.map((v) => Vt(v) ? v.trim() : v)), c.number && (a = n.map(ac)));
   let f, h = r[f = Xl(t)] || // also try camelCase event handler (#2249)
   r[f = Xl(Pn(t))];
   !h && o && (h = r[f = Xl(Ti(t))]), h && Nr(
@@ -1972,16 +1972,16 @@ function Qy(e, t, ...n) {
     );
   }
 }
-const ev = /* @__PURE__ */ new WeakMap();
-function Tp(e, t, n = !1) {
-  const r = n ? ev : t.emitsCache, a = r.get(e);
+const iv = /* @__PURE__ */ new WeakMap();
+function Op(e, t, n = !1) {
+  const r = n ? iv : t.emitsCache, a = r.get(e);
   if (a !== void 0)
     return a;
   const o = e.emits;
   let c = {}, f = !1;
   if (!Ze(e)) {
     const h = (g) => {
-      const v = Tp(g, t, !0);
+      const v = Op(g, t, !0);
       v && (f = !0, xn(c, v));
     };
     !n && t.mixins.length && t.mixins.forEach(h), e.extends && h(e.extends), e.mixins && e.mixins.forEach(h);
@@ -1991,7 +1991,7 @@ function Tp(e, t, n = !1) {
 function ll(e, t) {
   return !e || !Qs(t) ? !1 : (t = t.slice(2).replace(/Once$/, ""), ht(e, t[0].toLowerCase() + t.slice(1)) || ht(e, Ti(t)) || ht(e, t));
 }
-function _d(e) {
+function xd(e) {
   const {
     type: t,
     vnode: n,
@@ -2034,7 +2034,7 @@ function _d(e) {
           x,
           null
         )
-      ), P = t.props ? f : tv(f);
+      ), P = t.props ? f : av(f);
     }
   } catch (I) {
     oo.length = 0, al(I, e, 1), z = $e(ai);
@@ -2042,25 +2042,25 @@ function _d(e) {
   let $ = z;
   if (P && O !== !1) {
     const I = Object.keys(P), { shapeFlag: R } = $;
-    I.length && R & 7 && (o && I.some(el) && (P = nv(
+    I.length && R & 7 && (o && I.some(el) && (P = ov(
       P,
       o
     )), $ = xa($, P, !1, !0));
   }
-  return n.dirs && ($ = xa($, null, !1, !0), $.dirs = $.dirs ? $.dirs.concat(n.dirs) : n.dirs), n.transition && mc($, n.transition), z = $, Fs(j), z;
+  return n.dirs && ($ = xa($, null, !1, !0), $.dirs = $.dirs ? $.dirs.concat(n.dirs) : n.dirs), n.transition && gc($, n.transition), z = $, Fs(j), z;
 }
-const tv = (e) => {
+const av = (e) => {
   let t;
   for (const n in e)
     (n === "class" || n === "style" || Qs(n)) && ((t || (t = {}))[n] = e[n]);
   return t;
-}, nv = (e, t) => {
+}, ov = (e, t) => {
   const n = {};
   for (const r in e)
     (!el(r) || !(r.slice(9) in t)) && (n[r] = e[r]);
   return n;
 };
-function rv(e, t, n) {
+function sv(e, t, n) {
   const { props: r, children: a, component: o } = e, { props: c, children: f, patchFlag: h } = t, g = o.emitsOptions;
   if (t.dirs || t.transition)
     return !0;
@@ -2068,35 +2068,35 @@ function rv(e, t, n) {
     if (h & 1024)
       return !0;
     if (h & 16)
-      return r ? xd(r, c, g) : !!c;
+      return r ? Sd(r, c, g) : !!c;
     if (h & 8) {
       const v = t.dynamicProps;
       for (let x = 0; x < v.length; x++) {
         const S = v[x];
-        if (Ip(c, r, S) && !ll(g, S))
+        if (Fp(c, r, S) && !ll(g, S))
           return !0;
       }
     }
   } else
-    return (a || f) && (!f || !f.$stable) ? !0 : r === c ? !1 : r ? c ? xd(r, c, g) : !0 : !!c;
+    return (a || f) && (!f || !f.$stable) ? !0 : r === c ? !1 : r ? c ? Sd(r, c, g) : !0 : !!c;
   return !1;
 }
-function xd(e, t, n) {
+function Sd(e, t, n) {
   const r = Object.keys(t);
   if (r.length !== Object.keys(e).length)
     return !0;
   for (let a = 0; a < r.length; a++) {
     const o = r[a];
-    if (Ip(t, e, o) && !ll(n, o))
+    if (Fp(t, e, o) && !ll(n, o))
       return !0;
   }
   return !1;
 }
-function Ip(e, t, n) {
+function Fp(e, t, n) {
   const r = e[n], a = t[n];
-  return n === "style" && yt(r) && yt(a) ? !ac(r, a) : r !== a;
+  return n === "style" && yt(r) && yt(a) ? !oc(r, a) : r !== a;
 }
-function iv({ vnode: e, parent: t, suspense: n }, r) {
+function lv({ vnode: e, parent: t, suspense: n }, r) {
   for (; t; ) {
     const a = t.subTree;
     if (a.suspense && a.suspense.activeBranch === e && (a.suspense.vnode.el = a.el = r, e = a), a === e)
@@ -2106,15 +2106,15 @@ function iv({ vnode: e, parent: t, suspense: n }, r) {
   }
   n && n.activeBranch === e && (n.vnode.el = r);
 }
-const Ep = {}, Dp = () => Object.create(Ep), Op = (e) => Object.getPrototypeOf(e) === Ep;
-function av(e, t, n, r = !1) {
-  const a = {}, o = Dp();
-  e.propsDefaults = /* @__PURE__ */ Object.create(null), Fp(e, t, a, o);
+const Rp = {}, Lp = () => Object.create(Rp), zp = (e) => Object.getPrototypeOf(e) === Rp;
+function uv(e, t, n, r = !1) {
+  const a = {}, o = Lp();
+  e.propsDefaults = /* @__PURE__ */ Object.create(null), $p(e, t, a, o);
   for (const c in e.propsOptions[0])
     c in a || (a[c] = void 0);
-  n ? e.props = r ? a : /* @__PURE__ */ dy(a) : e.type.props ? e.props = a : e.props = o, e.attrs = o;
+  n ? e.props = r ? a : /* @__PURE__ */ gy(a) : e.type.props ? e.props = a : e.props = o, e.attrs = o;
 }
-function ov(e, t, n, r) {
+function cv(e, t, n, r) {
   const {
     props: a,
     attrs: o,
@@ -2153,7 +2153,7 @@ function ov(e, t, n, r) {
       }
     }
   } else {
-    Fp(e, t, a, o) && (g = !0);
+    $p(e, t, a, o) && (g = !0);
     let v;
     for (const x in f)
       (!t || // for camelCase
@@ -2175,7 +2175,7 @@ function ov(e, t, n, r) {
   }
   g && jr(e.attrs, "set", "");
 }
-function Fp(e, t, n, r) {
+function $p(e, t, n, r) {
   const [a, o] = e.propsOptions;
   let c = !1, f;
   if (t)
@@ -2233,9 +2233,9 @@ function Du(e, t, n, r, a, o) {
   }
   return r;
 }
-const sv = /* @__PURE__ */ new WeakMap();
-function Rp(e, t, n = !1) {
-  const r = n ? sv : t.propsCache, a = r.get(e);
+const fv = /* @__PURE__ */ new WeakMap();
+function jp(e, t, n = !1) {
+  const r = n ? fv : t.propsCache, a = r.get(e);
   if (a)
     return a;
   const o = e.props, c = {}, f = [];
@@ -2243,7 +2243,7 @@ function Rp(e, t, n = !1) {
   if (!Ze(e)) {
     const v = (x) => {
       h = !0;
-      const [S, M] = Rp(x, t, !0);
+      const [S, M] = jp(x, t, !0);
       xn(c, S), M && f.push(...M);
     };
     !n && t.mixins.length && t.mixins.forEach(v), e.extends && v(e.extends), e.mixins && e.mixins.forEach(v);
@@ -2253,12 +2253,12 @@ function Rp(e, t, n = !1) {
   if (Xe(o))
     for (let v = 0; v < o.length; v++) {
       const x = Pn(o[v]);
-      Sd(x) && (c[x] = kt);
+      wd(x) && (c[x] = kt);
     }
   else if (o)
     for (const v in o) {
       const x = Pn(v);
-      if (Sd(x)) {
+      if (wd(x)) {
         const S = o[v], M = c[x] = Xe(S) || Ze(S) ? { type: S } : xn({}, S), b = M.type;
         let O = !1, j = !0;
         if (Xe(b))
@@ -2283,53 +2283,53 @@ function Rp(e, t, n = !1) {
   const g = [c, f];
   return yt(e) && r.set(e, g), g;
 }
-function Sd(e) {
+function wd(e) {
   return e[0] !== "$" && !eo(e);
 }
-const bc = (e) => e === "_" || e === "_ctx" || e === "$stable", yc = (e) => Xe(e) ? e.map(hr) : [hr(e)], lv = (e, t, n) => {
+const yc = (e) => e === "_" || e === "_ctx" || e === "$stable", vc = (e) => Xe(e) ? e.map(hr) : [hr(e)], dv = (e, t, n) => {
   if (t._n)
     return t;
-  const r = vp((...a) => yc(t(...a)), n);
+  const r = wp((...a) => vc(t(...a)), n);
   return r._c = !1, r;
-}, Lp = (e, t, n) => {
+}, Vp = (e, t, n) => {
   const r = e._ctx;
   for (const a in e) {
-    if (bc(a)) continue;
+    if (yc(a)) continue;
     const o = e[a];
     if (Ze(o))
-      t[a] = lv(a, o, r);
+      t[a] = dv(a, o, r);
     else if (o != null) {
-      const c = yc(o);
+      const c = vc(o);
       t[a] = () => c;
     }
   }
-}, zp = (e, t) => {
-  const n = yc(t);
+}, Hp = (e, t) => {
+  const n = vc(t);
   e.slots.default = () => n;
-}, $p = (e, t, n) => {
+}, Up = (e, t, n) => {
   for (const r in t)
-    (n || !bc(r)) && (e[r] = t[r]);
-}, uv = (e, t, n) => {
-  const r = e.slots = Dp();
+    (n || !yc(r)) && (e[r] = t[r]);
+}, hv = (e, t, n) => {
+  const r = e.slots = Lp();
   if (e.vnode.shapeFlag & 32) {
     const a = t._;
-    a ? ($p(r, t, n), n && qh(r, "_", a, !0)) : Lp(t, r);
-  } else t && zp(e, t);
-}, cv = (e, t, n) => {
+    a ? (Up(r, t, n), n && Qh(r, "_", a, !0)) : Vp(t, r);
+  } else t && Hp(e, t);
+}, pv = (e, t, n) => {
   const { vnode: r, slots: a } = e;
   let o = !0, c = kt;
   if (r.shapeFlag & 32) {
     const f = t._;
-    f ? n && f === 1 ? o = !1 : $p(a, t, n) : (o = !t.$stable, Lp(t, a)), c = t;
-  } else t && (zp(e, t), c = { default: 1 });
+    f ? n && f === 1 ? o = !1 : Up(a, t, n) : (o = !t.$stable, Vp(t, a)), c = t;
+  } else t && (Hp(e, t), c = { default: 1 });
   if (o)
     for (const f in a)
-      !bc(f) && c[f] == null && delete a[f];
-}, Dn = mv;
-function fv(e) {
-  return dv(e);
+      !yc(f) && c[f] == null && delete a[f];
+}, Dn = vv;
+function mv(e) {
+  return gv(e);
 }
-function dv(e, t) {
+function gv(e, t) {
   const n = rl();
   n.__VUE__ = !0;
   const {
@@ -2495,7 +2495,7 @@ function dv(e, t) {
       "value" in Me && o(fe, "value", null, Me.value, D), (ne = Me.onVnodeBeforeMount) && sr(ne, ye, L);
     }
     d && hi(L, null, ye, "beforeMount");
-    const De = hv(he, Ce);
+    const De = bv(he, Ce);
     De && Ce.beforeEnter(fe), r(fe, V, te), ((ne = Me && Me.onVnodeMounted) || De || d) && Dn(() => {
       try {
         ne && sr(ne, ye, L), De && Ce.enter(fe), d && hi(L, null, ye, "mounted");
@@ -2508,7 +2508,7 @@ function dv(e, t) {
         M(L, ye[D]);
     if (he) {
       let D = he.subTree;
-      if (V === D || Up(D.type) && (D.ssContent === V || D.ssFallback === V)) {
+      if (V === D || Wp(D.type) && (D.ssContent === V || D.ssFallback === V)) {
         const Q = he.vnode;
         H(
           L,
@@ -2650,7 +2650,7 @@ function dv(e, t) {
     //  get moved around. Make sure all root level vnodes inherit el.
     // #2134 or if it's a component root, it may also get moved around
     // as the component is being moved.
-    (V.key != null || he && V === he.subTree) && jp(
+    (V.key != null || he && V === he.subTree) && Bp(
       L,
       V,
       !0
@@ -2683,12 +2683,12 @@ function dv(e, t) {
       fe
     ) : ce(L, V, fe);
   }, de = (L, V, te, ye, he, D, Q) => {
-    const ee = L.component = Sv(
+    const ee = L.component = Mv(
       L,
       ye,
       he
     );
-    if (wp(L) && (ee.ctx.renderer = nn), kv(ee, !1, Q), ee.asyncDep) {
+    if (Pp(L) && (ee.ctx.renderer = nn), Av(ee, !1, Q), ee.asyncDep) {
       if (he && he.registerDep(ee, we, Q), !L.el) {
         const fe = ee.subTree = $e(ai);
         z(null, fe, V, te), L.placeholder = fe.el;
@@ -2705,7 +2705,7 @@ function dv(e, t) {
       );
   }, ce = (L, V, te) => {
     const ye = V.component = L.component;
-    if (rv(L, V, te))
+    if (sv(L, V, te))
       if (ye.asyncDep && !ye.asyncResolved) {
         A(ye, V, te);
         return;
@@ -2718,7 +2718,7 @@ function dv(e, t) {
       if (L.isMounted) {
         let { next: ge, bu: Ce, u: d, parent: De, vnode: Re } = L;
         {
-          const oe = Vp(L);
+          const oe = Gp(L);
           if (oe) {
             ge && (ge.el = Re.el, A(L, ge, Q)), oe.asyncDep.then(() => {
               Dn(() => {
@@ -2730,7 +2730,7 @@ function dv(e, t) {
         }
         let Ue = ge, et;
         pi(L, !1), ge ? (ge.el = Re.el, A(L, ge, Q)) : ge = Re, Ce && bs(Ce), (et = ge.props && ge.props.onVnodeBeforeUpdate) && sr(et, De, ge, Re), pi(L, !0);
-        const gt = _d(L), at = L.subTree;
+        const gt = xd(L), at = L.subTree;
         L.subTree = gt, O(
           at,
           gt,
@@ -2741,7 +2741,7 @@ function dv(e, t) {
           L,
           he,
           D
-        ), ge.el = gt.el, Ue === null && iv(L, gt.el), d && Dn(d, he), (et = ge.props && ge.props.onVnodeUpdated) && Dn(
+        ), ge.el = gt.el, Ue === null && lv(L, gt.el), d && Dn(d, he), (et = ge.props && ge.props.onVnodeUpdated) && Dn(
           () => sr(et, De, ge, Re),
           he
         );
@@ -2754,7 +2754,7 @@ function dv(e, t) {
             gt,
             L.parent ? L.parent.type : void 0
           );
-          const oe = L.subTree = _d(L);
+          const oe = L.subTree = xd(L);
           O(
             null,
             oe,
@@ -2776,14 +2776,14 @@ function dv(e, t) {
       }
     };
     L.scope.on();
-    const fe = L.effect = new Qh(ee);
+    const fe = L.effect = new rp(ee);
     L.scope.off();
     const ne = L.update = fe.run.bind(fe), Me = L.job = fe.runIfDirty.bind(fe);
-    Me.i = L, Me.id = L.uid, fe.scheduler = () => pc(Me), pi(L, !0), ne();
+    Me.i = L, Me.id = L.uid, fe.scheduler = () => mc(Me), pi(L, !0), ne();
   }, A = (L, V, te) => {
     V.component = L;
     const ye = L.vnode.props;
-    L.vnode = V, L.next = null, ov(L, V.props, ye, te), cv(L, V.children, te), Br(), dd(L), Gr();
+    L.vnode = V, L.next = null, cv(L, V.props, ye, te), pv(L, V.children, te), Br(), hd(L), Gr();
   }, xe = (L, V, te, ye, he, D, Q, ee, fe = !1) => {
     const ne = L && L.children, Me = L ? L.shapeFlag : 0, ge = V.children, { patchFlag: Ce, shapeFlag: d } = V;
     if (Ce > 0) {
@@ -2968,11 +2968,11 @@ function dv(e, t) {
           fe
         ), et++);
       }
-      const Nt = at ? pv(Xt) : da;
+      const Nt = at ? yv(Xt) : da;
       for (Ue = Nt.length - 1, ne = gt - 1; ne >= 0; ne--) {
         const Ge = De + ne, Pt = V[Ge], E = V[Ge + 1], Se = Ge + 1 < Me ? (
           // #13559, #14173 fallback to el placeholder for unresolved async component
-          E.el || Hp(E)
+          E.el || Kp(E)
         ) : ye;
         Xt[ne] === 0 ? O(
           null,
@@ -3019,7 +3019,7 @@ function dv(e, t) {
         const { leave: ge, delayLeave: Ce, afterLeave: d } = ee, De = () => {
           L.ctx.isUnmounted ? a(D) : r(D, V, te);
         }, Re = () => {
-          D._isLeaving && D[Ty](
+          D._isLeaving && D[Oy](
             !0
             /* cancelled */
           ), ge(D, () => {
@@ -3105,7 +3105,7 @@ function dv(e, t) {
     a(V);
   }, Ye = (L, V, te) => {
     const { bum: ye, scope: he, job: D, subTree: Q, um: ee, m: fe, a: ne } = L;
-    wd(fe), wd(ne), ye && bs(ye), he.stop(), D && (D.flags |= 8, je(Q, L, V, te)), ee && Dn(ee, V), Dn(() => {
+    kd(fe), kd(ne), ye && bs(ye), he.stop(), D && (D.flags |= 8, je(Q, L, V, te)), ee && Dn(ee, V), Dn(() => {
       L.isUnmounted = !0;
     }, V);
   }, Ve = (L, V, te, ye = !1, he = !1, D = 0) => {
@@ -3116,7 +3116,7 @@ function dv(e, t) {
       return qt(L.component.subTree);
     if (L.shapeFlag & 128)
       return L.suspense.next();
-    const V = S(L.anchor || L.el), te = V && V[Ay];
+    const V = S(L.anchor || L.el), te = V && V[Ey];
     return te ? S(te) : V;
   };
   let An = !1;
@@ -3130,7 +3130,7 @@ function dv(e, t) {
       null,
       null,
       te
-    ), V._vnode = L, An || (An = !0, dd(ye), gp(), An = !1);
+    ), V._vnode = L, An || (An = !0, hd(ye), _p(), An = !1);
   }, nn = {
     p: O,
     um: je,
@@ -3146,7 +3146,7 @@ function dv(e, t) {
   return {
     render: Sn,
     hydrate: void 0,
-    createApp: Jy(Sn)
+    createApp: tv(Sn)
   };
 }
 function nu({ type: e, props: t }, n) {
@@ -3155,19 +3155,19 @@ function nu({ type: e, props: t }, n) {
 function pi({ effect: e, job: t }, n) {
   n ? (e.flags |= 32, t.flags |= 4) : (e.flags &= -33, t.flags &= -5);
 }
-function hv(e, t) {
+function bv(e, t) {
   return (!e || e && !e.pendingBranch) && t && !t.persisted;
 }
-function jp(e, t, n = !1) {
+function Bp(e, t, n = !1) {
   const r = e.children, a = t.children;
   if (Xe(r) && Xe(a))
     for (let o = 0; o < r.length; o++) {
       const c = r[o];
       let f = a[o];
-      f.shapeFlag & 1 && !f.dynamicChildren && ((f.patchFlag <= 0 || f.patchFlag === 32) && (f = a[o] = $r(a[o]), f.el = c.el), !n && f.patchFlag !== -2 && jp(c, f)), f.type === ul && (f.patchFlag === -1 && (f = a[o] = $r(f)), f.el = c.el), f.type === ai && !f.el && (f.el = c.el);
+      f.shapeFlag & 1 && !f.dynamicChildren && ((f.patchFlag <= 0 || f.patchFlag === 32) && (f = a[o] = $r(a[o]), f.el = c.el), !n && f.patchFlag !== -2 && Bp(c, f)), f.type === ul && (f.patchFlag === -1 && (f = a[o] = $r(f)), f.el = c.el), f.type === ai && !f.el && (f.el = c.el);
     }
 }
-function pv(e) {
+function yv(e) {
   const t = e.slice(), n = [0];
   let r, a, o, c, f;
   const h = e.length;
@@ -3187,43 +3187,43 @@ function pv(e) {
     n[o] = c, c = t[c];
   return n;
 }
-function Vp(e) {
+function Gp(e) {
   const t = e.subTree.component;
   if (t)
-    return t.asyncDep && !t.asyncResolved ? t : Vp(t);
+    return t.asyncDep && !t.asyncResolved ? t : Gp(t);
 }
-function wd(e) {
+function kd(e) {
   if (e)
     for (let t = 0; t < e.length; t++)
       e[t].flags |= 8;
 }
-function Hp(e) {
+function Kp(e) {
   if (e.placeholder)
     return e.placeholder;
   const t = e.component;
-  return t ? Hp(t.subTree) : null;
+  return t ? Kp(t.subTree) : null;
 }
-const Up = (e) => e.__isSuspense;
-function mv(e, t) {
-  t && t.pendingBranch ? Xe(e) ? t.effects.push(...e) : t.effects.push(e) : wy(e);
+const Wp = (e) => e.__isSuspense;
+function vv(e, t) {
+  t && t.pendingBranch ? Xe(e) ? t.effects.push(...e) : t.effects.push(e) : Py(e);
 }
 const ot = /* @__PURE__ */ Symbol.for("v-fgt"), ul = /* @__PURE__ */ Symbol.for("v-txt"), ai = /* @__PURE__ */ Symbol.for("v-cmt"), ru = /* @__PURE__ */ Symbol.for("v-stc"), oo = [];
 let Vn = null;
 function ke(e = !1) {
   oo.push(Vn = e ? null : []);
 }
-function gv() {
+function _v() {
   oo.pop(), Vn = oo[oo.length - 1] || null;
 }
 let fo = 1;
-function kd(e, t = !1) {
+function Nd(e, t = !1) {
   fo += e, e < 0 && Vn && t && (Vn.hasOnce = !0);
 }
-function Bp(e) {
-  return e.dynamicChildren = fo > 0 ? Vn || da : null, gv(), fo > 0 && Vn && Vn.push(e), e;
+function Yp(e) {
+  return e.dynamicChildren = fo > 0 ? Vn || da : null, _v(), fo > 0 && Vn && Vn.push(e), e;
 }
 function Pe(e, t, n, r, a, o) {
-  return Bp(
+  return Yp(
     X(
       e,
       t,
@@ -3236,7 +3236,7 @@ function Pe(e, t, n, r, a, o) {
   );
 }
 function Ii(e, t, n, r, a) {
-  return Bp(
+  return Yp(
     $e(
       e,
       t,
@@ -3247,13 +3247,13 @@ function Ii(e, t, n, r, a) {
     )
   );
 }
-function Gp(e) {
+function qp(e) {
   return e ? e.__v_isVNode === !0 : !1;
 }
 function za(e, t) {
   return e.type === t.type && e.key === t.key;
 }
-const Kp = ({ key: e }) => e ?? null, vs = ({
+const Xp = ({ key: e }) => e ?? null, vs = ({
   ref: e,
   ref_key: t,
   ref_for: n
@@ -3264,9 +3264,9 @@ function X(e, t = null, n = null, r = 0, a = null, o = e === ot ? 0 : 1, c = !1,
     __v_skip: !0,
     type: e,
     props: t,
-    key: t && Kp(t),
+    key: t && Xp(t),
     ref: t && vs(t),
-    scopeId: yp,
+    scopeId: Sp,
     slotScopeIds: null,
     children: n,
     component: null,
@@ -3288,7 +3288,7 @@ function X(e, t = null, n = null, r = 0, a = null, o = e === ot ? 0 : 1, c = !1,
     appContext: null,
     ctx: jn
   };
-  return f ? (vc(h, n), o & 128 && e.normalize(h)) : n && (h.shapeFlag |= Vt(n) ? 8 : 16), fo > 0 && // avoid a block node from tracking itself
+  return f ? (_c(h, n), o & 128 && e.normalize(h)) : n && (h.shapeFlag |= Vt(n) ? 8 : 16), fo > 0 && // avoid a block node from tracking itself
   !c && // has current parent block
   Vn && // presence of a patch flag indicates this node needs patching on updates.
   // component nodes also should always be patched, because even if the
@@ -3298,23 +3298,23 @@ function X(e, t = null, n = null, r = 0, a = null, o = e === ot ? 0 : 1, c = !1,
   // vnode should not be considered dynamic due to handler caching.
   h.patchFlag !== 32 && Vn.push(h), h;
 }
-const $e = bv;
-function bv(e, t = null, n = null, r = 0, a = null, o = !1) {
-  if ((!e || e === Mp) && (e = ai), Gp(e)) {
+const $e = xv;
+function xv(e, t = null, n = null, r = 0, a = null, o = !1) {
+  if ((!e || e === Tp) && (e = ai), qp(e)) {
     const f = xa(
       e,
       t,
       !0
       /* mergeRef: true */
     );
-    return n && vc(f, n), fo > 0 && !o && Vn && (f.shapeFlag & 6 ? Vn[Vn.indexOf(e)] = f : Vn.push(f)), f.patchFlag = -2, f;
+    return n && _c(f, n), fo > 0 && !o && Vn && (f.shapeFlag & 6 ? Vn[Vn.indexOf(e)] = f : Vn.push(f)), f.patchFlag = -2, f;
   }
-  if (Cv(e) && (e = e.__vccOpts), t) {
-    t = yv(t);
+  if (Dv(e) && (e = e.__vccOpts), t) {
+    t = Sv(t);
     let { class: f, style: h } = t;
-    f && !Vt(f) && (t.class = ft(f)), yt(h) && (/* @__PURE__ */ dc(h) && !Xe(h) && (h = xn({}, h)), t.style = Bt(h));
+    f && !Vt(f) && (t.class = ft(f)), yt(h) && (/* @__PURE__ */ hc(h) && !Xe(h) && (h = xn({}, h)), t.style = Bt(h));
   }
-  const c = Vt(e) ? 1 : Up(e) ? 128 : Cy(e) ? 64 : yt(e) ? 4 : Ze(e) ? 2 : 0;
+  const c = Vt(e) ? 1 : Wp(e) ? 128 : Dy(e) ? 64 : yt(e) ? 4 : Ze(e) ? 2 : 0;
   return X(
     e,
     t,
@@ -3326,8 +3326,8 @@ function bv(e, t = null, n = null, r = 0, a = null, o = !1) {
     !0
   );
 }
-function yv(e) {
-  return e ? /* @__PURE__ */ dc(e) || Op(e) ? xn({}, e) : e : null;
+function Sv(e) {
+  return e ? /* @__PURE__ */ hc(e) || zp(e) ? xn({}, e) : e : null;
 }
 function xa(e, t, n = !1, r = !1) {
   const { props: a, ref: o, patchFlag: c, children: f, transition: h } = e, g = t ? ri(a || {}, t) : a, v = {
@@ -3335,7 +3335,7 @@ function xa(e, t, n = !1, r = !1) {
     __v_skip: !0,
     type: e.type,
     props: g,
-    key: g && Kp(g),
+    key: g && Xp(g),
     ref: t && t.ref ? (
       // #2078 in the case of <component :is="vnode" ref="extra"/>
       // if the vnode itself already has a ref, cloneVNode will need to merge
@@ -3374,12 +3374,12 @@ function xa(e, t, n = !1, r = !1) {
     ctx: e.ctx,
     ce: e.ce
   };
-  return h && r && mc(
+  return h && r && gc(
     v,
     h.clone(v)
   ), v;
 }
-function vv(e = " ", t = 0) {
+function wv(e = " ", t = 0) {
   return $e(ul, null, e, t);
 }
 function zt(e = "", t = !1) {
@@ -3391,12 +3391,12 @@ function hr(e) {
     null,
     // #3666, avoid reference pollution when reusing vnode
     e.slice()
-  ) : Gp(e) ? $r(e) : $e(ul, null, String(e));
+  ) : qp(e) ? $r(e) : $e(ul, null, String(e));
 }
 function $r(e) {
   return e.el === null && e.patchFlag !== -1 || e.memo ? e : xa(e);
 }
-function vc(e, t) {
+function _c(e, t) {
   let n = 0;
   const { shapeFlag: r } = e;
   if (t == null)
@@ -3406,14 +3406,14 @@ function vc(e, t) {
   else if (typeof t == "object")
     if (r & 65) {
       const a = t.default;
-      a && (a._c && (a._d = !1), vc(e, a()), a._c && (a._d = !0));
+      a && (a._c && (a._d = !1), _c(e, a()), a._c && (a._d = !0));
       return;
     } else {
       n = 32;
       const a = t._;
-      !a && !Op(t) ? t._ctx = jn : a === 3 && jn && (jn.slots._ === 1 ? t._ = 1 : (t._ = 2, e.patchFlag |= 1024));
+      !a && !zp(t) ? t._ctx = jn : a === 3 && jn && (jn.slots._ === 1 ? t._ = 1 : (t._ = 2, e.patchFlag |= 1024));
     }
-  else Ze(t) ? (t = { default: t, _ctx: jn }, n = 32) : (t = String(t), r & 64 ? (n = 16, t = [vv(t)]) : n = 8);
+  else Ze(t) ? (t = { default: t, _ctx: jn }, n = 32) : (t = String(t), r & 64 ? (n = 16, t = [wv(t)]) : n = 8);
   e.children = t, e.shapeFlag |= n;
 }
 function ri(...e) {
@@ -3440,11 +3440,11 @@ function sr(e, t, n, r = null) {
     r
   ]);
 }
-const _v = Cp();
-let xv = 0;
-function Sv(e, t, n) {
-  const r = e.type, a = (t ? t.appContext : e.appContext) || _v, o = {
-    uid: xv++,
+const kv = Dp();
+let Nv = 0;
+function Mv(e, t, n) {
+  const r = e.type, a = (t ? t.appContext : e.appContext) || kv, o = {
+    uid: Nv++,
     vnode: e,
     type: r,
     parent: t,
@@ -3458,7 +3458,7 @@ function Sv(e, t, n) {
     update: null,
     // will be set synchronously right after creation
     job: null,
-    scope: new Kb(
+    scope: new Xb(
       !0
       /* detached */
     ),
@@ -3475,8 +3475,8 @@ function Sv(e, t, n) {
     components: null,
     directives: null,
     // resolved props and emits options
-    propsOptions: Rp(r, a),
-    emitsOptions: Tp(r, a),
+    propsOptions: jp(r, a),
+    emitsOptions: Op(r, a),
     // emit
     emit: null,
     // to be set immediately
@@ -3519,10 +3519,10 @@ function Sv(e, t, n) {
     ec: null,
     sp: null
   };
-  return o.ctx = { _: o }, o.root = t ? t.root : o, o.emit = Qy.bind(null, o), e.ce && e.ce(o), o;
+  return o.ctx = { _: o }, o.root = t ? t.root : o, o.emit = rv.bind(null, o), e.ce && e.ce(o), o;
 }
 let gn = null;
-const wv = () => gn || jn;
+const Pv = () => gn || jn;
 let zs, Ou;
 {
   const e = rl(), t = (n, r) => {
@@ -3544,27 +3544,27 @@ const So = (e) => {
   return zs(e), e.scope.on(), () => {
     e.scope.off(), zs(t);
   };
-}, Nd = () => {
+}, Md = () => {
   gn && gn.scope.off(), zs(null);
 };
-function Wp(e) {
+function Jp(e) {
   return e.vnode.shapeFlag & 4;
 }
 let ho = !1;
-function kv(e, t = !1, n = !1) {
+function Av(e, t = !1, n = !1) {
   t && Ou(t);
-  const { props: r, children: a } = e.vnode, o = Wp(e);
-  av(e, r, o, t), uv(e, a, n || t);
-  const c = o ? Nv(e, t) : void 0;
+  const { props: r, children: a } = e.vnode, o = Jp(e);
+  uv(e, r, o, t), hv(e, a, n || t);
+  const c = o ? Cv(e, t) : void 0;
   return t && Ou(!1), c;
 }
-function Nv(e, t) {
+function Cv(e, t) {
   const n = e.type;
-  e.accessCache = /* @__PURE__ */ Object.create(null), e.proxy = new Proxy(e.ctx, By);
+  e.accessCache = /* @__PURE__ */ Object.create(null), e.proxy = new Proxy(e.ctx, Yy);
   const { setup: r } = n;
   if (r) {
     Br();
-    const a = e.setupContext = r.length > 1 ? Pv(e) : null, o = So(e), c = xo(
+    const a = e.setupContext = r.length > 1 ? Iv(e) : null, o = So(e), c = xo(
       r,
       e,
       0,
@@ -3572,54 +3572,54 @@ function Nv(e, t) {
         e.props,
         a
       ]
-    ), f = Kh(c);
-    if (Gr(), o(), (f || e.sp) && !io(e) && Sp(e), f) {
-      if (c.then(Nd, Nd), t)
+    ), f = Xh(c);
+    if (Gr(), o(), (f || e.sp) && !io(e) && Mp(e), f) {
+      if (c.then(Md, Md), t)
         return c.then((h) => {
-          Md(e, h);
+          Pd(e, h);
         }).catch((h) => {
           al(h, e, 0);
         });
       e.asyncDep = c;
     } else
-      Md(e, c);
+      Pd(e, c);
   } else
-    Yp(e);
+    Zp(e);
 }
-function Md(e, t, n) {
-  Ze(t) ? e.type.__ssrInlineRender ? e.ssrRender = t : e.render = t : yt(t) && (e.setupState = hp(t)), Yp(e);
+function Pd(e, t, n) {
+  Ze(t) ? e.type.__ssrInlineRender ? e.ssrRender = t : e.render = t : yt(t) && (e.setupState = bp(t)), Zp(e);
 }
-function Yp(e, t, n) {
+function Zp(e, t, n) {
   const r = e.type;
   e.render || (e.render = r.render || wr);
   {
     const a = So(e);
     Br();
     try {
-      Gy(e);
+      qy(e);
     } finally {
       Gr(), a();
     }
   }
 }
-const Mv = {
+const Tv = {
   get(e, t) {
     return mn(e, "get", ""), e[t];
   }
 };
-function Pv(e) {
+function Iv(e) {
   const t = (n) => {
     e.exposed = n || {};
   };
   return {
-    attrs: new Proxy(e.attrs, Mv),
+    attrs: new Proxy(e.attrs, Tv),
     slots: e.slots,
     emit: e.emit,
     expose: t
   };
 }
 function cl(e) {
-  return e.exposed ? e.exposeProxy || (e.exposeProxy = new Proxy(hp(hy(e.exposed)), {
+  return e.exposed ? e.exposeProxy || (e.exposeProxy = new Proxy(bp(by(e.exposed)), {
     get(t, n) {
       if (n in t)
         return t[n];
@@ -3631,28 +3631,28 @@ function cl(e) {
     }
   })) : e.proxy;
 }
-function Av(e, t = !0) {
+function Ev(e, t = !0) {
   return Ze(e) ? e.displayName || e.name : e.name || t && e.__name;
 }
-function Cv(e) {
+function Dv(e) {
   return Ze(e) && "__vccOpts" in e;
 }
-const wt = (e, t) => /* @__PURE__ */ yy(e, t, ho), Tv = "3.5.32";
+const wt = (e, t) => /* @__PURE__ */ Sy(e, t, ho), Ov = "3.5.32";
 /**
 * @vue/runtime-dom v3.5.32
 * (c) 2018-present Yuxi (Evan) You and Vue contributors
 * @license MIT
 **/
 let Fu;
-const Pd = typeof window < "u" && window.trustedTypes;
-if (Pd)
+const Ad = typeof window < "u" && window.trustedTypes;
+if (Ad)
   try {
-    Fu = /* @__PURE__ */ Pd.createPolicy("vue", {
+    Fu = /* @__PURE__ */ Ad.createPolicy("vue", {
       createHTML: (e) => e
     });
   } catch {
   }
-const qp = Fu ? (e) => Fu.createHTML(e) : (e) => e, Iv = "http://www.w3.org/2000/svg", Ev = "http://www.w3.org/1998/Math/MathML", Fr = typeof document < "u" ? document : null, Ad = Fr && /* @__PURE__ */ Fr.createElement("template"), Dv = {
+const Qp = Fu ? (e) => Fu.createHTML(e) : (e) => e, Fv = "http://www.w3.org/2000/svg", Rv = "http://www.w3.org/1998/Math/MathML", Fr = typeof document < "u" ? document : null, Cd = Fr && /* @__PURE__ */ Fr.createElement("template"), Lv = {
   insert: (e, t, n) => {
     t.insertBefore(e, n || null);
   },
@@ -3661,7 +3661,7 @@ const qp = Fu ? (e) => Fu.createHTML(e) : (e) => e, Iv = "http://www.w3.org/2000
     t && t.removeChild(e);
   },
   createElement: (e, t, n, r) => {
-    const a = t === "svg" ? Fr.createElementNS(Iv, e) : t === "mathml" ? Fr.createElementNS(Ev, e) : n ? Fr.createElement(e, { is: n }) : Fr.createElement(e);
+    const a = t === "svg" ? Fr.createElementNS(Fv, e) : t === "mathml" ? Fr.createElementNS(Rv, e) : n ? Fr.createElement(e, { is: n }) : Fr.createElement(e);
     return e === "select" && r && r.multiple != null && a.setAttribute("multiple", r.multiple), a;
   },
   createText: (e) => Fr.createTextNode(e),
@@ -3688,10 +3688,10 @@ const qp = Fu ? (e) => Fu.createHTML(e) : (e) => e, Iv = "http://www.w3.org/2000
       for (; t.insertBefore(a.cloneNode(!0), n), !(a === o || !(a = a.nextSibling)); )
         ;
     else {
-      Ad.innerHTML = qp(
+      Cd.innerHTML = Qp(
         r === "svg" ? `<svg>${e}</svg>` : r === "mathml" ? `<math>${e}</math>` : e
       );
-      const f = Ad.content;
+      const f = Cd.content;
       if (r === "svg" || r === "mathml") {
         const h = f.firstChild;
         for (; h.firstChild; )
@@ -3707,12 +3707,12 @@ const qp = Fu ? (e) => Fu.createHTML(e) : (e) => e, Iv = "http://www.w3.org/2000
       n ? n.previousSibling : t.lastChild
     ];
   }
-}, Ov = /* @__PURE__ */ Symbol("_vtc");
-function Fv(e, t, n) {
-  const r = e[Ov];
+}, zv = /* @__PURE__ */ Symbol("_vtc");
+function $v(e, t, n) {
+  const r = e[zv];
   r && (t = (t ? [t, ...r] : [...r]).join(" ")), t == null ? e.removeAttribute("class") : n ? e.setAttribute("class", t) : e.className = t;
 }
-const $s = /* @__PURE__ */ Symbol("_vod"), Xp = /* @__PURE__ */ Symbol("_vsh"), wo = {
+const $s = /* @__PURE__ */ Symbol("_vod"), em = /* @__PURE__ */ Symbol("_vsh"), wo = {
   // used for prop mismatch check during hydration
   name: "show",
   beforeMount(e, { value: t }, { transition: n }) {
@@ -3731,10 +3731,10 @@ const $s = /* @__PURE__ */ Symbol("_vod"), Xp = /* @__PURE__ */ Symbol("_vsh"), 
   }
 };
 function $a(e, t) {
-  e.style.display = t ? e[$s] : "none", e[Xp] = !t;
+  e.style.display = t ? e[$s] : "none", e[em] = !t;
 }
-const Rv = /* @__PURE__ */ Symbol(""), Lv = /(?:^|;)\s*display\s*:/;
-function zv(e, t, n) {
+const jv = /* @__PURE__ */ Symbol(""), Vv = /(?:^|;)\s*display\s*:/;
+function Hv(e, t, n) {
   const r = e.style, a = Vt(n);
   let o = !1;
   if (n && !a) {
@@ -3751,29 +3751,29 @@ function zv(e, t, n) {
       c === "display" && (o = !0), _s(r, c, n[c]);
   } else if (a) {
     if (t !== n) {
-      const c = r[Rv];
-      c && (n += ";" + c), r.cssText = n, o = Lv.test(n);
+      const c = r[jv];
+      c && (n += ";" + c), r.cssText = n, o = Vv.test(n);
     }
   } else t && e.removeAttribute("style");
-  $s in e && (e[$s] = o ? r.display : "", e[Xp] && (r.display = "none"));
+  $s in e && (e[$s] = o ? r.display : "", e[em] && (r.display = "none"));
 }
-const Cd = /\s*!important$/;
+const Td = /\s*!important$/;
 function _s(e, t, n) {
   if (Xe(n))
     n.forEach((r) => _s(e, t, r));
   else if (n == null && (n = ""), t.startsWith("--"))
     e.setProperty(t, n);
   else {
-    const r = $v(e, t);
-    Cd.test(n) ? e.setProperty(
+    const r = Uv(e, t);
+    Td.test(n) ? e.setProperty(
       Ti(r),
-      n.replace(Cd, ""),
+      n.replace(Td, ""),
       "important"
     ) : e[r] = n;
   }
 }
-const Td = ["Webkit", "Moz", "ms"], iu = {};
-function $v(e, t) {
+const Id = ["Webkit", "Moz", "ms"], iu = {};
+function Uv(e, t) {
   const n = iu[t];
   if (n)
     return n;
@@ -3781,23 +3781,23 @@ function $v(e, t) {
   if (r !== "filter" && r in e)
     return iu[t] = r;
   r = nl(r);
-  for (let a = 0; a < Td.length; a++) {
-    const o = Td[a] + r;
+  for (let a = 0; a < Id.length; a++) {
+    const o = Id[a] + r;
     if (o in e)
       return iu[t] = o;
   }
   return t;
 }
-const Id = "http://www.w3.org/1999/xlink";
-function Ed(e, t, n, r, a, o = Bb(t)) {
-  r && t.startsWith("xlink:") ? n == null ? e.removeAttributeNS(Id, t.slice(6, t.length)) : e.setAttributeNS(Id, t, n) : n == null || o && !Xh(n) ? e.removeAttribute(t) : e.setAttribute(
+const Ed = "http://www.w3.org/1999/xlink";
+function Dd(e, t, n, r, a, o = Yb(t)) {
+  r && t.startsWith("xlink:") ? n == null ? e.removeAttributeNS(Ed, t.slice(6, t.length)) : e.setAttributeNS(Ed, t, n) : n == null || o && !ep(n) ? e.removeAttribute(t) : e.setAttribute(
     t,
     o ? "" : kr(n) ? String(n) : n
   );
 }
-function Dd(e, t, n, r, a) {
+function Od(e, t, n, r, a) {
   if (t === "innerHTML" || t === "textContent") {
-    n != null && (e[t] = t === "innerHTML" ? qp(n) : n);
+    n != null && (e[t] = t === "innerHTML" ? Qp(n) : n);
     return;
   }
   const o = e.tagName;
@@ -3814,7 +3814,7 @@ function Dd(e, t, n, r, a) {
   let c = !1;
   if (n === "" || n == null) {
     const f = typeof e[t];
-    f === "boolean" ? n = Xh(n) : n == null && f === "string" ? (n = "", c = !0) : f === "number" && (n = 0, c = !0);
+    f === "boolean" ? n = ep(n) : n == null && f === "string" ? (n = "", c = !0) : f === "number" && (n = 0, c = !0);
   }
   try {
     e[t] = n;
@@ -3825,54 +3825,54 @@ function Dd(e, t, n, r, a) {
 function la(e, t, n, r) {
   e.addEventListener(t, n, r);
 }
-function jv(e, t, n, r) {
+function Bv(e, t, n, r) {
   e.removeEventListener(t, n, r);
 }
-const Od = /* @__PURE__ */ Symbol("_vei");
-function Vv(e, t, n, r, a = null) {
-  const o = e[Od] || (e[Od] = {}), c = o[t];
+const Fd = /* @__PURE__ */ Symbol("_vei");
+function Gv(e, t, n, r, a = null) {
+  const o = e[Fd] || (e[Fd] = {}), c = o[t];
   if (r && c)
     c.value = r;
   else {
-    const [f, h] = Hv(t);
+    const [f, h] = Kv(t);
     if (r) {
-      const g = o[t] = Gv(
+      const g = o[t] = qv(
         r,
         a
       );
       la(e, f, g, h);
-    } else c && (jv(e, f, c, h), o[t] = void 0);
+    } else c && (Bv(e, f, c, h), o[t] = void 0);
   }
 }
-const Fd = /(?:Once|Passive|Capture)$/;
-function Hv(e) {
+const Rd = /(?:Once|Passive|Capture)$/;
+function Kv(e) {
   let t;
-  if (Fd.test(e)) {
+  if (Rd.test(e)) {
     t = {};
     let r;
-    for (; r = e.match(Fd); )
+    for (; r = e.match(Rd); )
       e = e.slice(0, e.length - r[0].length), t[r[0].toLowerCase()] = !0;
   }
   return [e[2] === ":" ? e.slice(3) : Ti(e.slice(2)), t];
 }
 let au = 0;
-const Uv = /* @__PURE__ */ Promise.resolve(), Bv = () => au || (Uv.then(() => au = 0), au = Date.now());
-function Gv(e, t) {
+const Wv = /* @__PURE__ */ Promise.resolve(), Yv = () => au || (Wv.then(() => au = 0), au = Date.now());
+function qv(e, t) {
   const n = (r) => {
     if (!r._vts)
       r._vts = Date.now();
     else if (r._vts <= n.attached)
       return;
     Nr(
-      Kv(r, n.value),
+      Xv(r, n.value),
       t,
       5,
       [r]
     );
   };
-  return n.value = e, n.attached = Bv(), n;
+  return n.value = e, n.attached = Yv(), n;
 }
-function Kv(e, t) {
+function Xv(e, t) {
   if (Xe(t)) {
     const n = e.stopImmediatePropagation;
     return e.stopImmediatePropagation = () => {
@@ -3883,16 +3883,16 @@ function Kv(e, t) {
   } else
     return t;
 }
-const Rd = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && // lowercase letter
-e.charCodeAt(2) > 96 && e.charCodeAt(2) < 123, Wv = (e, t, n, r, a, o) => {
+const Ld = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && // lowercase letter
+e.charCodeAt(2) > 96 && e.charCodeAt(2) < 123, Jv = (e, t, n, r, a, o) => {
   const c = a === "svg";
-  t === "class" ? Fv(e, r, c) : t === "style" ? zv(e, n, r) : Qs(t) ? el(t) || Vv(e, t, n, r, o) : (t[0] === "." ? (t = t.slice(1), !0) : t[0] === "^" ? (t = t.slice(1), !1) : Yv(e, t, r, c)) ? (Dd(e, t, r), !e.tagName.includes("-") && (t === "value" || t === "checked" || t === "selected") && Ed(e, t, r, c, o, t !== "value")) : /* #11081 force set props for possible async custom element */ e._isVueCE && // #12408 check if it's declared prop or it's async custom element
-  (qv(e, t) || // @ts-expect-error _def is private
-  e._def.__asyncLoader && (/[A-Z]/.test(t) || !Vt(r))) ? Dd(e, Pn(t), r, o, t) : (t === "true-value" ? e._trueValue = r : t === "false-value" && (e._falseValue = r), Ed(e, t, r, c));
+  t === "class" ? $v(e, r, c) : t === "style" ? Hv(e, n, r) : Qs(t) ? el(t) || Gv(e, t, n, r, o) : (t[0] === "." ? (t = t.slice(1), !0) : t[0] === "^" ? (t = t.slice(1), !1) : Zv(e, t, r, c)) ? (Od(e, t, r), !e.tagName.includes("-") && (t === "value" || t === "checked" || t === "selected") && Dd(e, t, r, c, o, t !== "value")) : /* #11081 force set props for possible async custom element */ e._isVueCE && // #12408 check if it's declared prop or it's async custom element
+  (Qv(e, t) || // @ts-expect-error _def is private
+  e._def.__asyncLoader && (/[A-Z]/.test(t) || !Vt(r))) ? Od(e, Pn(t), r, o, t) : (t === "true-value" ? e._trueValue = r : t === "false-value" && (e._falseValue = r), Dd(e, t, r, c));
 };
-function Yv(e, t, n, r) {
+function Zv(e, t, n, r) {
   if (r)
-    return !!(t === "innerHTML" || t === "textContent" || t in e && Rd(t) && Ze(n));
+    return !!(t === "innerHTML" || t === "textContent" || t in e && Ld(t) && Ze(n));
   if (t === "spellcheck" || t === "draggable" || t === "translate" || t === "autocorrect" || t === "sandbox" && e.tagName === "IFRAME" || t === "form" || t === "list" && e.tagName === "INPUT" || t === "type" && e.tagName === "TEXTAREA")
     return !1;
   if (t === "width" || t === "height") {
@@ -3900,9 +3900,9 @@ function Yv(e, t, n, r) {
     if (a === "IMG" || a === "VIDEO" || a === "CANVAS" || a === "SOURCE")
       return !1;
   }
-  return Rd(t) && Vt(n) ? !1 : t in e;
+  return Ld(t) && Vt(n) ? !1 : t in e;
 }
-function qv(e, t) {
+function Qv(e, t) {
   const n = (
     // @ts-expect-error _def is private
     e._def.props
@@ -3912,44 +3912,44 @@ function qv(e, t) {
   const r = Pn(t);
   return Array.isArray(n) ? n.some((a) => Pn(a) === r) : Object.keys(n).some((a) => Pn(a) === r);
 }
-const Ld = (e) => {
+const zd = (e) => {
   const t = e.props["onUpdate:modelValue"] || !1;
   return Xe(t) ? (n) => bs(t, n) : t;
 };
-function Xv(e) {
+function e1(e) {
   e.target.composing = !0;
 }
-function zd(e) {
+function $d(e) {
   const t = e.target;
   t.composing && (t.composing = !1, t.dispatchEvent(new Event("input")));
 }
 const ou = /* @__PURE__ */ Symbol("_assign");
-function $d(e, t, n) {
-  return t && (e = e.trim()), n && (e = ic(e)), e;
+function jd(e, t, n) {
+  return t && (e = e.trim()), n && (e = ac(e)), e;
 }
-const jd = {
+const Vd = {
   created(e, { modifiers: { lazy: t, trim: n, number: r } }, a) {
-    e[ou] = Ld(a);
+    e[ou] = zd(a);
     const o = r || a.props && a.props.type === "number";
     la(e, t ? "change" : "input", (c) => {
-      c.target.composing || e[ou]($d(e.value, n, o));
+      c.target.composing || e[ou](jd(e.value, n, o));
     }), (n || o) && la(e, "change", () => {
-      e.value = $d(e.value, n, o);
-    }), t || (la(e, "compositionstart", Xv), la(e, "compositionend", zd), la(e, "change", zd));
+      e.value = jd(e.value, n, o);
+    }), t || (la(e, "compositionstart", e1), la(e, "compositionend", $d), la(e, "change", $d));
   },
   // set value on mounted so it's after min/max for type="range"
   mounted(e, { value: t }) {
     e.value = t ?? "";
   },
   beforeUpdate(e, { value: t, oldValue: n, modifiers: { lazy: r, trim: a, number: o } }, c) {
-    if (e[ou] = Ld(c), e.composing) return;
-    const f = (o || e.type === "number") && !/^0\d/.test(e.value) ? ic(e.value) : e.value, h = t ?? "";
+    if (e[ou] = zd(c), e.composing) return;
+    const f = (o || e.type === "number") && !/^0\d/.test(e.value) ? ac(e.value) : e.value, h = t ?? "";
     if (f === h)
       return;
     const g = e.getRootNode();
     (g instanceof Document || g instanceof ShadowRoot) && g.activeElement === e && e.type !== "range" && (r && t === n || a && e.value.trim() === h) || (e.value = h);
   }
-}, Jv = ["ctrl", "shift", "alt", "meta"], Zv = {
+}, t1 = ["ctrl", "shift", "alt", "meta"], n1 = {
   stop: (e) => e.stopPropagation(),
   prevent: (e) => e.preventDefault(),
   self: (e) => e.target !== e.currentTarget,
@@ -3960,43 +3960,43 @@ const jd = {
   left: (e) => "button" in e && e.button !== 0,
   middle: (e) => "button" in e && e.button !== 1,
   right: (e) => "button" in e && e.button !== 2,
-  exact: (e, t) => Jv.some((n) => e[`${n}Key`] && !t.includes(n))
+  exact: (e, t) => t1.some((n) => e[`${n}Key`] && !t.includes(n))
 }, Hn = (e, t) => {
   if (!e) return e;
   const n = e._withMods || (e._withMods = {}), r = t.join(".");
   return n[r] || (n[r] = ((a, ...o) => {
     for (let c = 0; c < t.length; c++) {
-      const f = Zv[t[c]];
+      const f = n1[t[c]];
       if (f && f(a, t)) return;
     }
     return e(a, ...o);
   }));
-}, Qv = /* @__PURE__ */ xn({ patchProp: Wv }, Dv);
-let Vd;
-function e1() {
-  return Vd || (Vd = fv(Qv));
+}, r1 = /* @__PURE__ */ xn({ patchProp: Jv }, Lv);
+let Hd;
+function i1() {
+  return Hd || (Hd = mv(r1));
 }
-const _c = ((...e) => {
-  const t = e1().createApp(...e), { mount: n } = t;
+const xc = ((...e) => {
+  const t = i1().createApp(...e), { mount: n } = t;
   return t.mount = (r) => {
-    const a = n1(r);
+    const a = o1(r);
     if (!a) return;
     const o = t._component;
     !Ze(o) && !o.render && !o.template && (o.template = a.innerHTML), a.nodeType === 1 && (a.textContent = "");
-    const c = n(a, !1, t1(a));
+    const c = n(a, !1, a1(a));
     return a instanceof Element && (a.removeAttribute("v-cloak"), a.setAttribute("data-v-app", "")), c;
   }, t;
 });
-function t1(e) {
+function a1(e) {
   if (e instanceof SVGElement)
     return "svg";
   if (typeof MathMLElement == "function" && e instanceof MathMLElement)
     return "mathml";
 }
-function n1(e) {
+function o1(e) {
   return Vt(e) ? document.querySelector(e) : e;
 }
-const Ot = Math.PI / 180, Jp = Math.PI * 2, r1 = 2048;
+const Ot = Math.PI / 180, tm = Math.PI * 2, s1 = 2048;
 function St(e, t, n) {
   return Math.max(t, Math.min(n, e));
 }
@@ -4012,7 +4012,7 @@ function fa(e, t) {
 function xs(e, t) {
   return e.x * t.x + e.y * t.y + e.z * t.z;
 }
-function Hd(e, t) {
+function Ud(e, t) {
   return oi(
     e.y * t.z - e.z * t.y,
     e.z * t.x - e.x * t.z,
@@ -4023,24 +4023,24 @@ function qa(e) {
   const t = Math.hypot(e.x, e.y, e.z) || 1e-8;
   return oi(e.x / t, e.y / t, e.z / t);
 }
-function i1(e, t) {
+function l1(e, t) {
   const n = Number(e || 0) * Ot, r = Number(t || 0) * Ot, a = Math.cos(r);
   return oi(a * Math.sin(n), Math.sin(r), a * Math.cos(n));
 }
 function Ss(e, t, n = 0) {
-  const r = i1(e, t);
+  const r = l1(e, t);
   let a = oi(0, 1, 0);
   Math.abs(xs(r, a)) > 0.999 && (a = oi(0, 0, 1));
-  let o = qa(Hd(a, r)), c = qa(Hd(r, o));
+  let o = qa(Ud(a, r)), c = qa(Ud(r, o));
   const f = Number(n || 0) * Ot, h = Math.cos(f), g = Math.sin(f), v = js(fa(o, h), fa(c, g)), x = js(fa(o, -g), fa(c, h));
   return o = qa(v), c = qa(x), { fwd: r, right: o, up: c };
 }
-function a1(e, t) {
-  const n = (Number(e || 0) - 0.5) * Jp, r = (0.5 - Number(t || 0)) * Math.PI, a = Math.cos(r);
+function u1(e, t) {
+  const n = (Number(e || 0) - 0.5) * tm, r = (0.5 - Number(t || 0)) * Math.PI, a = Math.cos(r);
   return oi(a * Math.sin(n), Math.sin(r), a * Math.cos(n));
 }
-function Ud(e, t, n = 1) {
-  const r = Math.max(1, Math.round(Number(e || 1))), a = Math.max(1, Math.round(Number(t || 1))), o = Math.max(1, Number(n || 1)), c = Math.max(512, r1), f = Math.min(1, c / Math.max(r, a));
+function Bd(e, t, n = 1) {
+  const r = Math.max(1, Math.round(Number(e || 1))), a = Math.max(1, Math.round(Number(t || 1))), o = Math.max(1, Number(n || 1)), c = Math.max(512, s1), f = Math.min(1, c / Math.max(r, a));
   return {
     sourceWidth: r,
     sourceHeight: a,
@@ -4050,7 +4050,7 @@ function Ud(e, t, n = 1) {
     height: Math.max(1, Math.round(a * f))
   };
 }
-function Bd(e, t, n) {
+function Gd(e, t, n) {
   const r = e.createShader(t);
   if (e.shaderSource(r, n), e.compileShader(r), !e.getShaderParameter(r, e.COMPILE_STATUS)) {
     const a = e.getShaderInfoLog(r) || "shader compile failed";
@@ -4059,10 +4059,10 @@ function Bd(e, t, n) {
   return r;
 }
 function su(e, t, n) {
-  const r = Bd(e, e.VERTEX_SHADER, t);
+  const r = Gd(e, e.VERTEX_SHADER, t);
   let a;
   try {
-    a = Bd(e, e.FRAGMENT_SHADER, n);
+    a = Gd(e, e.FRAGMENT_SHADER, n);
   } catch (c) {
     throw e.deleteShader(r), c;
   }
@@ -4080,7 +4080,7 @@ out vec2 v_uv;
 void main() {
   gl_Position = vec4(a_position, 0.0, 1.0);
   v_uv = vec2(a_position.x * 0.5 + 0.5, 1.0 - (a_position.y * 0.5 + 0.5));
-}`, o1 = `#version 300 es
+}`, c1 = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 out vec4 outColor;
@@ -4155,7 +4155,7 @@ void main() {
   vec3 premul = bg.rgb * u_opacity;
   float alpha = bgAlpha;
   outColor = vec4(premul, alpha);
-}`, s1 = `#version 300 es
+}`, f1 = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 out vec4 outColor;
@@ -4233,7 +4233,7 @@ void main() {
     alpha = maskAlpha + alpha * (1.0 - maskAlpha);
   }
   outColor = vec4(premul, alpha);
-}`, l1 = `#version 300 es
+}`, d1 = `#version 300 es
 precision highp float;
 in vec2 v_uv;
 out vec4 outColor;
@@ -4300,7 +4300,7 @@ function ja(e, t, n) {
     vFovDeg: St(a, 0.1, 179)
   };
 }
-function u1(e) {
+function h1(e) {
   const t = Ss(
     Number(e.yawDeg || 0),
     Number(e.pitchDeg || 0),
@@ -4316,9 +4316,9 @@ function u1(e) {
     opacity: St(Number(e.opacity ?? 1), 0, 1)
   };
 }
-function c1(e = {}) {
+function p1(e = {}) {
   const t = (e == null ? void 0 : e.targetCanvas) || document.createElement("canvas");
-  let n = null, r = null, a = null, o = null, c = null, f = null, h = null, g = null, v = null, x = null, S = null, M = !1, b = Ud(1, 1, 1), O = null, j = null, z = null, P = null, $ = null;
+  let n = null, r = null, a = null, o = null, c = null, f = null, h = null, g = null, v = null, x = null, S = null, M = !1, b = Bd(1, 1, 1), O = null, j = null, z = null, P = null, $ = null;
   const I = /* @__PURE__ */ new Map();
   let R = {
     objectPass: { objects: [] },
@@ -4349,7 +4349,7 @@ function c1(e = {}) {
         stencil: !1,
         premultipliedAlpha: !0,
         preserveDrawingBuffer: !1
-      }), n ? (r = su(n, lu, o1), a = su(n, lu, s1), o = su(n, lu, l1), O = {
+      }), n ? (r = su(n, lu, c1), a = su(n, lu, f1), o = su(n, lu, d1), O = {
         mode: n.getUniformLocation(r, "u_mode"),
         yaw: n.getUniformLocation(r, "u_yaw"),
         pitch: n.getUniformLocation(r, "u_pitch"),
@@ -4428,7 +4428,7 @@ function c1(e = {}) {
     }
   }
   function q(D, Q, ee = 1) {
-    b = Ud(D, Q, ee), (t.width !== b.width || t.height !== b.height) && (t.width = b.width, t.height = b.height);
+    b = Bd(D, Q, ee), (t.width !== b.width || t.height !== b.height) && (t.width = b.width, t.height = b.height);
   }
   function re(D) {
     D === "background" ? v = null : D === "paint" ? x = null : S = null, G[D] && (G[D].width = 0, G[D].height = 0);
@@ -4578,7 +4578,7 @@ function c1(e = {}) {
             revision: oe.revision
           });
           if (!Nt) continue;
-          const Ge = u1({
+          const Ge = h1({
             yawDeg: ((De = oe == null ? void 0 : oe.transform) == null ? void 0 : De.yawDeg) || 0,
             pitchDeg: ((Re = oe == null ? void 0 : oe.transform) == null ? void 0 : Re.pitchDeg) || 0,
             rollDeg: ((Ue = oe == null ? void 0 : oe.transform) == null ? void 0 : Ue.rollDeg) || 0,
@@ -4664,7 +4664,7 @@ function c1(e = {}) {
     if (!Ce) return null;
     const d = Ss(Ce.yawDeg, Ce.pitchDeg, Ce.rollDeg), De = (Me - fe * 0.5) / (fe * 0.5) * Math.tan(St(Ce.hFovDeg, 1, 179) * Ot * 0.5), Re = (ne * 0.5 - ge) / (ne * 0.5) * Math.tan(St(Ce.vFovDeg, 0.1, 179) * Ot * 0.5), Ue = qa(js(js(fa(d.right, De), fa(d.up, Re)), d.fwd));
     return {
-      u: (Math.atan2(Ue.x, Ue.z) / Jp + 0.5 + 1) % 1,
+      u: (Math.atan2(Ue.x, Ue.z) / tm + 0.5 + 1) % 1,
       v: St(0.5 - Math.asin(St(Ue.y, -1, 1)) / Math.PI, 0, 1)
     };
   }
@@ -4679,7 +4679,7 @@ function c1(e = {}) {
     const Me = ja(D, fe, ne);
     if (!Me)
       return { x: fe * 0.5, y: ne * 0.5, visible: !1 };
-    const ge = Ss(Me.yawDeg, Me.pitchDeg, Me.rollDeg), Ce = a1(Q, ee), d = xs(Ce, ge.right), De = xs(Ce, ge.up), Re = xs(Ce, ge.fwd);
+    const ge = Ss(Me.yawDeg, Me.pitchDeg, Me.rollDeg), Ce = u1(Q, ee), d = xs(Ce, ge.right), De = xs(Ce, ge.up), Re = xs(Ce, ge.fwd);
     if (Re <= 1e-5) return { x: 0, y: 0, visible: !1 };
     const Ue = fe * 0.5 + d / Re * (fe * 0.5 / Math.tan(St(Me.hFovDeg, 1, 179) * Ot * 0.5)), et = ne * 0.5 - De / Re * (ne * 0.5 / Math.tan(St(Me.vFovDeg, 0.1, 179) * Ot * 0.5));
     return { x: Ue, y: et, visible: Ue >= 0 && Ue <= fe && et >= 0 && et <= ne };
@@ -4709,11 +4709,11 @@ function c1(e = {}) {
     }
   };
 }
-function Gd(e, t = 1, n = 16384) {
+function Kd(e, t = 1, n = 16384) {
   const r = Math.round(Number(e || t));
   return Math.min(n, Math.max(1, Number.isFinite(r) ? r : 1));
 }
-function f1() {
+function m1() {
   const e = /* @__PURE__ */ new Map();
   function t(c) {
     return c != null ? String(c) : "default";
@@ -4732,7 +4732,7 @@ function f1() {
         height: 0
       }, e.set(g, v);
     }
-    const x = Gd(f), S = Gd(h);
+    const x = Kd(f), S = Kd(h);
     return v.width !== x && (v.canvas.width = x, v.width = x), v.height !== S && (v.canvas.height = S, v.height = S), v;
   }
   function r(c) {
@@ -4752,37 +4752,37 @@ function f1() {
     dispose: o
   };
 }
-const d1 = /* @__PURE__ */ new Set([
+const g1 = /* @__PURE__ */ new Set([
   "sticker",
   "raster",
   "paint",
   "mask",
   "3d_object"
-]), h1 = /* @__PURE__ */ new Set([
+]), b1 = /* @__PURE__ */ new Set([
   "erp_image",
   "video",
   "3d"
 ]);
-function Zp(e, t, n) {
+function nm(e, t, n) {
   return Math.max(t, Math.min(n, e));
 }
-function p1(e, t) {
+function y1(e, t) {
   return e === "paint" || e === "mask" || e === "raster" ? !1 : t !== !1;
 }
-function m1(e = {}) {
-  const t = h1.has(String((e == null ? void 0 : e.type) || "")) ? String(e.type) : "erp_image", n = Number((e == null ? void 0 : e.opacity) ?? 1);
+function v1(e = {}) {
+  const t = b1.has(String((e == null ? void 0 : e.type) || "")) ? String(e.type) : "erp_image", n = Number((e == null ? void 0 : e.opacity) ?? 1);
   return {
     type: t,
     source: (e == null ? void 0 : e.source) || null,
     revision: String((e == null ? void 0 : e.revision) || ""),
     coverageDeg: Number((e == null ? void 0 : e.coverageDeg) || 360) === 180 ? 180 : 360,
-    opacity: Number.isFinite(n) ? Zp(n, 0, 1) : 1,
+    opacity: Number.isFinite(n) ? nm(n, 0, 1) : 1,
     visible: (e == null ? void 0 : e.visible) !== !1
   };
 }
-function g1(e = {}) {
+function _1(e = {}) {
   const t = String((e == null ? void 0 : e.type) || "");
-  if (!d1.has(t)) return null;
+  if (!g1.has(t)) return null;
   const n = Number((e == null ? void 0 : e.opacity) ?? 1), r = Number((e == null ? void 0 : e.zIndex) ?? (e == null ? void 0 : e.z_index) ?? 0);
   return {
     id: String((e == null ? void 0 : e.id) || ""),
@@ -4790,16 +4790,16 @@ function g1(e = {}) {
     source: (e == null ? void 0 : e.source) || null,
     revision: String((e == null ? void 0 : e.revision) || ""),
     visible: (e == null ? void 0 : e.visible) !== !1,
-    opacity: Number.isFinite(n) ? Zp(n, 0, 1) : 1,
+    opacity: Number.isFinite(n) ? nm(n, 0, 1) : 1,
     zIndex: Number.isFinite(r) ? r : 0,
-    coverageAware: p1(t, e == null ? void 0 : e.coverageAware),
+    coverageAware: y1(t, e == null ? void 0 : e.coverageAware),
     transform: e != null && e.transform && typeof e.transform == "object" ? { ...e.transform } : null,
     params: e != null && e.params && typeof e.params == "object" ? { ...e.params } : {}
   };
 }
-function b1(e = {}) {
+function x1(e = {}) {
   return {
-    objects: (Array.isArray(e == null ? void 0 : e.objects) ? e.objects : []).map((r) => g1(r)).filter((r) => !!r && r.visible !== !1).sort((r, a) => {
+    objects: (Array.isArray(e == null ? void 0 : e.objects) ? e.objects : []).map((r) => _1(r)).filter((r) => !!r && r.visible !== !1).sort((r, a) => {
       const o = Number((r == null ? void 0 : r.zIndex) || 0), c = Number((a == null ? void 0 : a.zIndex) || 0);
       return o - c;
     }),
@@ -4810,15 +4810,15 @@ function b1(e = {}) {
 function Sa(e = {}) {
   return {
     stateRevision: String((e == null ? void 0 : e.stateRevision) || ""),
-    background: m1((e == null ? void 0 : e.background) || {}),
-    objectPass: b1((e == null ? void 0 : e.objectPass) || {}),
+    background: v1((e == null ? void 0 : e.background) || {}),
+    objectPass: x1((e == null ? void 0 : e.objectPass) || {}),
     overlay: e != null && e.overlay && typeof e.overlay == "object" ? { ...e.overlay } : {}
   };
 }
-function y1(e, t, n) {
+function S1(e, t, n) {
   return Math.max(t, Math.min(n, e));
 }
-function xc(e = {}, t = "paint") {
+function Sc(e = {}, t = "paint") {
   const n = String((e == null ? void 0 : e.type) || t), r = Number((e == null ? void 0 : e.zIndex) ?? (e == null ? void 0 : e.z_index) ?? 0), a = Number((e == null ? void 0 : e.opacity) ?? 1);
   return {
     id: String((e == null ? void 0 : e.id) || `${n}_layer`),
@@ -4826,15 +4826,15 @@ function xc(e = {}, t = "paint") {
     source: (e == null ? void 0 : e.source) || null,
     revision: String((e == null ? void 0 : e.revision) || ""),
     zIndex: Number.isFinite(r) ? r : 0,
-    opacity: Number.isFinite(a) ? y1(a, 0, 1) : 1,
+    opacity: Number.isFinite(a) ? S1(a, 0, 1) : 1,
     visible: (e == null ? void 0 : e.visible) !== !1,
     coverageAware: !1,
     transform: e != null && e.transform && typeof e.transform == "object" ? { ...e.transform } : null,
     params: e != null && e.params && typeof e.params == "object" ? { ...e.params } : {}
   };
 }
-function v1(e, t, n = {}) {
-  return e ? xc({
+function w1(e, t, n = {}) {
+  return e ? Sc({
     id: String((n == null ? void 0 : n.id) || "paint_layer"),
     type: "paint",
     source: e,
@@ -4845,8 +4845,8 @@ function v1(e, t, n = {}) {
     params: (n == null ? void 0 : n.params) || {}
   }, "paint") : null;
 }
-function _1(e, t, n = {}) {
-  return e ? xc({
+function k1(e, t, n = {}) {
+  return e ? Sc({
     id: String((n == null ? void 0 : n.id) || "mask_layer"),
     type: "mask",
     source: e,
@@ -4857,8 +4857,8 @@ function _1(e, t, n = {}) {
     params: (n == null ? void 0 : n.params) || {}
   }, "mask") : null;
 }
-function x1(e, t, n = {}) {
-  return e ? xc({
+function N1(e, t, n = {}) {
+  return e ? Sc({
     id: String((n == null ? void 0 : n.id) || "raster_layer"),
     type: "raster",
     source: e,
@@ -4870,10 +4870,10 @@ function x1(e, t, n = {}) {
     params: (n == null ? void 0 : n.params) || {}
   }, "raster") : null;
 }
-function Qp(e = {}) {
-  const t = [], n = v1(e == null ? void 0 : e.paintSource, e == null ? void 0 : e.paintRevision, e == null ? void 0 : e.paintOptions), r = _1(e == null ? void 0 : e.maskSource, e == null ? void 0 : e.maskRevision, e == null ? void 0 : e.maskOptions), a = Array.isArray(e == null ? void 0 : e.rasterEntries) ? e.rasterEntries : [];
+function rm(e = {}) {
+  const t = [], n = w1(e == null ? void 0 : e.paintSource, e == null ? void 0 : e.paintRevision, e == null ? void 0 : e.paintOptions), r = k1(e == null ? void 0 : e.maskSource, e == null ? void 0 : e.maskRevision, e == null ? void 0 : e.maskOptions), a = Array.isArray(e == null ? void 0 : e.rasterEntries) ? e.rasterEntries : [];
   return n && t.push(n), r && t.push(r), a.forEach((o, c) => {
-    const f = x1(
+    const f = N1(
       (o == null ? void 0 : o.source) || null,
       (o == null ? void 0 : o.revision) || "",
       {
@@ -4891,7 +4891,7 @@ function Qp(e = {}) {
     return f !== h ? f - h : String((o == null ? void 0 : o.id) || "").localeCompare(String((c == null ? void 0 : c.id) || ""));
   });
 }
-function Sc(e, t) {
+function wc(e, t) {
   const n = new Map(
     (Array.isArray(t) ? t : []).map((r) => [String((r == null ? void 0 : r.assetId) || ""), r]).filter(([r, a]) => r && (a == null ? void 0 : a.source))
   );
@@ -4919,7 +4919,7 @@ function Sc(e, t) {
     } : null;
   }).filter(Boolean) : [];
 }
-function em(e = {}) {
+function im(e = {}) {
   const t = (e == null ? void 0 : e.backgroundSource) || null, n = Number((e == null ? void 0 : e.coverageDeg) || 360) === 180 ? 180 : 360, r = String((e == null ? void 0 : e.stateRevision) || ""), a = (e == null ? void 0 : e.scene) || { stickers: [], selectedId: null, hoveredId: null }, o = Array.isArray(e == null ? void 0 : e.textures) ? e.textures : [], c = String((e == null ? void 0 : e.backgroundRevision) || [
     String((t == null ? void 0 : t.currentSrc) || (t == null ? void 0 : t.src) || ""),
     Number((t == null ? void 0 : t.naturalWidth) || (t == null ? void 0 : t.width) || 0),
@@ -4937,7 +4937,7 @@ function em(e = {}) {
     objectPass: {
       selectedId: (a == null ? void 0 : a.selectedId) ?? null,
       hoveredId: (a == null ? void 0 : a.hoveredId) ?? null,
-      objects: Sc(a, o)
+      objects: wc(a, o)
     },
     overlay: {
       showMaskTint: (e == null ? void 0 : e.showMaskTint) === !0
@@ -4945,7 +4945,7 @@ function em(e = {}) {
   });
 }
 function Xa(e = {}) {
-  const t = (e == null ? void 0 : e.scene) || { stickers: [], selectedId: null, hoveredId: null }, n = Array.isArray(e == null ? void 0 : e.textures) ? e.textures : [], r = Sc(t, n), a = Qp({
+  const t = (e == null ? void 0 : e.scene) || { stickers: [], selectedId: null, hoveredId: null }, n = Array.isArray(e == null ? void 0 : e.textures) ? e.textures : [], r = wc(t, n), a = rm({
     paintSource: (e == null ? void 0 : e.paintSource) || null,
     paintRevision: (e == null ? void 0 : e.paintRevision) || "",
     paintOptions: (e == null ? void 0 : e.paintOptions) || null,
@@ -4973,7 +4973,7 @@ function Xa(e = {}) {
     }
   });
 }
-function S1(e = {}) {
+function M1(e = {}) {
   var o, c, f, h, g, v, x, S;
   if (e != null && e.background || e != null && e.objectPass || e != null && e.overlay) {
     const M = Sa(e), b = Array.isArray((o = M.objectPass) == null ? void 0 : o.objects) ? M.objectPass.objects : [], O = {
@@ -5024,8 +5024,8 @@ function S1(e = {}) {
       selectedId: (t == null ? void 0 : t.selectedId) ?? null,
       hoveredId: (t == null ? void 0 : t.hoveredId) ?? null,
       objects: [
-        ...Sc(t, n),
-        ...Qp({
+        ...wc(t, n),
+        ...rm({
           paintSource: e.paintSource || r.paintSource || null,
           paintRevision: e.paintRevision || r.paintRevision || "",
           paintOptions: e.paintOptions || null,
@@ -5053,10 +5053,10 @@ function S1(e = {}) {
     showMaskTint: e.showMaskTint === !0
   };
 }
-function w1(e) {
+function P1(e) {
   let t = null;
   function n(o = {}) {
-    const c = S1(o);
+    const c = M1(o);
     return e.syncState({
       stateRevision: c.stateRevision,
       backgroundSource: c.backgroundSource,
@@ -5086,7 +5086,7 @@ function w1(e) {
   };
 }
 function ko(e = {}) {
-  const t = typeof (e == null ? void 0 : e.rendererFactory) == "function" ? e.rendererFactory : (j) => c1(j), n = typeof (e == null ? void 0 : e.targetPoolFactory) == "function" ? e.targetPoolFactory : () => f1(), r = typeof (e == null ? void 0 : e.stateControllerFactory) == "function" ? e.stateControllerFactory : (j) => w1(j), a = t(e), o = (e == null ? void 0 : e.targetCanvas) || null, c = n();
+  const t = typeof (e == null ? void 0 : e.rendererFactory) == "function" ? e.rendererFactory : (j) => p1(j), n = typeof (e == null ? void 0 : e.targetPoolFactory) == "function" ? e.targetPoolFactory : () => m1(), r = typeof (e == null ? void 0 : e.stateControllerFactory) == "function" ? e.stateControllerFactory : (j) => P1(j), a = t(e), o = (e == null ? void 0 : e.targetCanvas) || null, c = n();
   let f = null;
   const h = r({
     syncState(j = {}) {
@@ -5160,7 +5160,7 @@ function ua(e, t) {
   const r = n.getContext("2d");
   return r && (r.clearRect(0, 0, n.width, n.height), r.imageSmoothingEnabled = !0), { canvas: n, ctx: r };
 }
-function k1() {
+function A1() {
   var e;
   try {
     return (window == null ? void 0 : window.__PANO_PAINT_DEBUG__) === !0 ? !0 : String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem("panoPaintDebug")) || "").trim() === "1";
@@ -5168,7 +5168,7 @@ function k1() {
     return !1;
   }
 }
-function Kd(e, t = 8) {
+function Wd(e, t = 8) {
   var v;
   const n = (v = e == null ? void 0 : e.getContext) == null ? void 0 : v.call(e, "2d"), r = Number((e == null ? void 0 : e.width) || 0), a = Number((e == null ? void 0 : e.height) || 0);
   if (!n || r < 1 || a < 1) return null;
@@ -5187,7 +5187,7 @@ function Kd(e, t = 8) {
     aspect: Number(((h - c + 1) / Math.max(1, g - f + 1)).toFixed(4))
   };
 }
-function wc(e, t) {
+function kc(e, t) {
   const n = Math.max(1, Math.ceil(e)), r = Math.max(1, Math.ceil(t));
   if (typeof OffscreenCanvas < "u") return new OffscreenCanvas(n, r);
   const a = document.createElement("canvas");
@@ -5201,8 +5201,8 @@ function Rr(e, t, n) {
 function Et(e) {
   e != null && e.ctx && e.ctx.clearRect(0, 0, e.canvas.width, e.canvas.height);
 }
-let uu = null, cu = null, Wd = null, Yd = null, Lt = null, Va = null, kn = null, ei = null;
-function N1() {
+let uu = null, cu = null, Yd = null, qd = null, Lt = null, Va = null, kn = null, ei = null;
+function C1() {
   if (cu) return cu;
   const e = 6, t = 17, n = document.createElement("canvas");
   n.width = t, n.height = t;
@@ -5214,44 +5214,44 @@ function fu(e, t) {
   const n = t.width, r = t.height;
   uu = Rr(uu, n, r);
   const a = uu;
-  Et(a), a.ctx.drawImage(t, 0, 0), a.ctx.globalCompositeOperation = "source-in", Yd !== a.ctx && (Wd = a.ctx.createPattern(N1(), "repeat"), Yd = a.ctx), a.ctx.fillStyle = Wd, a.ctx.fillRect(0, 0, n, r), a.ctx.globalCompositeOperation = "source-over", e.save(), e.globalCompositeOperation = "source-over", e.drawImage(a.canvas, 0, 0), e.restore();
+  Et(a), a.ctx.drawImage(t, 0, 0), a.ctx.globalCompositeOperation = "source-in", qd !== a.ctx && (Yd = a.ctx.createPattern(C1(), "repeat"), qd = a.ctx), a.ctx.fillStyle = Yd, a.ctx.fillRect(0, 0, n, r), a.ctx.globalCompositeOperation = "source-over", e.save(), e.globalCompositeOperation = "source-over", e.drawImage(a.canvas, 0, 0), e.restore();
 }
-function M1(e) {
+function T1(e) {
   return !e || typeof e != "object" ? { x: 0, y: 0 } : { x: Number(e.u || 0), y: Number(e.v || 0) };
 }
-function P1(e) {
+function I1(e) {
   const t = e == null ? void 0 : e.geometry;
   return t ? Array.isArray(t.rawPoints) && t.rawPoints.length ? t.rawPoints : Array.isArray(t.points) && t.points.length ? t.points : [] : [];
 }
-function A1(e, t) {
+function E1(e, t) {
   const n = Number(e == null ? void 0 : e.radiusValue), r = String((e == null ? void 0 : e.radiusModel) || "").trim(), a = (t == null ? void 0 : t.width) || 1;
   return r === "erp_uv_norm" && n > 0 ? Math.max(0.5, n * a) : r === "degree_norm" && n > 0 ? Math.max(0.5, n * 90 / 360 * a) : Math.max(0.5, Number((e == null ? void 0 : e.baseSize) || (e == null ? void 0 : e.size) || 10) * 0.5);
 }
-function C1(e, t) {
+function D1(e, t) {
   const n = Number(e == null ? void 0 : e.spacing);
   if (Number.isFinite(n) && n > 0) return Math.max(1, n * t * 2);
   const r = String((e == null ? void 0 : e.toolKind) || "pen");
   return Math.max(1, (r === "brush" || r === "eraser" ? 0.15 : 0.2) * t * 2);
 }
-const Dt = /* @__PURE__ */ new Map(), kc = 128;
-function T1(e, t, n, r, a, o) {
+const Dt = /* @__PURE__ */ new Map(), Nc = 128;
+function O1(e, t, n, r, a, o) {
   const c = Math.max(1, Math.round(e)), f = Math.max(0, Math.min(1, t)), h = `${c}:${f.toFixed(2)}:${n}:${r}:${a}:${o.toFixed(3)}`;
   if (Dt.has(h)) {
     const P = Dt.get(h);
     return Dt.delete(h), Dt.set(h, P), P;
   }
-  Dt.size >= kc && Dt.delete(Dt.keys().next().value);
-  const g = c * 2 + 2, v = c + 1, x = wc(g, g), S = x.getContext("2d"), M = f * c, b = c + 1, O = `rgba(${n},${r},${a},${o})`, j = `rgba(${n},${r},${a},0)`, z = S.createRadialGradient(v, v, M, v, v, b);
+  Dt.size >= Nc && Dt.delete(Dt.keys().next().value);
+  const g = c * 2 + 2, v = c + 1, x = kc(g, g), S = x.getContext("2d"), M = f * c, b = c + 1, O = `rgba(${n},${r},${a},${o})`, j = `rgba(${n},${r},${a},0)`, z = S.createRadialGradient(v, v, M, v, v, b);
   return z.addColorStop(0, O), z.addColorStop(1, j), S.fillStyle = z, S.fillRect(0, 0, g, g), Dt.set(h, x), x;
 }
-function I1(e, t, n, r, a, o, c) {
+function F1(e, t, n, r, a, o, c) {
   const { r: f, g: h, b: g, a: v } = r, x = Math.max(2, Math.ceil(e) * 2), S = Math.max(2, Math.ceil(t) * 2), M = Math.max(0, a), b = Math.max(0, Math.min(0.99, o)), O = Math.max(0, Math.min(1, c ?? 0)), j = `chisel:${x}:${S}:${n.toFixed(2)}:${f}:${h}:${g}:${v.toFixed(3)}:${M.toFixed(2)}:${b.toFixed(2)}:${O.toFixed(2)}`;
   if (Dt.has(j)) {
     const se = Dt.get(j);
     return Dt.delete(j), Dt.set(j, se), se;
   }
-  Dt.size >= kc && Dt.delete(Dt.keys().next().value);
-  const z = wc(x, S), P = z.getContext("2d"), $ = P.createImageData(x, S), I = $.data, R = Math.max(0, e - t), G = Math.max(0, Math.min(1, n)), H = 1 + M;
+  Dt.size >= Nc && Dt.delete(Dt.keys().next().value);
+  const z = kc(x, S), P = z.getContext("2d"), $ = P.createImageData(x, S), I = $.data, R = Math.max(0, e - t), G = Math.max(0, Math.min(1, n)), H = 1 + M;
   for (let se = 0; se < S; se++)
     for (let ie = 0; ie < x; ie++) {
       const T = ie + 0.5 - e, q = se + 0.5 - t, re = Math.max(Math.abs(T) - R, 0), de = Math.hypot(re, q) / t;
@@ -5278,52 +5278,52 @@ function ki(e) {
   let t = e + 1831565813 >>> 0;
   return t = Math.imul(t ^ t >>> 15, t | 1), t ^= t + Math.imul(t ^ t >>> 7, t | 61), ((t ^ t >>> 14) >>> 0) / 4294967296;
 }
-function E1(e, t, n, r, a, o, c) {
+function R1(e, t, n, r, a, o, c) {
   const f = e + 0.5 - n, h = t + 0.5 - r, g = Math.max(0, n - r), v = Math.max(Math.abs(f) - g, 0), x = Math.hypot(v, h) / r;
   if (x >= 1) return 0;
   const S = ki(ga(e * 17 + 3, t * 13 + 7)), M = x + o * 0.22 * (S - 0.5);
   if (M >= 1) return 0;
-  const b = M <= a ? 1 : Math.max(0, (1 - M) / Math.max(1e-4, 1 - a)), O = D1(e, t, f, h, n, r), j = o * 0.55;
+  const b = M <= a ? 1 : Math.max(0, (1 - M) / Math.max(1e-4, 1 - a)), O = L1(e, t, f, h, n, r), j = o * 0.55;
   if (O < j) return 0;
   const P = 0.45 + 0.55 * ((O - j) / Math.max(1e-4, 1 - j));
   return Math.round(255 * Math.min(1, c * b * P));
 }
-function D1(e, t, n, r, a, o) {
+function L1(e, t, n, r, a, o) {
   const c = Math.floor((n + a) / 3), f = Math.floor((r + o) / 2), h = ki(ga(c * 13 + 700, f * 17 + 400)), g = Math.floor((n + a) / 1.5), v = Math.floor((r + o) / 1.5), x = ki(ga(g * 23 + 800, v * 29 + 500)), S = ki(ga(e * 3 + 100, t * 5 + 200));
   return h * 0.55 + x * 0.3 + S * 0.15;
 }
-function O1(e, t, n, r, a) {
+function z1(e, t, n, r, a) {
   const { r: o, g: c, b: f, a: h } = r, g = Math.max(2, Math.ceil(e) * 2), v = Math.max(2, Math.ceil(t) * 2), x = Math.max(0, Math.min(1, a)), S = `crayon:${g}:${v}:${n.toFixed(2)}:${o}:${c}:${f}:${h.toFixed(3)}:${x.toFixed(2)}`;
   if (Dt.has(S)) {
     const P = Dt.get(S);
     return Dt.delete(S), Dt.set(S, P), P;
   }
-  Dt.size >= kc && Dt.delete(Dt.keys().next().value);
-  const M = wc(g, v), b = M.getContext("2d"), O = b.createImageData(g, v), j = O.data, z = Math.max(0, Math.min(1, n));
+  Dt.size >= Nc && Dt.delete(Dt.keys().next().value);
+  const M = kc(g, v), b = M.getContext("2d"), O = b.createImageData(g, v), j = O.data, z = Math.max(0, Math.min(1, n));
   for (let P = 0; P < v; P++)
     for (let $ = 0; $ < g; $++) {
-      const I = E1($, P, e, t, z, x, h);
+      const I = R1($, P, e, t, z, x, h);
       if (I <= 0) continue;
       const R = (P * g + $) * 4;
       j[R] = o, j[R + 1] = c, j[R + 2] = f, j[R + 3] = I;
     }
   return b.putImageData(O, 0, 0), Dt.set(S, M), M;
 }
-function tm(e, t, n) {
+function am(e, t, n) {
   var O, j;
-  const r = String((t == null ? void 0 : t.stampKind) || "round"), a = A1(t, n), o = Math.max(0, Math.min(1, Number((t == null ? void 0 : t.hardness) ?? 0.9))), c = F1(t), f = Math.max(0.1, Number((t == null ? void 0 : t.aspect) ?? 1)), h = Number(((O = t == null ? void 0 : t.angle) == null ? void 0 : O.value) ?? 0), g = C1(t, a), v = String(((j = t == null ? void 0 : t.targetSpace) == null ? void 0 : j.viewMode) || ""), x = (n == null ? void 0 : n.kind) === "ERP_GLOBAL" && v !== "unwrap", S = t == null ? void 0 : t.scatter, M = S ? { radius: Number(S.radius ?? 1.5), count: Math.max(1, Math.round(S.count ?? 6)) } : null;
+  const r = String((t == null ? void 0 : t.stampKind) || "round"), a = E1(t, n), o = Math.max(0, Math.min(1, Number((t == null ? void 0 : t.hardness) ?? 0.9))), c = $1(t), f = Math.max(0.1, Number((t == null ? void 0 : t.aspect) ?? 1)), h = Number(((O = t == null ? void 0 : t.angle) == null ? void 0 : O.value) ?? 0), g = D1(t, a), v = String(((j = t == null ? void 0 : t.targetSpace) == null ? void 0 : j.viewMode) || ""), x = (n == null ? void 0 : n.kind) === "ERP_GLOBAL" && v !== "unwrap", S = t == null ? void 0 : t.scatter, M = S ? { radius: Number(S.radius ?? 1.5), count: Math.max(1, Math.round(S.count ?? 6)) } : null;
   let b;
   if (r === "chisel") {
     const z = a * f, P = a, $ = Math.max(0, Number((t == null ? void 0 : t.chiselEdgeLift) ?? 0.4)), I = Math.max(0, Number((t == null ? void 0 : t.chiselCenterDip) ?? 0.3)), R = Math.max(0, Math.min(1, Number((t == null ? void 0 : t.chiselFiber) ?? 0)));
-    b = I1(z, P, o, c, $, I, R);
+    b = F1(z, P, o, c, $, I, R);
   } else if (r === "crayon") {
     const z = a * f, P = a, $ = Math.max(0, Math.min(1, Number((t == null ? void 0 : t.crayonGrain) ?? 0.65)));
-    b = O1(z, P, o, c, $);
+    b = z1(z, P, o, c, $);
   } else
-    b = T1(a, o, c.r, c.g, c.b, c.a);
+    b = O1(a, o, c.r, c.g, c.b, c.a);
   return { ctx: e, stampTex: b, radiusPx: a, spacingPx: g, desc: n, aspect: f, angle: h, stampKind: r, scatter: M, latitudeCorrection: x };
 }
-function F1(e) {
+function $1(e) {
   const t = String((e == null ? void 0 : e.layerKind) || "paint");
   if (String((e == null ? void 0 : e.toolKind) || "pen") === "eraser" || t === "mask")
     return { r: 255, g: 255, b: 255, a: 1 };
@@ -5335,13 +5335,13 @@ function F1(e) {
     a: o
   };
 }
-function R1(e) {
+function j1(e) {
   const t = String((e == null ? void 0 : e.layerKind) || "paint");
   if (String((e == null ? void 0 : e.toolKind) || "pen") === "eraser" || t === "mask") return "rgba(255,255,255,1)";
   const r = (e == null ? void 0 : e.color) || { r: 1, g: 0.25, b: 0.25, a: 1 }, a = Math.max(0, Math.min(1, Number(r.a ?? 1)));
   return `rgba(${Math.round(Number(r.r || 0) * 255)},${Math.round(Number(r.g || 0) * 255)},${Math.round(Number(r.b || 0) * 255)},${a})`;
 }
-function qd(e, t, n, r, a) {
+function Xd(e, t, n, r, a) {
   const o = e.angle, c = e.desc.width;
   function f(g, v) {
     o === 0 ? e.ctx.drawImage(e.stampTex, g - a, v - r, a * 2, r * 2) : (e.ctx.save(), e.ctx.translate(g, v), e.ctx.rotate(o), e.ctx.drawImage(e.stampTex, -a, -r, a * 2, r * 2), e.ctx.restore());
@@ -5350,23 +5350,23 @@ function qd(e, t, n, r, a) {
   const h = o === 0 ? a : a * Math.abs(Math.cos(o)) + r * Math.abs(Math.sin(o));
   t - h < 0 && f(t + c, n), t + h > c && f(t - c, n);
 }
-function Nc(e, t, n, r) {
+function Mc(e, t, n, r) {
   const a = Math.max(0.01, Number.isFinite(r) ? r : 1);
   if (e.scatter) {
     const { radius: g, count: v } = e.scatter, x = g * e.radiusPx * a, S = ga(t, n);
     for (let M = 0; M < v; M++) {
       const b = ki(S + M * 2) * Math.PI * 2, O = Math.sqrt(ki(S + M * 2 + 1)) * x, j = t + Math.cos(b) * O, z = n + Math.sin(b) * O, P = Math.max(0.5, e.radiusPx * a * 0.48), $ = (0.5 - z / Math.max(1, e.desc.height)) * Math.PI, I = e.latitudeCorrection ? 1 / Math.max(0.05, Math.cos($)) : 1, R = P * e.aspect * I;
-      qd(e, j, z, P, R);
+      Xd(e, j, z, P, R);
     }
     return;
   }
   const o = Math.max(0.5, e.radiusPx * a), c = (0.5 - n / Math.max(1, e.desc.height)) * Math.PI, f = e.latitudeCorrection ? 1 / Math.max(0.05, Math.cos(c)) : 1, h = o * e.aspect * f;
-  qd(e, t, n, o, h);
+  Xd(e, t, n, o, h);
 }
-function Xd(e, t, n) {
-  const r = P1(t);
+function Jd(e, t, n) {
+  const r = I1(t);
   if (!e || r.length === 0) return;
-  const a = n.width, o = n.height, c = tm(e, t, n);
+  const a = n.width, o = n.height, c = am(e, t, n);
   e.save(), e.globalCompositeOperation = "source-over";
   const f = [];
   for (let S = 0; S < r.length; S++) {
@@ -5374,7 +5374,7 @@ function Xd(e, t, n) {
     const b = Number(r[S].v || 0) * o;
     S > 0 && Math.abs(M - f[S - 1].x) > a * 0.5 && (M += M < f[S - 1].x ? a : -a), f.push({ x: M, y: b });
   }
-  if (Nc(c, f[0].x, f[0].y, 1), f.length === 1) {
+  if (Mc(c, f[0].x, f[0].y, 1), f.length === 1) {
     e.restore();
     return;
   }
@@ -5389,10 +5389,10 @@ function ws(e, t, n) {
   var x;
   const r = Array.isArray((x = t == null ? void 0 : t.geometry) == null ? void 0 : x.points) ? t.geometry.points : [];
   if (!e || r.length < 3) return;
-  const a = n.width, o = n.height, c = R1(t), f = [];
+  const a = n.width, o = n.height, c = j1(t), f = [];
   let h = 1 / 0, g = -1 / 0;
   for (let S = 0; S < r.length; S++) {
-    const M = M1(r[S]);
+    const M = T1(r[S]);
     let b = Number(M.x || 0) * a;
     S > 0 && Math.abs(b - f[S - 1].x) > a * 0.5 && (b += b < f[S - 1].x ? a : -a), f.push({ x: b, y: Number(M.y || 0) * o }), b < h && (h = b), b > g && (g = b);
   }
@@ -5410,7 +5410,7 @@ function Zo(e, t, n) {
     return;
   }
   const o = String((t == null ? void 0 : t.toolKind) || "") === "eraser" ? 1 : Math.max(0, Math.min(1, Number((t == null ? void 0 : t.opacity) ?? 1)));
-  o >= 0.999 ? Xd(e, t, n) : (Va = Rr(Va, n.width, n.height), Et(Va), Xd(Va.ctx, t, n), e.save(), e.globalAlpha = o, e.drawImage(Va.canvas, 0, 0), e.restore());
+  o >= 0.999 ? Jd(e, t, n) : (Va = Rr(Va, n.width, n.height), Et(Va), Jd(Va.ctx, t, n), e.save(), e.globalAlpha = o, e.drawImage(Va.canvas, 0, 0), e.restore());
 }
 function mi(e, t) {
   e.save(), e.globalCompositeOperation = "destination-out", e.drawImage(t, 0, 0), e.restore();
@@ -5421,7 +5421,7 @@ function po(e, t, n, r, a, o) {
   let g = e.spacingPx - o;
   for (; g <= h; ) {
     const v = g / h;
-    Nc(e, t + c * v, n + f * v, 1), g += e.spacingPx;
+    Mc(e, t + c * v, n + f * v, 1), g += e.spacingPx;
   }
   return h - g + e.spacingPx;
 }
@@ -5434,14 +5434,14 @@ function Vs(e, t, n, r, a, o) {
   }
   return j;
 }
-function L1(e, t, n, r) {
+function V1(e, t, n, r) {
   const a = e.currentStroke.ctx;
   if (!a) return;
   const o = e.descriptor, c = o.width, f = n * o.height, h = e.activeStroke;
   let g = t * c;
   if (h && Math.abs(g - h.prev.x) > c * 0.5 && (g += g < h.prev.x ? c : -c), !h) {
-    const M = tm(a, r, o), b = Math.max(0, Math.min(1, Number((r == null ? void 0 : r.opacity) ?? 1))), O = Math.max(0, Number((r == null ? void 0 : r.velocityWidthFactor) ?? 0)), j = String((r == null ? void 0 : r.toolKind) || "") === "eraser", z = String((r == null ? void 0 : r.layerKind) || "paint");
-    a.globalCompositeOperation = "source-over", Nc(M, g, f, 1), e.activeStroke = {
+    const M = am(a, r, o), b = Math.max(0, Math.min(1, Number((r == null ? void 0 : r.opacity) ?? 1))), O = Math.max(0, Number((r == null ? void 0 : r.velocityWidthFactor) ?? 0)), j = String((r == null ? void 0 : r.toolKind) || "") === "eraser", z = String((r == null ? void 0 : r.layerKind) || "paint");
+    a.globalCompositeOperation = "source-over", Mc(M, g, f, 1), e.activeStroke = {
       pprev: { x: g, y: f },
       prev: { x: g, y: f },
       lastMidX: g,
@@ -5624,7 +5624,7 @@ function Ru(e = {}) {
       const Ae = Math.max(0, Math.min(1, (ce == null ? void 0 : ce.strokeOpacity) ?? 1));
       A.ctx.save(), A.ctx.globalAlpha = Ae, A.ctx.drawImage(de.currentStroke.canvas, 0, 0), A.ctx.restore();
     }
-    k1() && (String((T == null ? void 0 : T.toolKind) || ""), String((we == null ? void 0 : we.kind) || ""), Number((we == null ? void 0 : we.width) || 0), Number((we == null ? void 0 : we.height) || 0), String(((xe = T == null ? void 0 : T.targetSpace) == null ? void 0 : xe.viewMode) || ""), Number((T == null ? void 0 : T.aspect) ?? 1), Kd(de.currentStroke.canvas), Kd(A.canvas), void 0), Et(de.currentStroke), de.activeStroke = null, de.displayDirty = !0, g = null, v = "", O([...a.keys()]);
+    A1() && (String((T == null ? void 0 : T.toolKind) || ""), String((we == null ? void 0 : we.kind) || ""), Number((we == null ? void 0 : we.width) || 0), Number((we == null ? void 0 : we.height) || 0), String(((xe = T == null ? void 0 : T.targetSpace) == null ? void 0 : xe.viewMode) || ""), Number((T == null ? void 0 : T.aspect) ?? 1), Wd(de.currentStroke.canvas), Wd(A.canvas), void 0), Et(de.currentStroke), de.activeStroke = null, de.displayDirty = !0, g = null, v = "", O([...a.keys()]);
   }
   function $(T) {
     if (v === "mask")
@@ -5681,7 +5681,7 @@ function Ru(e = {}) {
   return {
     rebuildCommitted: j,
     beginStroke: z,
-    appendStrokePoint: L1,
+    appendStrokePoint: V1,
     updateActiveStroke: I,
     commitActiveStroke: P,
     cancelActiveStroke: $,
@@ -5703,7 +5703,7 @@ function du(e, t, n) {
 function Ut(e) {
   return ((e + 180) % 360 + 360) % 360 - 180;
 }
-function z1(e, t) {
+function H1(e, t) {
   let n = Ut(t) - Ut(e);
   return n > 180 && (n -= 360), n < -180 && (n += 360), n;
 }
@@ -5712,7 +5712,7 @@ function Ha(e) {
   const t = Number(e);
   return Number.isFinite(t) ? t : null;
 }
-function Mc(e, t = 0) {
+function Pc(e, t = 0) {
   const n = Ha(e == null ? void 0 : e.deltaY);
   if (n != null) return Math.sign(n);
   const r = Ha(e == null ? void 0 : e.wheelDeltaY);
@@ -5722,7 +5722,7 @@ function Mc(e, t = 0) {
   const o = Ha(e == null ? void 0 : e.detail);
   return o != null ? Math.sign(o) : Math.sign(Ha(t) || 0);
 }
-function nm(e) {
+function om(e) {
   if (!(e != null && e.addEventListener)) return () => {
   };
   const t = () => {
@@ -5734,12 +5734,12 @@ function nm(e) {
     return (n = e.removeEventListener) == null ? void 0 : n.call(e, "pointerenter", t);
   };
 }
-const Jd = Math.PI / 180, Zd = 0.12, $1 = Lu, j1 = 35, V1 = 140, Ja = 100, H1 = 20, Qd = 0.8;
-function U1(e, t, n) {
-  const r = Math.max(1, Number(t || 1)), a = Math.max(1, Number(n || 1)), o = W(Number(e || Ja), 1, 179) * Jd;
-  return 2 * Math.atan(Math.tan(o * 0.5) * (a / r)) / Jd;
+const Zd = Math.PI / 180, Qd = 0.12, U1 = Lu, B1 = 35, G1 = 140, Ja = 100, K1 = 20, eh = 0.8;
+function W1(e, t, n) {
+  const r = Math.max(1, Number(t || 1)), a = Math.max(1, Number(n || 1)), o = W(Number(e || Ja), 1, 179) * Zd;
+  return 2 * Math.atan(Math.tan(o * 0.5) * (a / r)) / Zd;
 }
-function Pc(e = {}) {
+function Ac(e = {}) {
   const t = typeof e.getView == "function" ? e.getView : (() => ({ yaw: 0, pitch: 0, fov: Ja })), n = typeof e.setView == "function" ? e.setView : (() => {
   }), r = typeof e.getInvert == "function" ? e.getInvert : (() => ({ x: 1, y: 1 })), a = typeof e.getUnwrapRect == "function" ? e.getUnwrapRect : (() => ({ w: 1, h: 1 })), o = typeof e.getViewportSize == "function" ? e.getViewportSize : (() => ({ w: 0, h: 0 })), c = typeof e.onInteraction == "function" ? e.onInteraction : (() => {
   }), f = typeof e.onDebug == "function" ? e.onDebug : null, h = {
@@ -5766,10 +5766,10 @@ function Pc(e = {}) {
     } else {
       const xe = o() || { w: 0, h: 0 }, Ae = Math.max(1, Number(xe.w || 0)), Ne = Math.max(1, Number(xe.h || 0));
       if (Ae > 1 && Ne > 1) {
-        const U = W(Number(de.fov || Ja), 1, 179), je = W(U1(U, Ae, Ne), 0.1, 179);
+        const U = W(Number(de.fov || Ja), 1, 179), je = W(W1(U, Ae, Ne), 0.1, 179);
         ce = -(ie / Ae) * U * re, we = T / Ne * je * J;
       } else
-        ce = -ie * Zd * re, we = T * Zd * J;
+        ce = -ie * Qd * re, we = T * Qd * J;
     }
     de.yaw = Ut(Number(de.yaw || 0) + ce), de.pitch = W(Number(de.pitch || 0) + we, -89.9, 89.9), n(de), h.velHistory.push({ ts: G, yaw: de.yaw, pitch: de.pitch });
     let A = 0;
@@ -5790,7 +5790,7 @@ function Pc(e = {}) {
       h.inertia.vx = 0, h.inertia.vy = 0;
     h.velHistory = [];
     const R = Math.hypot(h.inertia.vx, h.inertia.vy);
-    return h.inertia.active = R > H1, h.inertia.lastTs = $, g("drag", { phase: "end", speed: R, inertiaActive: h.inertia.active }), !0;
+    return h.inertia.active = R > K1, h.inertia.lastTs = $, g("drag", { phase: "end", speed: R, inertiaActive: h.inertia.active }), !0;
   }
   function M(P = performance.now()) {
     if (!h.inertia.active) return !1;
@@ -5799,7 +5799,7 @@ function Pc(e = {}) {
     const R = { ...t() };
     R.yaw = Ut(Number(R.yaw || 0) + h.inertia.vx * I), R.pitch = W(Number(R.pitch || 0) + h.inertia.vy * I, -89.9, 89.9);
     const G = Math.exp(-5.5 * I);
-    return h.inertia.vx *= G, h.inertia.vy *= G, Math.abs(h.inertia.vx) < Qd && Math.abs(h.inertia.vy) < Qd && (h.inertia.vx = 0, h.inertia.vy = 0, h.inertia.active = !1), n(R), c(), h.inertia.active;
+    return h.inertia.vx *= G, h.inertia.vy *= G, Math.abs(h.inertia.vx) < eh && Math.abs(h.inertia.vy) < eh && (h.inertia.vx = 0, h.inertia.vy = 0, h.inertia.active = !1), n(R), c(), h.inertia.active;
   }
   function b() {
     const P = h.drag.active || h.inertia.active || h.inertia.vx !== 0 || h.inertia.vy !== 0;
@@ -5809,10 +5809,10 @@ function Pc(e = {}) {
     const $ = Math.sign(Number(P || 0));
     if (!$) return !1;
     const I = { ...t() }, R = Number(I.fov || Ja);
-    return I.fov = W(R + $ * $1, j1, V1), n(I), c(), g("wheel", { deltaSign: $, fovBefore: R, fovAfter: I.fov }), !0;
+    return I.fov = W(R + $ * U1, B1, G1), n(I), c(), g("wheel", { deltaSign: $, fovBefore: R, fovAfter: I.fov }), !0;
   }
   function j(P, $ = 0) {
-    return O(Mc(P, $));
+    return O(Pc(P, $));
   }
   function z() {
     n({ yaw: 0, pitch: 0, fov: Ja }), h.inertia.active = !1, h.inertia.vx = 0, h.inertia.vy = 0, c();
@@ -5833,13 +5833,13 @@ function Hs(e) {
   const t = String(e || "").trim();
   return t ? t === "PanoramaPreview" || t === "Panorama Preview" ? !0 : /^panorama[\s_]*preview(?:\s*\(node\s*2\.0\)|_legacy)?$/i.test(t) : !1;
 }
-const eh = Math.PI / 180;
+const th = Math.PI / 180;
 function Ua(e, t = 0) {
   const n = Number(e);
   return Number.isFinite(n) ? n : Number(t);
 }
-function B1(e) {
-  const t = e || {}, n = Ua(t.yaw_deg, 0), r = Ua(t.pitch_deg, 0), a = Ua(t.roll_deg ?? t.rot_deg, 0), o = du(Ua(t.hFOV_deg, 90), 1, 179), c = du(Ua(t.vFOV_deg, 60), 1, 179), f = Math.tan(o * eh * 0.5) / Math.max(1e-6, Math.tan(c * eh * 0.5)), h = du(f, 0.1, 10);
+function Y1(e) {
+  const t = e || {}, n = Ua(t.yaw_deg, 0), r = Ua(t.pitch_deg, 0), a = Ua(t.roll_deg ?? t.rot_deg, 0), o = du(Ua(t.hFOV_deg, 90), 1, 179), c = du(Ua(t.vFOV_deg, 60), 1, 179), f = Math.tan(o * th * 0.5) / Math.max(1e-6, Math.tan(c * th * 0.5)), h = du(f, 0.1, 10);
   return {
     yaw: n,
     pitch: r,
@@ -5849,8 +5849,8 @@ function B1(e) {
     aspect: h
   };
 }
-const rm = 0.28;
-function G1(e) {
+const sm = 0.28;
+function q1(e) {
   const t = e && typeof e == "object" ? e : {}, n = W(Number(t.x0 ?? 0), 0, 1), r = W(Number(t.y0 ?? 0), 0, 1), a = W(Number(t.x1 ?? 1), 0, 1), o = W(Number(t.y1 ?? 1), 0, 1);
   return {
     x0: Math.min(n, a),
@@ -5859,7 +5859,7 @@ function G1(e) {
     y1: Math.max(r, o)
   };
 }
-function K1(e, t = {}) {
+function X1(e, t = {}) {
   if (!e || typeof e != "object") return null;
   const n = String(e.asset_id || e.assetId || "").trim(), r = e.type === "external_image" || e.source_kind === "external_image", a = n || (r ? String(e.id || "").trim() : ""), o = t.includeHidden === !0, c = e.visible === !1, f = o && r && c;
   return {
@@ -5871,8 +5871,8 @@ function K1(e, t = {}) {
     rollDeg: Number(e.rot_deg ?? e.roll_deg ?? e.rollDeg ?? 0),
     hFovDeg: W(Number(e.hFOV_deg || e.hFovDeg || 30), 1, 179),
     vFovDeg: W(Number(e.vFOV_deg || e.vFovDeg || 30), 1, 179),
-    crop: G1(e.crop),
-    opacity: f ? rm : W(Number(e.opacity ?? 1), 0, 1),
+    crop: q1(e.crop),
+    opacity: f ? sm : W(Number(e.opacity ?? 1), 0, 1),
     visible: f ? !0 : e.visible !== !1,
     external: r
   };
@@ -5881,12 +5881,12 @@ function fl(e, t = {}) {
   var o;
   const n = Array.isArray(t.stickers) ? t.stickers : Array.isArray(e == null ? void 0 : e.stickers) ? e.stickers : [], r = t.includeHidden === !0;
   return {
-    stickers: n.map((c) => K1(c, { includeHidden: r })).filter((c) => c && (r || c.visible !== !1)).sort((c, f) => Number(c.zIndex || 0) - Number(f.zIndex || 0)),
+    stickers: n.map((c) => X1(c, { includeHidden: r })).filter((c) => c && (r || c.visible !== !1)).sort((c, f) => Number(c.zIndex || 0) - Number(f.zIndex || 0)),
     selectedId: t.selectedId ?? ((o = e == null ? void 0 : e.active) == null ? void 0 : o.selected_sticker_id) ?? null,
     hoveredId: t.hoveredId ?? null
   };
 }
-function im(e, t, n = {}) {
+function lm(e, t, n = {}) {
   if (typeof t != "function") return [];
   const r = n.scene || fl(e, n), a = e && typeof e == "object" && e.assets && typeof e.assets == "object" ? e.assets : {}, o = [], c = /* @__PURE__ */ new Set();
   return r.stickers.forEach((f) => {
@@ -5917,11 +5917,11 @@ function mo(e, t = 360) {
     coverageDeg: Number(t || 360) === 180 ? 180 : 360
   };
 }
-function W1(e, t = 360) {
+function J1(e, t = 360) {
   return mo(e, t);
 }
 function vr(e) {
-  const t = B1(e || {});
+  const t = Y1(e || {});
   return {
     mode: "cutout",
     yawDeg: Number((e == null ? void 0 : e.yaw_deg) || 0),
@@ -5956,12 +5956,12 @@ function Hr(e) {
   const t = Math.hypot(e.x, e.y, e.z) || 1e-8;
   return Yr(e.x / t, e.y / t, e.z / t);
 }
-function am(e, t) {
+function um(e, t) {
   const n = e * _n, r = t * _n, a = Math.cos(r);
   return Yr(a * Math.sin(n), Math.sin(r), a * Math.cos(n));
 }
 function No(e, t, n = 0) {
-  const r = am(e, t), a = Yr(0, 1, 0);
+  const r = um(e, t), a = Yr(0, 1, 0);
   let o = Us(a, r);
   Math.hypot(o.x, o.y, o.z) < 1e-6 && (o = Yr(1, 0, 0)), o = Hr(o);
   const c = Hr(Us(r, o)), f = n * _n, h = Math.cos(f), g = Math.sin(f), v = si(_r(o, h), _r(c, g)), x = si(_r(o, -g), _r(c, h));
@@ -5972,13 +5972,13 @@ function dl(e) {
   const t = ((Qe(e, 0) + 180) % 360 + 360) % 360 - 180;
   return t <= -180 ? 180 : t;
 }
-function om(e, t) {
+function cm(e, t) {
   let n = Qe(e, 0) - Qe(t, 0);
   for (; n <= -Math.PI; ) n += Math.PI * 2;
   for (; n > Math.PI; ) n -= Math.PI * 2;
   return n;
 }
-function sm(e, t, { shiftKey: n = !1 } = {}) {
+function fm(e, t, { shiftKey: n = !1 } = {}) {
   let r = Qe(e, 0) + Qe(t, 0) * Wr;
   return n && (r = Math.round(r / 15) * 15), dl(r);
 }
@@ -6006,15 +6006,15 @@ function Mi(e, t) {
     r / (2 * a.tanHalfY)
   ));
 }
-function Ac(e, t) {
+function Cc(e, t) {
   const n = Math.max(1, Qe((e == null ? void 0 : e.w) ?? (e == null ? void 0 : e.width), 1)), r = Math.max(1, Qe((e == null ? void 0 : e.h) ?? (e == null ? void 0 : e.height), 1)), a = Math.max(1e-6, Qe(t, 1)), o = Math.min(n, r * a);
   return { width: o, height: o / a };
 }
-function Cc(e, t) {
+function Tc(e, t) {
   const n = Math.max(1e-12, Qe(t, 1)), r = Math.max(1e-6, Qe((e == null ? void 0 : e.width) ?? (e == null ? void 0 : e.w), 1)), a = Math.max(1e-6, Qe((e == null ? void 0 : e.height) ?? (e == null ? void 0 : e.h), 1)), o = W(2 * Math.atan(r / (2 * n)) * Wr, Mr, Pr), c = W(2 * Math.atan(a / (2 * n)) * Wr, Mr, Pr);
   return { hFOV_deg: o, vFOV_deg: c };
 }
-function Y1(e, t, n) {
+function Z1(e, t, n) {
   const r = Qe(e == null ? void 0 : e.x, 0), a = Qe(e == null ? void 0 : e.y, 0), o = Math.max(1, Qe((e == null ? void 0 : e.w) ?? (e == null ? void 0 : e.width), 1)), c = Math.max(1, Qe((e == null ? void 0 : e.h) ?? (e == null ? void 0 : e.height), 1)), f = Na(t), h = Math.max(1e-12, Qe(n, 1)), g = 2 * h * f.tanHalfX, v = 2 * h * f.tanHalfY;
   return {
     x: r + (o - g) * 0.5,
@@ -6031,7 +6031,7 @@ function $u(e, t, n = zu) {
     halfH: Math.min(f * 0.5, o)
   };
 }
-function lm(e, t, n) {
+function dm(e, t, n) {
   const r = Math.max(1e-12, Qe(t, 1));
   return {
     x: (Qe(n == null ? void 0 : n.x, 0) - Qe(e == null ? void 0 : e.x, 0)) / r,
@@ -6046,12 +6046,12 @@ function ks(e, t) {
     Pr
   );
 }
-function th(e, t = 0) {
+function nh(e, t = 0) {
   const n = Number(e);
   return Number.isFinite(n) && n > 0 ? n : Number(t);
 }
-function q1(e, t) {
-  const n = th(e, 1), r = th(t, 1);
+function Q1(e, t) {
+  const n = nh(e, 1), r = nh(t, 1);
   if (n <= 0 || r <= 0) return "1:1";
   const a = 1e3, o = Math.max(1, Math.round(n * a)), c = Math.max(1, Math.round(r * a)), f = (g, v) => v ? f(v, g % v) : g, h = f(o, c) || 1;
   return `${Math.max(1, Math.round(o / h))}:${Math.max(1, Math.round(c / h))}`;
@@ -6070,14 +6070,14 @@ function vi(e) {
     ["2:3", 2 / 3],
     ["3:4", 3 / 4]
   ].find(([, a]) => Math.abs(t - a) <= 0.015);
-  return (r == null ? void 0 : r[0]) || q1(t, 1);
+  return (r == null ? void 0 : r[0]) || Q1(t, 1);
 }
-function um(e) {
+function hm(e) {
   if (!e || typeof e != "object") return e;
   const t = { ...e, locked: e.locked === !0 };
   return delete t.out_w, delete t.out_h, t.aspect_id = vi(t), t;
 }
-function cm({
+function pm({
   id: e = "",
   yawDeg: t = 0,
   pitchDeg: n = 0,
@@ -6086,7 +6086,7 @@ function cm({
   frameFovDeg: o = null
 } = {}) {
   const c = o == null || String(o).trim() === "" ? NaN : Number(o), f = Number.isFinite(c) ? W(c, Mr, Pr) : W(Math.min(42, Qe(a, 100) * 0.42), 8, 96);
-  return um({
+  return hm({
     id: String(e),
     label: "Frame 1",
     yaw_deg: Qe(t, 0),
@@ -6102,25 +6102,25 @@ function Lr(e) {
   const t = String(e.aspect_id || "").trim();
   return /^\d+:\d+$/.test(t) ? t : vi(e);
 }
-function fm(e, t) {
+function mm(e, t) {
   const n = Na(e), r = Qe(t, 1);
   if (!(r > 0)) return null;
   const a = 2 * Math.atan(n.tanHalfX * r) * Wr, o = 2 * Math.atan(n.tanHalfY * r) * Wr;
   return a < Mr || a > Pr || o < Mr || o > Pr ? null : { hFOV_deg: a, vFOV_deg: o };
 }
-function dm(e, t, n = Lu) {
+function gm(e, t, n = Lu) {
   const r = Math.sign(Qe(t, 0)), a = Math.abs(Qe(n, Lu));
   if (!r || !(a > 0)) return null;
   const o = Na(e), c = o.hFovDeg + r * a;
   if (c < Mr || c > Pr) return null;
   const f = Math.tan(c * _n * 0.5);
-  return fm(e, f / o.tanHalfX);
+  return mm(e, f / o.tanHalfX);
 }
-function hm(e, t) {
+function bm(e, t) {
   const n = Na(e), r = No(n.yawDeg, n.pitchDeg, n.rollDeg), a = Qe(t == null ? void 0 : t.x, 0), o = Qe(t == null ? void 0 : t.y, 0);
   return Hr(si(si(r.fwd, _r(r.right, a)), _r(r.up, o)));
 }
-function pm({
+function ym({
   readState: e,
   reduce: t,
   projectModel: n,
@@ -6173,30 +6173,30 @@ function pm({
     }
   };
 }
-const Bs = Math.PI / 180, xr = 180 / Math.PI, X1 = Object.freeze({
+const Bs = Math.PI / 180, xr = 180 / Math.PI, e_ = Object.freeze({
   top: 58,
   right: 32,
   bottom: 32,
   left: 32
-}), J1 = 260;
-function nh(e) {
+}), t_ = 260;
+function rh(e) {
   const t = String(e ?? "").trim();
   if (!t) return null;
   const n = Number(t);
   return Number.isFinite(n) && n > 0 ? n : null;
 }
-function mm(e, t) {
-  return t ? mm(t, e % t) : e;
+function vm(e, t) {
+  return t ? vm(t, e % t) : e;
 }
-function Z1(e, t) {
-  const r = Math.max(e, t) <= Number.MAX_SAFE_INTEGER / 1e3, a = r ? 1e3 : 1e6, o = r ? 1 : Math.max(e, t), c = Math.max(1, Math.round(e / o * a)), f = Math.max(1, Math.round(t / o * a)), h = mm(c, f) || 1;
+function n_(e, t) {
+  const r = Math.max(e, t) <= Number.MAX_SAFE_INTEGER / 1e3, a = r ? 1e3 : 1e6, o = r ? 1 : Math.max(e, t), c = Math.max(1, Math.round(e / o * a)), f = Math.max(1, Math.round(t / o * a)), h = vm(c, f) || 1;
   return `${Math.round(c / h)}:${Math.round(f / h)}`;
 }
 function go(e, t) {
-  const n = nh(e), r = nh(t);
+  const n = rh(e), r = rh(t);
   if (n == null || r == null) return null;
   const a = n / r;
-  return !Number.isFinite(a) || a <= 0 ? null : { width: n, height: r, ratio: a, label: Z1(n, r) };
+  return !Number.isFinite(a) || a <= 0 ? null : { width: n, height: r, ratio: a, label: n_(n, r) };
 }
 function Ai(e) {
   var r;
@@ -6205,7 +6205,7 @@ function Ai(e) {
   const n = String(((r = e == null ? void 0 : e.active) == null ? void 0 : r.selected_shot_id) || "");
   return t.find((a) => String((a == null ? void 0 : a.id) || "") === n) || t[0] || null;
 }
-function gm(e) {
+function _m(e) {
   const t = Ai(e), n = Number((t == null ? void 0 : t.roll_deg) ?? (t == null ? void 0 : t.rot_deg) ?? 0), r = Math.abs(n) < 0.05 ? 0 : n;
   return {
     hasShot: !!t,
@@ -6216,7 +6216,7 @@ function gm(e) {
     rollLabel: `${r.toFixed(1)}°`
   };
 }
-function Tc(e, t, n = X1) {
+function Ic(e, t, n = e_) {
   const r = Math.max(1, Number((e == null ? void 0 : e.width) ?? (e == null ? void 0 : e.w) ?? 1)), a = Math.max(1, Number((e == null ? void 0 : e.height) ?? (e == null ? void 0 : e.h) ?? 1)), o = Math.max(0, Number((n == null ? void 0 : n.top) || 0)), c = Math.max(0, Number((n == null ? void 0 : n.right) || 0)), f = Math.max(0, Number((n == null ? void 0 : n.bottom) || 0)), h = Math.max(0, Number((n == null ? void 0 : n.left) || 0)), g = (j, z, P) => {
     const $ = j + z, I = Math.max(0, P - 1), R = $ > I && $ > 0 ? I / $ : 1;
     return [j * R, z * R];
@@ -6225,7 +6225,7 @@ function Tc(e, t, n = X1) {
     y: S,
     w: Math.max(1, r - v - x),
     h: Math.max(1, a - S - M)
-  }, O = Ac(b, t);
+  }, O = Cc(b, t);
   return {
     x: b.x + (b.w - O.width) * 0.5,
     y: b.y + (b.h - O.height) * 0.5,
@@ -6234,20 +6234,20 @@ function Tc(e, t, n = X1) {
     safeRect: b
   };
 }
-function Q1(e = {}, t = {}) {
-  const n = Math.max(1, Number((t == null ? void 0 : t.width) ?? (t == null ? void 0 : t.w) ?? 1)), r = Math.max(1, Number((t == null ? void 0 : t.height) ?? (t == null ? void 0 : t.h) ?? 1)), a = Tc({ width: n, height: r }, 1), o = W(Number((e == null ? void 0 : e.fov) || 100), 1, 179), c = n / (2 * Math.tan(o * Bs * 0.5)), f = { x: a.x + a.w * 0.5, y: a.y + a.h * 0.5 }, h = {
+function r_(e = {}, t = {}) {
+  const n = Math.max(1, Number((t == null ? void 0 : t.width) ?? (t == null ? void 0 : t.w) ?? 1)), r = Math.max(1, Number((t == null ? void 0 : t.height) ?? (t == null ? void 0 : t.h) ?? 1)), a = Ic({ width: n, height: r }, 1), o = W(Number((e == null ? void 0 : e.fov) || 100), 1, 179), c = n / (2 * Math.tan(o * Bs * 0.5)), f = { x: a.x + a.w * 0.5, y: a.y + a.h * 0.5 }, h = {
     yaw_deg: Number((e == null ? void 0 : e.yaw) || 0),
     pitch_deg: Number((e == null ? void 0 : e.pitch) || 0),
     roll_deg: 0
-  }, g = hm(h, lm(
+  }, g = bm(h, dm(
     { x: n * 0.5, y: r * 0.5 },
     c,
     f
-  )), v = e_(g, No(
+  )), v = i_(g, No(
     h.yaw_deg,
     h.pitch_deg,
     h.roll_deg
-  ).right), x = Cc({ width: a.w, height: a.h }, c);
+  ).right), x = Tc({ width: a.w, height: a.h }, c);
   return {
     type: "add-frame",
     yawDeg: v.yaw,
@@ -6256,14 +6256,14 @@ function Q1(e = {}, t = {}) {
     frameFovDeg: x.hFOV_deg
   };
 }
-function bm(e) {
+function xm(e) {
   return {
     yaw: Ut(Math.atan2(Number((e == null ? void 0 : e.x) || 0), Number((e == null ? void 0 : e.z) || 0)) * xr),
     pitch: W(Math.asin(W(Number((e == null ? void 0 : e.y) || 0), -1, 1)) * xr, -89.9, 89.9)
   };
 }
-function e_(e, t) {
-  const n = bm(e), r = No(n.yaw, n.pitch, 0), a = Ni(t, e), o = {
+function i_(e, t) {
+  const n = xm(e), r = No(n.yaw, n.pitch, 0), a = Ni(t, e), o = {
     x: Number((t == null ? void 0 : t.x) || 0) - Number((e == null ? void 0 : e.x) || 0) * a,
     y: Number((t == null ? void 0 : t.y) || 0) - Number((e == null ? void 0 : e.y) || 0) * a,
     z: Number((t == null ? void 0 : t.z) || 0) - Number((e == null ? void 0 : e.z) || 0) * a
@@ -6282,19 +6282,19 @@ function e_(e, t) {
     ) * xr)
   };
 }
-function ym(e, t = {}) {
-  const n = Math.max(1, Number((t == null ? void 0 : t.width) ?? (t == null ? void 0 : t.w) ?? 1)), r = Math.max(1, Number((t == null ? void 0 : t.height) ?? (t == null ? void 0 : t.h) ?? 1)), a = Tc({ width: n, height: r }, Pi(e)), o = Mi(a, e), c = { x: a.x + a.w * 0.5, y: a.y + a.h * 0.5 }, f = hm(e, lm(
+function Sm(e, t = {}) {
+  const n = Math.max(1, Number((t == null ? void 0 : t.width) ?? (t == null ? void 0 : t.w) ?? 1)), r = Math.max(1, Number((t == null ? void 0 : t.height) ?? (t == null ? void 0 : t.h) ?? 1)), a = Ic({ width: n, height: r }, Pi(e)), o = Mi(a, e), c = { x: a.x + a.w * 0.5, y: a.y + a.h * 0.5 }, f = bm(e, dm(
     c,
     o,
     { x: n * 0.5, y: r * 0.5 }
-  )), h = bm(f);
+  )), h = xm(f);
   return {
     yaw: h.yaw,
     pitch: h.pitch,
     fov: W(2 * Math.atan(n / (2 * o)) * xr, 1, 179)
   };
 }
-function t_(e, t, n) {
+function a_(e, t, n) {
   const r = Math.max(1, Number((e == null ? void 0 : e.width) ?? (e == null ? void 0 : e.w) ?? 1)), a = Math.max(1, Number((e == null ? void 0 : e.height) ?? (e == null ? void 0 : e.h) ?? 1)), o = Number((t == null ? void 0 : t.x) || 0) + Math.max(1, Number((t == null ? void 0 : t.w) ?? (t == null ? void 0 : t.width) ?? 1)) * 0.5, c = Number((t == null ? void 0 : t.y) || 0) + Math.max(1, Number((t == null ? void 0 : t.h) ?? (t == null ? void 0 : t.height) ?? 1)) * 0.5, f = Mi(t, n), h = {
     width: Math.max(o, r - o) * 2,
     height: Math.max(c, a - c) * 2
@@ -6334,29 +6334,29 @@ function ea(e, t) {
     changed: !0
   };
 }
-function n_(e, t, n) {
+function o_(e, t, n) {
   const r = Number((n == null ? void 0 : n.w) ?? (n == null ? void 0 : n.width)), a = Number((n == null ? void 0 : n.h) ?? (n == null ? void 0 : n.height));
   if (Number.isFinite(r) && r > 0 && Number.isFinite(a) && a > 0) {
     const c = Mi(n, e);
-    return Cc(Ac(n, t), c);
+    return Tc(Cc(n, t), c);
   }
   const o = Math.max(1, Math.min(179, Number((e == null ? void 0 : e.vFOV_deg) || 60)));
   return { vFOV_deg: o, hFOV_deg: ks(o, t) };
 }
-function rh(e, t, n, { preserveOrientation: r = !1, safeRect: a = null } = {}) {
+function ih(e, t, n, { preserveOrientation: r = !1, safeRect: a = null } = {}) {
   let o = go(t, n);
   if (!o) return e;
   const c = Pi(e) >= 1;
   r && o.ratio >= 1 !== c && (o = go(o.height, o.width));
-  const f = n_(e, o.ratio, a);
+  const f = o_(e, o.ratio, a);
   return Math.abs(Number(e.hFOV_deg || 0) - f.hFOV_deg) <= 1e-12 && Math.abs(Number(e.vFOV_deg || 0) - f.vFOV_deg) <= 1e-12 && String(e.aspect_id || "") === o.label ? e : { ...e, ...f, aspect_id: o.label };
 }
-function vm(e, t = {}) {
+function wm(e, t = {}) {
   var n;
   if (!e || typeof e != "object") return { state: e, changed: !1 };
   if (t.type === "add-frame") {
     if (Ai(e)) return { state: e, changed: !1 };
-    const r = String(t.id || `frame_${Date.now().toString(36)}`), a = cm({
+    const r = String(t.id || `frame_${Date.now().toString(36)}`), a = pm({
       id: r,
       yawDeg: t.yawDeg,
       pitchDeg: t.pitchDeg,
@@ -6387,7 +6387,7 @@ function vm(e, t = {}) {
     };
   }
   if (t.type === "set-aspect")
-    return ea(e, (r) => rh(
+    return ea(e, (r) => ih(
       r,
       t.width,
       t.height,
@@ -6399,7 +6399,7 @@ function vm(e, t = {}) {
   if (t.type === "swap-aspect")
     return ea(e, (r) => {
       const o = String(Lr(r) || "").match(/^([0-9.]+):([0-9.]+)$/), c = o ? go(o[1], o[2]) : go(Pi(r), 1);
-      return c ? rh(r, c.height, c.width, { safeRect: t.safeRect }) : r;
+      return c ? ih(r, c.height, c.width, { safeRect: t.safeRect }) : r;
     });
   if (t.type === "set-roll") {
     const r = Number(t.value);
@@ -6411,17 +6411,17 @@ function vm(e, t = {}) {
     }) : { state: e, changed: !1 };
   }
   return t.type === "scale-fov" ? ea(e, (r) => {
-    const a = fm(r, t.scale);
+    const a = mm(r, t.scale);
     return a ? { ...r, ...a } : r;
   }) : t.type === "step-fov" ? ea(e, (r) => {
-    const a = dm(r, t.direction);
+    const a = gm(r, t.direction);
     return a ? { ...r, ...a } : r;
   }) : t.type === "pan-camera" ? ea(e, (r) => {
-    const a = Sm(t.startShot || r, t);
+    const a = Mm(t.startShot || r, t);
     return Math.abs(Number(a.yaw_deg) - Number(r.yaw_deg || 0)) > 1e-12 || Math.abs(Number(a.pitch_deg) - Number(r.pitch_deg || 0)) > 1e-12 ? { ...r, yaw_deg: a.yaw_deg, pitch_deg: a.pitch_deg } : r;
   }) : { state: e, changed: !1 };
 }
-function _m({
+function km({
   frame: e,
   point: t,
   startRollDeg: n = 0,
@@ -6452,21 +6452,21 @@ function _m({
     accumulatedRad: 0
   };
 }
-function xm(e, t, n = {}) {
+function Nm(e, t, n = {}) {
   var c, f;
   if (!e || !t) return null;
   const r = Math.atan2(
     Number(t.y || 0) - Number(((c = e.center) == null ? void 0 : c.y) || 0),
     Number(t.x || 0) - Number(((f = e.center) == null ? void 0 : f.x) || 0)
-  ), a = Number(e.accumulatedRad || 0) + om(r, Number(e.lastAngle || 0));
+  ), a = Number(e.accumulatedRad || 0) + cm(r, Number(e.lastAngle || 0));
   return {
     gesture: { ...e, lastAngle: r, accumulatedRad: a },
-    rollDeg: sm(e.startRollDeg, a, {
+    rollDeg: fm(e.startRollDeg, a, {
       shiftKey: e.source === "alt" && n.shiftKey === !0
     })
   };
 }
-function Sm(e, t = {}) {
+function Mm(e, t = {}) {
   if (!e || typeof e != "object") return e;
   const n = Math.max(1, Number(t.focalPx || 1)), r = t.invertX === !0 ? -1 : 1, a = t.invertY === !0 ? -1 : 1, o = Number(t.dx || 0) * r, c = Number(t.dy || 0) * a, f = Number(e.roll_deg ?? e.rot_deg ?? 0) * Bs, h = Math.cos(f), g = Math.sin(f), v = o / n, x = -c / n, S = v * h - x * g, M = v * g + x * h, b = Number(e.pitch_deg || 0) * Bs, O = Math.max(0.25, Math.abs(Math.cos(b)));
   return {
@@ -6475,7 +6475,7 @@ function Sm(e, t = {}) {
     pitch_deg: W(Number(e.pitch_deg || 0) - Math.atan(M) * xr, -90, 90)
   };
 }
-function r_({
+function s_({
   readState: e,
   publishLiveState: t = () => {
   },
@@ -6483,10 +6483,10 @@ function r_({
   onChange: r = () => {
   }
 } = {}) {
-  return pm({
+  return ym({
     readState: e,
-    reduce: vm,
-    projectModel: gm,
+    reduce: wm,
+    projectModel: _m,
     publishLiveState: t,
     commitState: n,
     onChange: r
@@ -6537,14 +6537,14 @@ const Te = Object.freeze({
   paintbrush_vertical_tool: "paintbrush_vertical_tool",
   eraser_tool: "eraser_tool",
   lasso_tool: "lasso_tool"
-}), i_ = (e) => {
+}), l_ = (e) => {
   const t = {};
   for (const n of e.matchAll(/([:\w-]+)=(["'])(.*?)\2/g)) t[n[1]] = n[3];
   return t;
-}, a_ = (e) => Array.from(e.matchAll(/<(path|circle|rect|line|polyline|polygon)([^>]*)\/>/g), (t) => ({
+}, u_ = (e) => Array.from(e.matchAll(/<(path|circle|rect|line|polyline|polygon)([^>]*)\/>/g), (t) => ({
   tag: t[1],
-  attrs: i_(t[2])
-})), o_ = {
+  attrs: l_(t[2])
+})), c_ = {
   globe: { name: "world", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M3 12a9 9 0 1 0 18 0a9 9 0 0 0 -18 0' /><path d='M3.6 9h16.8' /><path d='M3.6 15h16.8' /><path d='M11.5 3a17 17 0 0 0 0 18' /><path d='M12.5 3a17 17 0 0 1 0 18' />" },
   pano: { name: "view-360", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0' /><path d='M12 12m-4 0a4 9 0 1 0 8 0a4 9 0 1 0 -8 0' /><path d='M3 12c0 2.21 4.03 4 9 4s9 -1.79 9 -4s-4.03 -4 -9 -4s-9 1.79 -9 4z' />" },
   unwrap: { name: "panorama-horizontal", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M4.338 5.53c5.106 1.932 10.211 1.932 15.317 0a1 1 0 0 1 1.345 .934v11c0 .692 -.692 1.2 -1.34 .962c-5.107 -1.932 -10.214 -1.932 -15.321 0c-.648 .246 -1.339 -.242 -1.339 -.935v-11.027a1 1 0 0 1 1.338 -.935l0 .001' />" },
@@ -6589,10 +6589,10 @@ const Te = Object.freeze({
   paintbrush_vertical_tool: { name: "brush", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M3 21v-4a4 4 0 1 1 4 4h-4' /><path d='M21 3a16 16 0 0 0 -12.8 10.2' /><path d='M21 3a16 16 0 0 1 -10.2 12.8' /><path d='M10.6 9a9 9 0 0 1 4.4 4.4' />" },
   eraser_tool: { name: "eraser", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M19 20h-10.5l-4.21 -4.3a1 1 0 0 1 0 -1.41l10 -10a1 1 0 0 1 1.41 0l5 5a1 1 0 0 1 0 1.41l-9.2 9.3' /><path d='M18 13.3l-6.3 -6.3' />" },
   lasso_tool: { name: "lasso", body: "<path stroke='none' d='M0 0h24v24H0z' fill='none' /><path d='M4.028 13.252c-.657 -.972 -1.028 -2.078 -1.028 -3.252c0 -3.866 4.03 -7 9 -7s9 3.134 9 7s-4.03 7 -9 7c-1.913 0 -3.686 -.464 -5.144 -1.255' /><path d='M3 15a2 2 0 1 0 4 0a2 2 0 1 0 -4 0' /><path d='M5 17c0 1.42 .316 2.805 1 4' />" }
-}, ih = Object.fromEntries(
-  Object.entries(o_).map(([e, t]) => [e, {
+}, ah = Object.fromEntries(
+  Object.entries(c_).map(([e, t]) => [e, {
     name: t.name,
-    elements: a_(t.body)
+    elements: u_(t.body)
   }])
 ), en = {
   __name: "SvgIcon",
@@ -6603,7 +6603,7 @@ const Te = Object.freeze({
   setup(e) {
     const t = e, n = wt(() => {
       const r = String(t.icon || "");
-      return Object.prototype.hasOwnProperty.call(ih, r) ? ih[r] : null;
+      return Object.prototype.hasOwnProperty.call(ah, r) ? ah[r] : null;
     });
     return (r, a) => n.value ? (ke(), Pe("svg", {
       key: 0,
@@ -6661,20 +6661,20 @@ const Te = Object.freeze({
       const r = { ...t.attrs };
       return t.tag === "button" && r.type == null && (r.type = t.type), t.label && (r["aria-label"] = t.label), t.tip && (r["data-tip"] = t.tip), t.pressed != null && (r["aria-pressed"] = t.pressed), r;
     });
-    return (r, a) => (ke(), Ii(Hy(e.tag), ri({
+    return (r, a) => (ke(), Ii(Ky(e.tag), ri({
       class: ["pano-btn pano-btn-icon", e.extraClass]
     }, n.value), {
-      default: vp(() => [
+      default: wp(() => [
         $e(en, { icon: e.icon }, null, 8, ["icon"])
       ]),
       _: 1
     }, 16, ["class"]));
   }
-}, s_ = ["aria-expanded", "disabled"], l_ = {
+}, f_ = ["aria-expanded", "disabled"], d_ = {
   class: "pano-frame-aspect-popover pano-cutout-aspect-pop",
   role: "dialog",
   "aria-label": "Aspect ratio"
-}, u_ = ["data-aspect", "disabled", "onClick"], c_ = { class: "pano-cutout-aspect-custom" }, f_ = ["disabled"], d_ = ["disabled"], h_ = ["data-custom-width", "data-custom-height", "disabled"], wm = {
+}, h_ = ["data-aspect", "disabled", "onClick"], p_ = { class: "pano-cutout-aspect-custom" }, m_ = ["disabled"], g_ = ["disabled"], b_ = ["data-custom-width", "data-custom-height", "disabled"], Pm = {
   __name: "PanoCutoutAspectPicker",
   props: {
     model: { type: Object, default: () => ({}) },
@@ -6717,7 +6717,7 @@ const Te = Object.freeze({
       var j;
       n.model.aspectOpen === !0 && ((j = f.value) != null && j.contains(O.target) || x({ type: "close-aspect" }));
     }
-    gc(() => {
+    bc(() => {
       document.addEventListener("pointerdown", S, !0);
     }), sl(() => {
       document.removeEventListener("pointerdown", S, !0);
@@ -6770,8 +6770,8 @@ const Te = Object.freeze({
           icon: pt(Te).chevron,
           "class-name": "pano-cutout-aspect-caret"
         }, null, 8, ["icon"])
-      ], 8, s_)),
-      Si(X("div", l_, [
+      ], 8, f_)),
+      Si(X("div", d_, [
         (ke(!0), Pe(ot, null, jt(g.value, (z) => (ke(), Pe("button", {
           key: z.value,
           class: ft(["pano-btn pano-frame-aspect-choice", { active: z.active === !0 }]),
@@ -6780,8 +6780,8 @@ const Te = Object.freeze({
           "data-aspect": z.value,
           disabled: h.value,
           onClick: (P) => M(z)
-        }, ct(z.label), 11, u_))), 128)),
-        X("div", c_, [
+        }, ct(z.label), 11, h_))), 128)),
+        X("div", p_, [
           Si(X("input", {
             "onUpdate:modelValue": j[2] || (j[2] = (z) => o.value = z),
             name: "customWidth",
@@ -6791,8 +6791,8 @@ const Te = Object.freeze({
             inputmode: "decimal",
             "aria-label": "Custom aspect width",
             disabled: h.value
-          }, null, 8, f_), [
-            [jd, o.value]
+          }, null, 8, m_), [
+            [Vd, o.value]
           ]),
           j[4] || (j[4] = X("span", { "aria-hidden": "true" }, ":", -1)),
           Si(X("input", {
@@ -6804,8 +6804,8 @@ const Te = Object.freeze({
             inputmode: "decimal",
             "aria-label": "Custom aspect height",
             disabled: h.value
-          }, null, 8, d_), [
-            [jd, c.value]
+          }, null, 8, g_), [
+            [Vd, c.value]
           ]),
           X("button", {
             class: "pano-btn",
@@ -6815,17 +6815,17 @@ const Te = Object.freeze({
             "data-custom-height": c.value,
             disabled: h.value,
             onClick: b
-          }, "Apply", 8, h_)
+          }, "Apply", 8, b_)
         ])
       ], 512), [
         [wo, e.model.aspectOpen === !0]
       ])
     ], 2));
   }
-}, p_ = {
+}, y_ = {
   class: "pano-cutout-node-help-popover",
   role: "tooltip"
-}, m_ = {
+}, v_ = {
   __name: "PanoCutoutNodeHelp",
   setup(e) {
     const t = /* @__PURE__ */ vn(!1), n = Object.freeze([
@@ -6852,7 +6852,7 @@ const Te = Object.freeze({
         "extra-class": "pano-cutout-node-help-button",
         onClick: a[0] || (a[0] = Hn((o) => t.value = !t.value, ["stop"]))
       }, null, 8, ["icon", "pressed"]),
-      X("div", p_, [
+      X("div", y_, [
         a[3] || (a[3] = X("div", { class: "pano-cutout-node-help-title" }, "Node controls", -1)),
         (ke(!0), Pe(ot, null, jt(pt(n), (o) => (ke(), Pe("div", {
           key: o[0],
@@ -6864,10 +6864,10 @@ const Te = Object.freeze({
       ])
     ], 34));
   }
-}, g_ = { class: "pano-cutout-node-surface" }, b_ = ["title", "disabled"], y_ = { class: "value" }, v_ = {
+}, __ = { class: "pano-cutout-node-surface" }, x_ = ["title", "disabled"], S_ = { class: "value" }, w_ = {
   key: 0,
   class: "pano-cutout-node-empty-note"
-}, __ = {
+}, k_ = {
   __name: "PanoCutoutNodeSurface",
   props: {
     model: { type: Object, default: () => ({}) },
@@ -6879,7 +6879,7 @@ const Te = Object.freeze({
       var a;
       (a = t.onAction) == null || a.call(t, r);
     }
-    return (r, a) => (ke(), Pe("div", g_, [
+    return (r, a) => (ke(), Pe("div", __, [
       X("div", {
         class: "pano-cutout-node-toolbar",
         role: "toolbar",
@@ -6908,7 +6908,7 @@ const Te = Object.freeze({
           attrs: { "data-action": e.model.hasShot ? "delete-frame" : "add-frame" },
           onClick: a[1] || (a[1] = (o) => n({ type: e.model.hasShot ? "delete-frame" : "add-frame" }))
         }, null, 8, ["icon", "label", "tip", "attrs"]),
-        $e(wm, {
+        $e(Pm, {
           model: e.model,
           mode: "node",
           onAction: n
@@ -6924,8 +6924,8 @@ const Te = Object.freeze({
           $e(en, {
             icon: pt(Te).roll
           }, null, 8, ["icon"]),
-          X("span", y_, ct(e.model.rollLabel || "0.0°"), 1)
-        ], 40, b_),
+          X("span", S_, ct(e.model.rollLabel || "0.0°"), 1)
+        ], 40, x_),
         $e(tn, {
           icon: pt(Te).rotate_90,
           label: "Toggle Portrait/Landscape",
@@ -6937,12 +6937,12 @@ const Te = Object.freeze({
           },
           onClick: a[3] || (a[3] = (o) => n({ type: "swap-aspect" }))
         }, null, 8, ["icon", "attrs"]),
-        $e(m_)
+        $e(v_)
       ], 32),
-      e.model.hasShot === !1 ? (ke(), Pe("div", v_, " Choose a view · + Add Frame ")) : zt("", !0)
+      e.model.hasShot === !1 ? (ke(), Pe("div", w_, " Choose a view · + Add Frame ")) : zt("", !0)
     ]));
   }
-}, km = {
+}, Am = {
   __name: "PanoImageFilePicker",
   emits: ["file-selected", "file-cancelled"],
   setup(e, { expose: t, emit: n }) {
@@ -6984,10 +6984,10 @@ const Te = Object.freeze({
       onCancel: v
     }, null, 544));
   }
-}, x_ = {
+}, N_ = {
   class: "pano-stickers-node-help-popover",
   role: "tooltip"
-}, S_ = {
+}, M_ = {
   __name: "PanoStickersNodeHelp",
   setup(e) {
     const t = /* @__PURE__ */ vn(!1), n = Object.freeze([
@@ -7017,7 +7017,7 @@ const Te = Object.freeze({
         "extra-class": "pano-stickers-node-help-button",
         onClick: a[0] || (a[0] = Hn((o) => t.value = !t.value, ["stop"]))
       }, null, 8, ["icon", "pressed"]),
-      X("div", x_, [
+      X("div", N_, [
         a[3] || (a[3] = X("div", { class: "pano-stickers-node-help-title" }, "Node controls", -1)),
         (ke(!0), Pe(ot, null, jt(pt(n), (o) => (ke(), Pe("div", {
           key: o[0],
@@ -7029,13 +7029,13 @@ const Te = Object.freeze({
       ])
     ], 34));
   }
-}, w_ = { class: "pano-stickers-node-surface" }, k_ = ["disabled"], N_ = {
+}, P_ = { class: "pano-stickers-node-surface" }, A_ = ["disabled"], C_ = {
   key: 0,
   class: "pano-stickers-node-empty-note"
-}, M_ = {
+}, T_ = {
   key: 1,
   class: "pano-stickers-node-drop-cue"
-}, P_ = {
+}, I_ = {
   __name: "PanoStickersNodeSurface",
   props: {
     model: { type: Object, default: () => ({}) },
@@ -7054,7 +7054,7 @@ const Te = Object.freeze({
     function o(c) {
       r({ type: "add-image-file", file: (c == null ? void 0 : c.file) || null });
     }
-    return (c, f) => (ke(), Pe("div", w_, [
+    return (c, f) => (ke(), Pe("div", P_, [
       X("div", {
         class: "pano-stickers-node-toolbar",
         role: "toolbar",
@@ -7086,7 +7086,7 @@ const Te = Object.freeze({
             icon: pt(Te).image
           }, null, 8, ["icon"]),
           f[8] || (f[8] = X("span", { class: "label" }, "Add Image", -1))
-        ], 8, k_),
+        ], 8, A_),
         $e(tn, {
           icon: e.model.locked ? pt(Te).lock_closed : pt(Te).lock_open,
           label: e.model.locked ? "Unlock Sticker" : "Lock Sticker",
@@ -7119,18 +7119,18 @@ const Te = Object.freeze({
           },
           onClick: f[4] || (f[4] = (h) => r({ type: e.model.isExternalSelection ? "restore-initial" : "delete-selected" }))
         }, null, 8, ["icon", "label", "tip", "attrs"]),
-        $e(S_)
+        $e(M_)
       ], 32),
-      e.model.hasStickers === !1 ? (ke(), Pe("div", N_, " Add Image to place a sticker ")) : zt("", !0),
-      e.model.dropActive === !0 ? (ke(), Pe("div", M_, "Drop image to add")) : zt("", !0),
-      $e(km, {
+      e.model.hasStickers === !1 ? (ke(), Pe("div", C_, " Add Image to place a sticker ")) : zt("", !0),
+      e.model.dropActive === !0 ? (ke(), Pe("div", T_, "Drop image to add")) : zt("", !0),
+      $e(Am, {
         ref_key: "imageFilePickerRef",
         ref: n,
         onFileSelected: o
       }, null, 512)
     ]));
   }
-}, Ns = "sticker_image_1", Nm = "external_image";
+}, Ns = "sticker_image_1", Cm = "external_image";
 function Ms(e, t, n) {
   const r = Math.min(179, Math.max(0.1, Number(e || 30))), a = Math.max(1, Number(n || 1)) / Math.max(1, Number(t || 1)), o = 2 * Math.atan(Math.tan(r * Math.PI / 180 * 0.5) * a) * 180 / Math.PI;
   return Math.min(179, Math.max(0.1, o));
@@ -7139,26 +7139,26 @@ function hu(e) {
   const t = Number(e);
   return Number.isFinite(t) ? Math.trunc(t) : 0;
 }
-function Ic(e) {
+function Ec(e) {
   var n;
   const t = String(((n = e == null ? void 0 : e.active) == null ? void 0 : n.selected_sticker_id) || "");
   return t && (Array.isArray(e == null ? void 0 : e.stickers) ? e.stickers : []).find((r) => String((r == null ? void 0 : r.id) || "") === t) || null;
 }
-function Ec(e) {
-  return String((e == null ? void 0 : e.id) || "") === Ns || String((e == null ? void 0 : e.source_kind) || "") === Nm;
+function Dc(e) {
+  return String((e == null ? void 0 : e.id) || "") === Ns || String((e == null ? void 0 : e.source_kind) || "") === Cm;
 }
-const Mm = ["yaw_deg", "pitch_deg", "hFOV_deg", "vFOV_deg", "rot_deg"];
-function Pm(e) {
-  return !Ec(e) || !(e != null && e.initial_pose) || typeof e.initial_pose != "object" ? null : Object.fromEntries(Mm.map((t) => {
+const Tm = ["yaw_deg", "pitch_deg", "hFOV_deg", "vFOV_deg", "rot_deg"];
+function Im(e) {
+  return !Dc(e) || !(e != null && e.initial_pose) || typeof e.initial_pose != "object" ? null : Object.fromEntries(Tm.map((t) => {
     const n = t === "hFOV_deg" || t === "vFOV_deg" ? 30 : 0, r = Number(e[t]), a = Number(e.initial_pose[t]);
     return [t, Number.isFinite(a) ? a : Number.isFinite(r) ? r : n];
   }));
 }
-function Am(e) {
-  const t = Pm(e);
-  return t ? Mm.some((n) => Math.abs(Number((e == null ? void 0 : e[n]) || 0) - t[n]) > 1e-4) : !1;
+function Em(e) {
+  const t = Im(e);
+  return t ? Tm.some((n) => Math.abs(Number((e == null ? void 0 : e[n]) || 0) - t[n]) > 1e-4) : !1;
 }
-function Cm(e, t = {}) {
+function Dm(e, t = {}) {
   var I, R, G;
   if (!e || typeof e != "object") return { state: e, changed: !1 };
   const n = Array.isArray(e.stickers) ? e.stickers : [], r = n.findIndex((H) => String((H == null ? void 0 : H.id) || "") === Ns);
@@ -7199,7 +7199,7 @@ function Cm(e, t = {}) {
   }, P = {
     ...c || {},
     id: Ns,
-    source_kind: Nm,
+    source_kind: Cm,
     source_link_id: a,
     source_state_hash: o,
     ...z,
@@ -7209,7 +7209,7 @@ function Cm(e, t = {}) {
   }, $ = r >= 0 ? n.map((H, se) => se === r ? P : H) : [...n, P];
   return { state: { ...e, stickers: $ }, changed: !0 };
 }
-function Dc(e) {
+function Oc(e) {
   const t = (Array.isArray(e == null ? void 0 : e.stickers) ? e.stickers : []).filter((o) => o && typeof o == "object").map((o) => ({
     type: "sticker",
     id: String(o.id || ""),
@@ -7228,13 +7228,13 @@ function Dc(e) {
   }));
   return [...t, ...r, ...a].sort((o, c) => o.z_index - c.z_index);
 }
-function Tm(e) {
-  const t = Ic(e), n = Ec(t), r = (Array.isArray(e == null ? void 0 : e.stickers) ? e.stickers : []).some((f) => f && f.visible !== !1), a = Dc(e), o = t ? a.findIndex((f) => f.type === "sticker" && f.item === t) : -1, c = (t == null ? void 0 : t.locked) === !0;
+function Om(e) {
+  const t = Ec(e), n = Dc(t), r = (Array.isArray(e == null ? void 0 : e.stickers) ? e.stickers : []).some((f) => f && f.visible !== !1), a = Oc(e), o = t ? a.findIndex((f) => f.type === "sticker" && f.item === t) : -1, c = (t == null ? void 0 : t.locked) === !0;
   return {
     hasStickers: r,
     hasSelection: !!t,
     isExternalSelection: n,
-    canRestoreInitial: Am(t),
+    canRestoreInitial: Em(t),
     selectedId: t ? String(t.id || "") : null,
     locked: c,
     canDelete: !!t && !c,
@@ -7242,7 +7242,7 @@ function Tm(e) {
     canMoveBackward: o > 0
   };
 }
-function A_(e) {
+function E_(e) {
   var t, n;
   return {
     ...e,
@@ -7254,10 +7254,10 @@ function A_(e) {
     }
   };
 }
-function ah(e, t) {
-  const n = Ic(e);
+function oh(e, t) {
+  const n = Ec(e);
   if (!n || n.locked === !0) return { state: e, changed: !1 };
-  const r = A_(e), a = String(n.id || ""), o = Dc(r), c = o.findIndex((h) => h.type === "sticker" && h.id === a);
+  const r = E_(e), a = String(n.id || ""), o = Oc(r), c = o.findIndex((h) => h.type === "sticker" && h.id === a);
   if (c < 0) return { state: e, changed: !1 };
   if (t === "front" && c === o.length - 1 || t === "back" && c === 0)
     return { state: e, changed: !1 };
@@ -7266,7 +7266,7 @@ function ah(e, t) {
     h.item.z_index = g;
   }), { state: r, changed: !0 };
 }
-function C_(e) {
+function D_(e) {
   const t = new Set(
     (Array.isArray(e.stickers) ? e.stickers : []).map((n) => String((n == null ? void 0 : n.asset_id) || "")).filter(Boolean)
   );
@@ -7274,15 +7274,15 @@ function C_(e) {
     Object.entries(e.assets || {}).filter(([n]) => t.has(String(n)))
   );
 }
-function T_(e, t = {}) {
+function O_(e, t = {}) {
   var r, a;
   if (!e || typeof e != "object") return { state: e, changed: !1 };
-  if (t.type === "sync-external") return Cm(e, t.value);
+  if (t.type === "sync-external") return Dm(e, t.value);
   if (t.type === "add-sticker") {
     const o = t.value && typeof t.value == "object" ? t.value : {}, c = String(o.stickerId || "").trim(), f = String(o.assetId || "").trim();
     if (!c || !f || !o.asset || (Array.isArray(e.stickers) ? e.stickers : []).some((S) => String((S == null ? void 0 : S.id) || "") === c))
       return { state: e, changed: !1 };
-    const g = Dc(e).reduce((S, M) => Math.max(S, Number(M.z_index || 0)), -1), v = 30, x = {
+    const g = Oc(e).reduce((S, M) => Math.max(S, Number(M.z_index || 0)), -1), v = 30, x = {
       id: c,
       asset_id: f,
       yaw_deg: Number(o.yaw_deg || 0),
@@ -7309,7 +7309,7 @@ function T_(e, t = {}) {
       changed: !0
     };
   }
-  const n = Ic(e);
+  const n = Ec(e);
   if (!n) return { state: e, changed: !1 };
   if (t.type === "toggle-lock") {
     const o = n.locked !== !0;
@@ -7322,8 +7322,8 @@ function T_(e, t = {}) {
     };
   }
   if (t.type === "restore-initial") {
-    const o = Pm(n);
-    return !o || !Am(n) ? { state: e, changed: !1 } : {
+    const o = Im(n);
+    return !o || !Em(n) ? { state: e, changed: !1 } : {
       state: {
         ...e,
         stickers: e.stickers.map((c) => c === n ? { ...c, ...o } : c)
@@ -7332,10 +7332,10 @@ function T_(e, t = {}) {
     };
   }
   if (n.locked === !0) return { state: e, changed: !1 };
-  if (t.type === "bring-front") return ah(e, "front");
-  if (t.type === "send-back") return ah(e, "back");
+  if (t.type === "bring-front") return oh(e, "front");
+  if (t.type === "send-back") return oh(e, "back");
   if (t.type === "delete-selected") {
-    if (Ec(n))
+    if (Dc(n))
       return n.visible === !1 ? { state: e, changed: !1 } : {
         state: {
           ...e,
@@ -7348,7 +7348,7 @@ function T_(e, t = {}) {
       stickers: o,
       active: { ...e.active || {}, selected_sticker_id: c }
     };
-    return f.assets = C_(f), { state: f, changed: !0 };
+    return f.assets = D_(f), { state: f, changed: !0 };
   }
   if (t.type === "set-transform") {
     const o = t.value && typeof t.value == "object" ? t.value : {}, c = ["yaw_deg", "pitch_deg", "hFOV_deg", "vFOV_deg", "rot_deg"], f = {};
@@ -7365,21 +7365,22 @@ function T_(e, t = {}) {
   }
   return { state: e, changed: !1 };
 }
-function I_(e = {}) {
-  return pm({
+function F_(e = {}) {
+  return ym({
     ...e,
-    reduce: T_,
-    projectModel: Tm
+    reduce: O_,
+    projectModel: Om
   });
 }
-function E_(e = {}) {
+const sh = 24;
+function R_(e = {}) {
   return (e == null ? void 0 : e.locked) === !0 ? "#ff4d4f" : String((e == null ? void 0 : e.source_kind) || "") === "external_image" || String((e == null ? void 0 : e.id) || "") === "sticker_image_1" ? "#f59e0b" : "#0070f3";
 }
-function oh(e, t) {
+function lh(e, t) {
   const n = Number((e == null ? void 0 : e.x) || 0) - Number((t == null ? void 0 : t.x) || 0), r = Number((e == null ? void 0 : e.y) || 0) - Number((t == null ? void 0 : t.y) || 0);
   return n * n + r * r;
 }
-function D_(e, t) {
+function L_(e, t) {
   let n = !1;
   for (let r = 0, a = t.length - 1; r < t.length; a = r, r += 1) {
     const o = t[r], c = t[a];
@@ -7389,7 +7390,7 @@ function D_(e, t) {
 }
 function ju(e, t) {
   if (!(e != null && e.visible)) return { kind: "none" };
-  const n = e.corners.findIndex((r) => oh(r, t) <= 121);
+  const n = e.corners.findIndex((r) => lh(r, t) <= 121);
   if (n >= 0) {
     const r = e.corners[n], a = r.x - e.center.x, o = r.y - e.center.y;
     return {
@@ -7398,9 +7399,9 @@ function ju(e, t) {
       cursor: a * o >= 0 ? "nwse-resize" : "nesw-resize"
     };
   }
-  return oh(e.rotateHandle, t) <= 144 ? { kind: "rotate", cursor: "grab" } : D_(t, e.corners) ? { kind: "move", cursor: "default" } : { kind: "none" };
+  return lh(e.rotateHandle, t) <= 144 ? { kind: "rotate", cursor: "grab" } : L_(t, e.corners) ? { kind: "move", cursor: "default" } : { kind: "none" };
 }
-function Im(e, t, { selected: n = !0 } = {}) {
+function Fm(e, t, { selected: n = !0 } = {}) {
   if (!e || !Array.isArray(t)) return !1;
   e.strokeStyle = n ? "rgba(250, 250, 250, 0.9)" : "#71717a", e.lineWidth = n ? 2 : 1, e.beginPath();
   let r = !1;
@@ -7408,30 +7409,30 @@ function Im(e, t, { selected: n = !0 } = {}) {
     r ? e.lineTo(o.x, o.y) : (e.moveTo(o.x, o.y), r = !0);
   })), r ? (e.closePath(), e.stroke(), !0) : !1;
 }
-function Em(e, t, { accent: n = "#0070f3" } = {}) {
+function Rm(e, t, { accent: n = "#0070f3" } = {}) {
   !e || !t || (e.fillStyle = n, t.corners.forEach((r) => {
-    e.beginPath(), e.arc(r.x, r.y, 6.5, 0, Math.PI * 2), e.fill();
-  }), e.strokeStyle = "rgba(250, 250, 250, 0.9)", e.lineWidth = 1.8, e.beginPath(), e.moveTo(t.rotateStemBase.x, t.rotateStemBase.y), e.lineTo(t.rotateHandle.x, t.rotateHandle.y), e.stroke(), e.fillStyle = n, e.beginPath(), e.arc(t.rotateHandle.x, t.rotateHandle.y, 10, 0, Math.PI * 2), e.fill());
+    e.beginPath(), e.arc(r.x, r.y, 5.5, 0, Math.PI * 2), e.fill();
+  }), e.strokeStyle = "rgba(250, 250, 250, 0.9)", e.lineWidth = 1.8, e.beginPath(), e.moveTo(t.rotateStemBase.x, t.rotateStemBase.y), e.lineTo(t.rotateHandle.x, t.rotateHandle.y), e.stroke(), e.fillStyle = n, e.beginPath(), e.arc(t.rotateHandle.x, t.rotateHandle.y, 8, 0, Math.PI * 2), e.fill());
 }
-function Dm(e) {
+function Lm(e) {
   return {
     width: Math.max(1, Number((e == null ? void 0 : e.width) ?? (e == null ? void 0 : e.w) ?? 1)),
     height: Math.max(1, Number((e == null ? void 0 : e.height) ?? (e == null ? void 0 : e.h) ?? 1))
   };
 }
-function Om(e) {
+function zm(e) {
   return No(
     Number((e == null ? void 0 : e.yawDeg) ?? (e == null ? void 0 : e.yaw) ?? 0),
     Number((e == null ? void 0 : e.pitchDeg) ?? (e == null ? void 0 : e.pitch) ?? 0),
     0
   );
 }
-function O_(e, t, n) {
-  const { width: r, height: a } = Dm(n), { right: o, up: c, fwd: f } = Om(t), h = W(Number((t == null ? void 0 : t.fovDeg) ?? (t == null ? void 0 : t.fov) ?? 100), 1, 179) * _n, g = 2 * Math.atan(Math.tan(h * 0.5) * (a / r)), v = (Number((e == null ? void 0 : e.x) || 0) - r * 0.5) / (r * 0.5) * Math.tan(h * 0.5), x = (a * 0.5 - Number((e == null ? void 0 : e.y) || 0)) / (a * 0.5) * Math.tan(g * 0.5);
+function z_(e, t, n) {
+  const { width: r, height: a } = Lm(n), { right: o, up: c, fwd: f } = zm(t), h = W(Number((t == null ? void 0 : t.fovDeg) ?? (t == null ? void 0 : t.fov) ?? 100), 1, 179) * _n, g = 2 * Math.atan(Math.tan(h * 0.5) * (a / r)), v = (Number((e == null ? void 0 : e.x) || 0) - r * 0.5) / (r * 0.5) * Math.tan(h * 0.5), x = (a * 0.5 - Number((e == null ? void 0 : e.y) || 0)) / (a * 0.5) * Math.tan(g * 0.5);
   return Hr(si(si(_r(o, v), _r(c, x)), f));
 }
 function Ba(e, t, n) {
-  const { width: r, height: a } = Dm(n), { right: o, up: c, fwd: f } = Om(t), h = Ni(e, o), g = Ni(e, c), v = Ni(e, f), x = 1e-4;
+  const { width: r, height: a } = Lm(n), { right: o, up: c, fwd: f } = zm(t), h = Ni(e, o), g = Ni(e, c), v = Ni(e, f), x = 1e-4;
   if (!Number.isFinite(v)) return null;
   const S = Math.max(v, x), M = W(Number((t == null ? void 0 : t.fovDeg) ?? (t == null ? void 0 : t.fov) ?? 100), 1, 179) * _n, b = 2 * Math.atan(Math.tan(M * 0.5) * (a / r)), O = r * 0.5 / Math.tan(M * 0.5), j = a * 0.5 / Math.tan(b * 0.5), z = Math.max(r, a) * 2;
   return {
@@ -7440,8 +7441,8 @@ function Ba(e, t, n) {
     rawZ: v
   };
 }
-function F_(e) {
-  const t = am(Number((e == null ? void 0 : e.yaw_deg) || 0), Number((e == null ? void 0 : e.pitch_deg) || 0));
+function $_(e) {
+  const t = um(Number((e == null ? void 0 : e.yaw_deg) || 0), Number((e == null ? void 0 : e.pitch_deg) || 0));
   let n = Yr(0, 1, 0);
   Math.abs(Ni(t, n)) > 0.999 && (n = Yr(0, 0, 1));
   const r = Hr(Us(n, t)), a = Hr(Us(t, r)), o = Number((e == null ? void 0 : e.rot_deg) ?? (e == null ? void 0 : e.roll_deg) ?? 0) * _n;
@@ -7462,9 +7463,9 @@ function gi(e, t, n) {
     _r(e.up, a)
   ));
 }
-function Fm(e, t, n) {
+function $m(e, t, n) {
   if (!e || e.visible === !1) return { visible: !1 };
-  const r = F_(e), a = Ba(r.centerDir, t, n);
+  const r = $_(e), a = Ba(r.centerDir, t, n);
   if (!a) return { visible: !1 };
   const o = [
     gi(r, -r.tanX, r.tanY),
@@ -7496,14 +7497,14 @@ function Fm(e, t, n) {
     boundaryEdges: c,
     rotateStemBase: { x: f.x, y: f.y },
     rotateHandle: {
-      x: f.x + v / S * 30,
-      y: f.y + x / S * 30
+      x: f.x + v / S * sh,
+      y: f.y + x / S * sh
     },
     visible: !0
   };
 }
-function sh(e, t, n, r, a) {
-  const o = (Array.isArray(e) ? e : []).filter((f) => f && f.visible !== !1).map((f) => ({ item: f, geometry: Fm(f, r, a) })).filter((f) => f.geometry.visible).sort((f, h) => {
+function uh(e, t, n, r, a) {
+  const o = (Array.isArray(e) ? e : []).filter((f) => f && f.visible !== !1).map((f) => ({ item: f, geometry: $m(f, r, a) })).filter((f) => f.geometry.visible).sort((f, h) => {
     var g, v;
     return Number(((g = h.item) == null ? void 0 : g.z_index) || 0) - Number(((v = f.item) == null ? void 0 : v.z_index) || 0);
   }), c = o.find((f) => {
@@ -7520,15 +7521,15 @@ function sh(e, t, n, r, a) {
   }
   return null;
 }
-function R_(e, t, n, r) {
-  const a = O_(t, n, r);
+function j_(e, t, n, r) {
+  const a = z_(t, n, r);
   return {
     ...e,
     yaw_deg: Ut(Math.atan2(a.x, a.z) * Wr),
     pitch_deg: Math.asin(W(a.y, -1, 1)) * Wr
   };
 }
-function L_(e, t, n) {
+function V_(e, t, n) {
   const r = Math.max(1, Number(n || 0)) / Math.max(1, Number(t || 1));
   return {
     ...e,
@@ -7536,13 +7537,13 @@ function L_(e, t, n) {
     vFOV_deg: W(Number((e == null ? void 0 : e.vFOV_deg) || 20) * r, 1, 179)
   };
 }
-function z_(e, t, n, r = !1) {
+function H_(e, t, n, r = !1) {
   const a = (Number(n || 0) - Number(t || 0)) * Wr;
   let o = Number((e == null ? void 0 : e.rot_deg) ?? (e == null ? void 0 : e.roll_deg) ?? 0) - a;
   return r && (o = Math.round(o / 45) * 45), { ...e, rot_deg: o };
 }
 let Qo = null;
-function Oc() {
+function Fc() {
   return Qo || (Qo = new Promise((e) => {
     const t = document.getElementById("pano-suite-style-link");
     if (t) {
@@ -7565,11 +7566,11 @@ function Kn(e, t = 0) {
   const n = Number(e);
   return Number.isFinite(n) ? n : t;
 }
-function $_(e, t = 1024) {
+function U_(e, t = 1024) {
   const n = Math.max(1, Math.round(Kn(e, 2048))), r = Math.min(n, Math.max(1, Math.round(Kn(t, 1024))));
   return { width: r, height: Math.max(1, Math.round(r * 0.5)) };
 }
-function j_(e, t, n) {
+function B_(e, t, n) {
   const r = Kn(t), a = Kn(n), o = e == null ? void 0 : e.bbox;
   if (!o || r < 1 || a < 1) return null;
   const c = Kn(o.u0), f = Kn(o.v0), h = Kn(o.u1), g = Kn(o.v1);
@@ -7585,7 +7586,7 @@ function j_(e, t, n) {
     wrapOffsets: [-r, 0, r]
   };
 }
-function V_(e, t, n) {
+function G_(e, t, n) {
   const r = String((e == null ? void 0 : e.rasterDataUrl) || ""), a = (e == null ? void 0 : e.bbox) || {}, o = (e == null ? void 0 : e.transform) || {};
   return [
     String((e == null ? void 0 : e.id) || ""),
@@ -7603,7 +7604,7 @@ function V_(e, t, n) {
     o.scale
   ].join(":");
 }
-function H_() {
+function K_() {
   const e = /* @__PURE__ */ new Map(), t = /* @__PURE__ */ new Map();
   function n() {
     if (!(e.size <= 16))
@@ -7627,9 +7628,9 @@ function H_() {
   }
   function a(o, c, f, h = null) {
     if (!o || o.visible === !1 || String(o.layerKind || "paint") !== "paint") return null;
-    const g = String(o.rasterDataUrl || "").trim(), v = j_(o, c, f);
+    const g = String(o.rasterDataUrl || "").trim(), v = B_(o, c, f);
     if (!g.startsWith("data:") || !v) return null;
-    const x = V_(o, c, f), S = String((o == null ? void 0 : o.id) || "").trim() || x, M = t.get(S);
+    const x = G_(o, c, f), S = String((o == null ? void 0 : o.id) || "").trim() || x, M = t.get(S);
     if ((M == null ? void 0 : M.revision) === x) return { source: M.source, revision: x };
     const b = r(g, h), O = Number(b.naturalWidth || b.width || 0), j = Number(b.naturalHeight || b.height || 0);
     if (!b.complete || O < 1 || j < 1) return null;
@@ -7660,13 +7661,13 @@ function H_() {
     }
   };
 }
-function U_(e) {
+function W_(e) {
   return Math.max(0, Number(e || 0)) + 1;
 }
-function B_(e, t = "", n = 0) {
+function Y_(e, t = "", n = 0) {
   return [String(e || ""), String(t || ""), Math.max(0, Number(n || 0))].join("|");
 }
-function G_({ ImageCtor: e = null, maxEntries: t = 32 } = {}) {
+function q_({ ImageCtor: e = null, maxEntries: t = 32 } = {}) {
   const n = /* @__PURE__ */ new Map(), r = /* @__PURE__ */ new WeakMap(), a = Math.max(1, Math.trunc(Number(t || 32)));
   function o(x) {
     if (!x) return;
@@ -7733,7 +7734,7 @@ function hl(e, t = "") {
   const r = Gs(e);
   return Object.prototype.hasOwnProperty.call(r, n) ? r[n] !== !1 : (e == null ? void 0 : e.__panoNodeOutputMediaCurrent) !== !1;
 }
-function lh(e, t = "") {
+function ch(e, t = "") {
   if (!e) return;
   const n = String(t || "").trim();
   if (n) {
@@ -7742,7 +7743,7 @@ function lh(e, t = "") {
   }
   e.__panoNodeOutputMediaCurrent = !1;
 }
-function K_(e, t = "") {
+function X_(e, t = "") {
   if (!e) return;
   const n = String(t || "").trim();
   if (n) {
@@ -7755,13 +7756,13 @@ function K_(e, t = "") {
     r[a] = !0;
   });
 }
-function uh(e, t, n, r = ["erp_image", "bg_erp"]) {
+function fh(e, t, n, r = ["erp_image", "bg_erp"]) {
   const a = String(t ?? "").trim().toLowerCase();
   if (!(t === 1 || a === "input")) return !1;
   const c = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs[Number(n)] : null;
   return r.includes(String((c == null ? void 0 : c.name) || ""));
 }
-function W_(e, t = [], n = null) {
+function J_(e, t = [], n = null) {
   var a;
   const r = typeof n == "function" ? n : (o) => String((o == null ? void 0 : o.src) || (o == null ? void 0 : o.url) || o || "").trim();
   for (const o of t) {
@@ -7776,7 +7777,7 @@ function W_(e, t = [], n = null) {
   }
   return "";
 }
-function Y_({
+function Z_({
   documentRef: e = typeof document < "u" ? document : null,
   src: t = "",
   onFrame: n = null
@@ -7812,7 +7813,7 @@ function bt(e, t = null) {
   const n = Number(e);
   return Number.isFinite(n) ? n : t;
 }
-function q_() {
+function Q_() {
   return {
     version: 1,
     groups: [],
@@ -7821,7 +7822,7 @@ function q_() {
     raster_objects: []
   };
 }
-function X_(e) {
+function ex(e) {
   if (!Array.isArray(e)) return [];
   const t = [], n = /* @__PURE__ */ new Set();
   for (const r of e) {
@@ -7840,7 +7841,7 @@ function X_(e) {
   }
   return t;
 }
-function J_(e) {
+function tx(e) {
   if (!e || typeof e != "object") return null;
   const t = String(e.kind || "").trim();
   if (t === "ERP_GLOBAL") return { kind: "ERP_GLOBAL" };
@@ -7850,7 +7851,7 @@ function J_(e) {
   }
   return null;
 }
-function Z_(e, t) {
+function nx(e, t) {
   if (!e || typeof e != "object" || !t) return null;
   const n = bt(e.t, 0), r = bt(e.widthScale, null), a = bt(e.pressureLike, null);
   if (t.kind === "ERP_GLOBAL") {
@@ -7882,13 +7883,13 @@ function es(e, t, n = 1) {
   if (!Array.isArray(e)) return null;
   const r = [];
   for (const a of e) {
-    const o = Z_(a, t);
+    const o = nx(a, t);
     if (!o) return null;
     r.push(o);
   }
   return r.length >= n ? r : null;
 }
-function Q_(e, t, n, r) {
+function rx(e, t, n, r) {
   if (!e || typeof e != "object") return null;
   const a = String(e.geometryKind || "").trim();
   if (a === "lasso_fill") {
@@ -7907,11 +7908,11 @@ function Q_(e, t, n, r) {
     processedPoints: f || o.map((h) => ({ ...h }))
   };
 }
-function ex(e, t) {
+function ix(e, t) {
   if (!e || typeof e != "object" || String(e.layerKind || "") !== t) return null;
-  const n = J_(e.targetSpace);
+  const n = tx(e.targetSpace);
   if (!n) return null;
-  const r = String(e.toolKind || "").trim(), a = Q_(e.geometry, n, r, t === "paint");
+  const r = String(e.toolKind || "").trim(), a = rx(e.geometry, n, r, t === "paint");
   if (!a) return null;
   const o = bt(e.size, null), c = bt(e.opacity, null);
   if (o == null || c == null) return null;
@@ -7948,23 +7949,23 @@ function ex(e, t) {
     geometry: a
   };
 }
-function ch(e, t) {
+function dh(e, t) {
   const n = { strokes: [] };
   if (!e || typeof e != "object" || !Array.isArray(e.strokes)) return n;
   for (const r of e.strokes) {
-    const a = ex(r, t);
+    const a = ix(r, t);
     a && n.strokes.push(a);
   }
   return n;
 }
-function tx(e) {
+function ax(e) {
   if (!e || typeof e != "object") return null;
   const t = bt(e.u0, null), n = bt(e.v0, null), r = bt(e.u1, null), a = bt(e.v1, null);
   if (t == null || n == null || r == null || a == null) return null;
   const o = (f) => Math.max(0, Math.min(1, f)), c = { u0: o(t), v0: o(n), u1: o(r), v1: o(a) };
   return c.u1 <= c.u0 || c.v1 <= c.v0 ? null : c;
 }
-function nx(e) {
+function ox(e) {
   const t = e || {};
   return {
     du: bt(t.du, 0) ?? 0,
@@ -7973,7 +7974,7 @@ function nx(e) {
     scale: Math.max(0.01, bt(t.scale, 1) ?? 1)
   };
 }
-function rx(e, t) {
+function sx(e, t) {
   if (!e || typeof e != "object" || String(e.type || "") !== "raster_frozen") return null;
   const n = String(e.id || "").trim();
   if (!n) return null;
@@ -7981,7 +7982,7 @@ function rx(e, t) {
   if (r !== "paint" && r !== "mask") return null;
   const a = String(e.rasterDataUrl || "").trim();
   if (!a.startsWith("data:")) return null;
-  const o = tx(e.bbox);
+  const o = ax(e.bbox);
   return o ? {
     id: n,
     type: "raster_frozen",
@@ -7990,26 +7991,26 @@ function rx(e, t) {
     locked: e.locked === !0,
     bbox: o,
     rasterDataUrl: a,
-    transform: nx(e.transform)
+    transform: ox(e.transform)
   } : null;
 }
-function ix(e) {
+function lx(e) {
   if (!Array.isArray(e)) return [];
   const t = [], n = /* @__PURE__ */ new Set();
   for (const r of e) {
-    const a = rx(r, t.length);
+    const a = sx(r, t.length);
     !a || n.has(a.id) || (n.add(a.id), t.push(a));
   }
   return t;
 }
 function so(e) {
-  const t = q_();
+  const t = Q_();
   return !e || typeof e != "object" ? t : {
     version: 1,
-    groups: X_(e.groups),
-    paint: ch(e.paint, "paint"),
-    mask: ch(e.mask, "mask"),
-    raster_objects: ix(e.raster_objects)
+    groups: ex(e.groups),
+    paint: dh(e.paint, "paint"),
+    mask: dh(e.mask, "mask"),
+    raster_objects: lx(e.raster_objects)
   };
 }
 let ts = { text: null, parsed: null };
@@ -8024,7 +8025,7 @@ function Vu(e) {
     preview_quality: n === "draft" || n === "balanced" || n === "high" ? n : "balanced"
   };
 }
-function ax({
+function ux({
   outputPreset: e = 2048,
   backgroundColor: t = "#00ff00",
   coverage: n = 360,
@@ -8046,44 +8047,44 @@ function ax({
     active: { selected_sticker_id: null, selected_shot_id: null }
   };
 }
-function ox(e, t = 2048) {
+function cx(e, t = 2048) {
   if (typeof e == "number" && Number.isFinite(e)) return Math.round(e);
   const n = String(e ?? "").trim();
   if (!n) return t;
   const r = n.includes("x") ? n.split("x", 1)[0].trim() : n, a = Number(r);
   return Number.isFinite(a) ? Math.round(a) : t;
 }
-function sx(e) {
+function fx(e) {
   if (!e || typeof e != "object") return {};
   const t = {};
   return Object.entries(e).forEach(([n, r]) => {
     t[n] = r && typeof r == "object" ? { ...r } : r;
   }), t;
 }
-function lx(e) {
+function dx(e) {
   return Array.isArray(e) ? e.map((t) => {
     if (!t || typeof t != "object") return t;
     const n = { ...t };
     return n.crop && typeof n.crop == "object" && (n.crop = { ...n.crop }), n.initial_pose && typeof n.initial_pose == "object" && (n.initial_pose = { ...n.initial_pose }), n.visible = n.visible !== !1, n.locked = n.locked === !0, n;
   }) : [];
 }
-function ux(e) {
-  return Array.isArray(e) ? e.map((t) => um(t)) : [];
+function hx(e) {
+  return Array.isArray(e) ? e.map((t) => hm(t)) : [];
 }
-function cx(e, t) {
+function px(e, t) {
   const n = Array.isArray(e) ? e : [];
   if (n.length === 0) return { shots: [], selectedShotId: null };
   const r = String(t || ""), a = n.find((c) => String((c == null ? void 0 : c.id) || "") === r) || n[0], o = String((a == null ? void 0 : a.id) || "") || null;
   return { shots: [a], selectedShotId: o };
 }
-function Rm(e, t = {}) {
+function jm(e, t = {}) {
   const n = {
     outputPreset: 2048,
     backgroundColor: "#00ff00",
     coverage: 360,
     sharedUiSettings: null,
     ...t
-  }, r = ax(n), a = String(e || "").trim();
+  }, r = ux(n), a = String(e || "").trim();
   if (!a) return r;
   try {
     let o = null;
@@ -8094,15 +8095,15 @@ function Rm(e, t = {}) {
       version: 1,
       projection_model: "pinhole_rectilinear",
       alpha_mode: "straight",
-      assets: sx(o.assets),
-      stickers: lx(o.stickers),
-      shots: ux(o.shots),
+      assets: fx(o.assets),
+      stickers: dx(o.stickers),
+      shots: hx(o.shots),
       painting: so(o.painting),
       painting_layer: o.painting_layer && typeof o.painting_layer == "object" ? o.painting_layer : null,
       ui_settings: Vu(o.ui_settings),
       active: o.active && typeof o.active == "object" ? { ...o.active } : { ...r.active }
     };
-    return c && (f.ui_settings = Vu({ ...f.ui_settings, ...c })), f.output_preset = ox(
+    return c && (f.ui_settings = Vu({ ...f.ui_settings, ...c })), f.output_preset = cx(
       n.outputPreset,
       Number(f.output_preset || r.output_preset)
     ), f.bg_color = String(n.backgroundColor || f.bg_color || r.bg_color), f.coverage = ln(n.coverage), delete f.editor_history, f;
@@ -8110,7 +8111,7 @@ function Rm(e, t = {}) {
     return ts = { text: a, parsed: null }, r;
   }
 }
-function fh(e) {
+function hh(e) {
   if (!e || typeof e != "object") return e;
   const t = JSON.parse(JSON.stringify(e));
   return delete t.editor_history, delete t.painting_layer, t;
@@ -8120,20 +8121,20 @@ function Ur(e, t) {
   var n;
   return ((n = e == null ? void 0 : e.widgets) == null ? void 0 : n.find((r) => (r == null ? void 0 : r.name) === t)) || null;
 }
-function fx(e) {
+function mx(e) {
   var c, f;
   const t = Ur(e, Ks);
   if (!t) return !1;
   const n = String(t.value ?? "").trim();
   if (n && n !== "{}") return !1;
-  const r = Rm(n, {
+  const r = jm(n, {
     coverage: (c = Ur(e, "coverage")) == null ? void 0 : c.value
-  }), a = vm(r, { type: "add-frame" });
+  }), a = wm(r, { type: "add-frame" });
   if (!a.changed) return !1;
   const o = JSON.stringify(a.state);
   return t.value = o, (f = t.callback) == null || f.call(t, o), !0;
 }
-function Fc(e, t) {
+function Rc(e, t) {
   if (!e || e.__panoCoverageWidgetSyncInstalled) return;
   const n = Ur(e, "coverage");
   if (!n) return;
@@ -8144,23 +8145,23 @@ function Fc(e, t) {
     return e.__panoStateCache = null, e.__panoLiveStateOverride = null, e.__panoWrappedErpCache = null, e.__panoPanoBackgroundCache = null, (f = (c = e.__panoPreviewNodeRuntime) == null ? void 0 : c.requestDraw) == null || f.call(c), (g = (h = e.__panoDomPreview) == null ? void 0 : h.requestDraw) == null || g.call(h), (v = e.setDirtyCanvas) == null || v.call(e, !0, !0), (S = (x = e.graph) == null ? void 0 : x.setDirtyCanvas) == null || S.call(x, !0, !0), (b = (M = t == null ? void 0 : t.canvas) == null ? void 0 : M.setDirty) == null || b.call(M, !0, !0), o;
   }, e.__panoCoverageWidgetSyncInstalled = !0;
 }
-function dx(e) {
+function gx(e) {
   const t = String(e ?? "").trim();
   return /^#?[0-9a-fA-F]{6}$/.test(t) || /^#?[0-9a-fA-F]{3}$/.test(t);
 }
-function dh(e) {
+function ph(e) {
   const t = String(e ?? "").trim();
   return t.startsWith("{") && t.endsWith("}");
 }
-function hx(e) {
+function bx(e) {
   var v, x, S, M, b, O;
   if (!e) return;
   const t = Ur(e, "coverage"), n = Ur(e, "bg_color"), r = Ur(e, Ks), a = Ur(e, "sticker_state");
   if (!t || !n || !r) return;
   const o = String(t.value ?? "").trim(), c = String(n.value ?? "").trim(), f = String(r.value ?? "").trim();
-  if (!(!/^(180|360)$/.test(o) && dx(o) && (dh(c) || c === ""))) return;
+  if (!(!/^(180|360)$/.test(o) && gx(o) && (ph(c) || c === ""))) return;
   let g = "360";
-  if (dh(c))
+  if (ph(c))
     try {
       g = String(ln((v = JSON.parse(c)) == null ? void 0 : v.coverage));
     } catch {
@@ -8189,7 +8190,7 @@ function Hu(e, t, n) {
   }
   return a = e.addWidget("button", t, null, n), a && (a.serialize = !1), a;
 }
-async function px(e, { tolerateOperationFailure: t = !1 } = {}) {
+async function yx(e, { tolerateOperationFailure: t = !1 } = {}) {
   const n = e == null ? void 0 : e.__panoPendingStickerUploads;
   if (n instanceof Map)
     for (; n.size > 0; ) {
@@ -8215,22 +8216,22 @@ function Uu(e, t, n) {
     e.__panoStickerOperationTail === c && (e.__panoStickerOperationTail = null);
   }), o;
 }
-async function Lm(e, t = {}) {
+async function Vm(e, t = {}) {
   var r;
-  await px(e, t);
+  await yx(e, t);
   const n = (e == null ? void 0 : e.__panoStateFlushers) instanceof Set ? Array.from(e.__panoStateFlushers) : [];
   for (const a of n) await a();
   await ((r = e == null ? void 0 : e.__panoFlushStateBeforeQueue) == null ? void 0 : r.call(e));
 }
-function mx(e, t) {
+function vx(e, t) {
   if (!t || t.__panoQueueBarrierInstalled) return;
   t.__panoQueueBarrierInstalled = !0;
   const n = typeof t.serializeValue == "function" ? t.serializeValue : null;
   t.serializeValue = async function(...r) {
-    return await Lm(e), n ? n.apply(this, r) : this.value;
+    return await Vm(e), n ? n.apply(this, r) : this.value;
   };
 }
-function gx(e) {
+function _x(e) {
   var t, n;
   try {
     (t = e.__panoDomRestore) == null || t.call(e);
@@ -8242,7 +8243,7 @@ function gx(e) {
   }
   e.__panoDomPreview = null, e.__panoLegacyPreviewHooked = !1, e.__panoPreviewHooked = !1, e.__panoPreviewAttached = !1, e.__panoPreviewMountKey = null;
 }
-function hh(e, {
+function mh(e, {
   app: t,
   matchType: n,
   buttonText: r,
@@ -8256,9 +8257,9 @@ function hh(e, {
     var S;
     const v = `editor_btn|${n}`;
     if (g.__panoPreviewAttached === !0 && g.__panoPreviewMountKey === v) return;
-    gx(g), Fc(g, t), Ps(g, Ks);
+    _x(g), Rc(g, t), Ps(g, Ks);
     const x = Ur(g, Ks);
-    if (mx(g, x), x && !x.__panoPreviewPatchedCb) {
+    if (vx(g, x), x && !x.__panoPreviewPatchedCb) {
       x.__panoPreviewPatchedCb = !0;
       const M = x.callback;
       x.callback = (b) => {
@@ -8285,11 +8286,11 @@ function hh(e, {
     const v = e.prototype[g];
     e.prototype[g] = function() {
       const x = v ? v.apply(this, arguments) : void 0;
-      return g === "onNodeCreated" && n === "PanoramaCutout" && fx(this), g === "onConfigure" && n === "PanoramaStickers" && this.widgets && hx(this), (g === "onNodeCreated" || this.widgets) && h(this), x;
+      return g === "onNodeCreated" && n === "PanoramaCutout" && mx(this), g === "onConfigure" && n === "PanoramaStickers" && this.widgets && bx(this), (g === "onNodeCreated" || this.widgets) && h(this), x;
     };
   }
 }
-function bx(e) {
+function xx(e) {
   if (!(e != null && e.prototype)) return;
   const t = e.prototype.onNodeCreated;
   e.prototype.onNodeCreated = function() {
@@ -8297,7 +8298,7 @@ function bx(e) {
     return (!Array.isArray(this.size) || this.size[0] < 10 || this.size[1] < 10) && (this.size = [360, 260]), n;
   };
 }
-function yx(e, {
+function Sx(e, {
   app: t,
   openEditor: n,
   attachPreview: r,
@@ -8311,7 +8312,7 @@ function yx(e, {
       a(o);
       return;
     }
-    Fc(e, t);
+    Rc(e, t);
     const h = (g = e) => n(g, "stickers", { readOnly: !0, hideSidebar: !1 });
     Hu(e, "Open Preview", () => h(e)), r(e, {
       buttonText: "Open Preview",
@@ -8322,7 +8323,7 @@ function yx(e, {
   };
   a(o);
 }
-function vx({
+function wx({
   app: e,
   openEditor: t,
   attachStickers: n,
@@ -8335,7 +8336,7 @@ function vx({
     name: "ComfyUI.PanoramaSuite.Editor",
     beforeRegisterNodeDef(f, h) {
       const g = String((h == null ? void 0 : h.name) || "");
-      (g === "PanoramaStickers" || g === "Panorama Stickers") && hh(f, {
+      (g === "PanoramaStickers" || g === "Panorama Stickers") && mh(f, {
         app: e,
         matchType: "PanoramaStickers",
         buttonText: "Open Stickers Editor",
@@ -8343,7 +8344,7 @@ function vx({
         attachStickers: n,
         attachCutout: r,
         enableStickersPreview: c
-      }), (g === "PanoramaCutout" || g === "Panorama Cutout") && hh(f, {
+      }), (g === "PanoramaCutout" || g === "Panorama Cutout") && mh(f, {
         app: e,
         matchType: "PanoramaCutout",
         buttonText: "Open Cutout Editor",
@@ -8351,26 +8352,26 @@ function vx({
         attachStickers: n,
         attachCutout: r,
         enableStickersPreview: c
-      }), Hs(g) && bx(f);
+      }), Hs(g) && xx(f);
     },
     nodeCreated(f) {
       const h = String((f == null ? void 0 : f.comfyClass) || (f == null ? void 0 : f.type) || (f == null ? void 0 : f.title) || "");
-      Fc(f, e), Hs(h) && yx(f, { app: e, openEditor: t, attachPreview: a, requestFrame: o });
+      Rc(f, e), Hs(h) && Sx(f, { app: e, openEditor: t, attachPreview: a, requestFrame: o });
     }
   };
 }
-const _x = /\.(png|jpe?g|webp|gif|bmp)$/i;
+const kx = /\.(png|jpe?g|webp|gif|bmp)$/i;
 function Sr(e) {
-  return e ? String(e.type || "").toLowerCase().startsWith("image/") ? !0 : _x.test(String(e.name || "")) : !1;
+  return e ? String(e.type || "").toLowerCase().startsWith("image/") ? !0 : kx.test(String(e.name || "")) : !1;
 }
-function Rc(e) {
+function Lc(e) {
   var t;
   return e ? (t = e.items) != null && t.length ? Array.from(e.items).some((n) => {
     const r = String((n == null ? void 0 : n.type) || "").trim().toLowerCase();
     return (n == null ? void 0 : n.kind) === "file" && (!r || r.startsWith("image/") || r === "application/octet-stream");
   }) : Array.from(e.files || []).some((n) => Sr(n)) : !1;
 }
-function xx(e, t = {}) {
+function Nx(e, t = {}) {
   if (!(e != null && e.addEventListener) || !(e != null && e.removeEventListener)) return () => {
   };
   const n = typeof t.onActive == "function" ? t.onActive : () => {
@@ -8379,7 +8380,7 @@ function xx(e, t = {}) {
     var g, v, x;
     (g = h == null ? void 0 : h.preventDefault) == null || g.call(h), (v = h == null ? void 0 : h.stopPropagation) == null || v.call(h), (x = h == null ? void 0 : h.stopImmediatePropagation) == null || x.call(h);
   }, o = (h) => {
-    if (Rc(h == null ? void 0 : h.dataTransfer)) {
+    if (Lc(h == null ? void 0 : h.dataTransfer)) {
       a(h);
       try {
         h.dataTransfer.dropEffect = "copy";
@@ -8443,7 +8444,7 @@ async function As(e, { fetchApi: t } = {}) {
   };
 }
 const Za = /* @__PURE__ */ new WeakMap();
-function zm(e, t) {
+function Hm(e, t) {
   if (!e || typeof t != "function") return () => {
   };
   let n = Za.get(e);
@@ -8464,23 +8465,29 @@ function Qa(e, ...t) {
   const n = Za.get(e), r = n == null ? void 0 : n[n.length - 1];
   return r ? (r.handler(...t), !0) : !1;
 }
-const ph = /* @__PURE__ */ new WeakSet();
+const gh = /* @__PURE__ */ new WeakSet(), bh = /* @__PURE__ */ new WeakSet();
+let yh = 0;
+function Gu(e) {
+  if (!e || typeof e != "object" || bh.has(e)) return e;
+  const t = String(e.type || "preview");
+  return yh += 1, e.type = `${t}:pano-${yh}`, bh.add(e), e;
+}
 function Ws(e) {
-  if (!e || typeof e != "object" || ph.has(e)) return e;
+  if (!e || typeof e != "object" || gh.has(e)) return e;
   const t = typeof e.onRemove == "function" ? e.onRemove : null;
   let n = !1;
   return e.onRemove = function(...r) {
     if (!n)
       return n = !0, t == null ? void 0 : t.apply(this, r);
-  }, ph.add(e), e;
+  }, gh.add(e), e;
 }
-function $m(e, t) {
+function Um(e, t) {
   var r, a;
   if (!t || ((a = (r = Ws(t)) == null ? void 0 : r.onRemove) == null || a.call(r), !Array.isArray(e == null ? void 0 : e.widgets))) return !1;
   const n = e.widgets.indexOf(t);
   return n < 0 ? !1 : (e.widgets.splice(n, 1), Array.isArray(e.widgets_values) && e.widgets_values.length > n && e.widgets_values.splice(n, 1), !0);
 }
-function Sx({ requestFrame: e, cancelFrame: t, restore: n } = {}) {
+function Mx({ requestFrame: e, cancelFrame: t, restore: n } = {}) {
   let r = 0, a = null, o = !1;
   return { schedule: (h) => o || r || typeof e != "function" ? !1 : (a = h, r = e(() => {
     r = 0;
@@ -8490,15 +8497,15 @@ function Sx({ requestFrame: e, cancelFrame: t, restore: n } = {}) {
     o || (o = !0, r && typeof t == "function" && t(r), r = 0, a = null);
   } };
 }
-const { app: $t } = gs, Lc = G_();
-function Gu() {
+const { app: $t } = gs, zc = q_();
+function Ku() {
   var e, t;
   return String(
     ((t = (e = window == null ? void 0 : window.comfyAPI) == null ? void 0 : e.app) == null ? void 0 : t.ANIM_PREVIEW_WIDGET) || (gs == null ? void 0 : gs.ANIM_PREVIEW_WIDGET) || "$$comfy_animation_preview"
   );
 }
-const Ys = Math.PI / 180, wx = {}, kx = { Nu: 24, Nv: 14 }, Nx = 10, Mx = "pano_suite.ui_settings.v1", Px = 120;
-function mh() {
+const Ys = Math.PI / 180, Px = {}, Ax = { Nu: 24, Nv: 14 }, Cx = 10, Tx = "pano_suite.ui_settings.v1", Ix = 120;
+function vh() {
   var t;
   const e = {
     invert_view_x: !1,
@@ -8506,7 +8513,7 @@ function mh() {
     preview_quality: "balanced"
   };
   try {
-    const n = String(((t = window == null ? void 0 : window.localStorage) == null ? void 0 : t.getItem(Mx)) || "").trim();
+    const n = String(((t = window == null ? void 0 : window.localStorage) == null ? void 0 : t.getItem(Tx)) || "").trim();
     if (!n) return e;
     const r = JSON.parse(n), a = String((r == null ? void 0 : r.preview_quality) || "balanced");
     return {
@@ -8518,7 +8525,7 @@ function mh() {
     return e;
   }
 }
-function Ax() {
+function Ex() {
   var e;
   try {
     return (window == null ? void 0 : window.__PANO_PREVIEW_DEBUG__) === !0 ? !0 : String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem("panoPreviewDebug")) || "").trim() === "1";
@@ -8545,7 +8552,7 @@ function Ga(e) {
     styleTransform: String(((c = e.style) == null ? void 0 : c.transform) || "")
   };
 }
-function Cx() {
+function Dx() {
   if (document.getElementById("pano-node-preview-mode-style")) return;
   const e = document.createElement("style");
   e.id = "pano-node-preview-mode-style", e.textContent = `
@@ -8566,7 +8573,7 @@ function Cx() {
     }
   `, document.head.appendChild(e);
 }
-function Ku(e) {
+function Wu(e) {
   const t = e == null ? void 0 : e.size;
   if (t == null) return null;
   const n = (r, a) => {
@@ -8589,41 +8596,41 @@ function Ku(e) {
   }
   return null;
 }
-function jm(e) {
-  const t = Ku(e);
+function Bm(e) {
+  const t = Wu(e);
   return !t || t[0] < 10 || t[1] < 10;
 }
-function Tx(e, t, n) {
-  jm(e) && (e.size = [Math.max(1, Number(t)), Math.max(1, Number(n))]);
+function Ox(e, t, n) {
+  Bm(e) && (e.size = [Math.max(1, Number(t)), Math.max(1, Number(n))]);
 }
-function Wu(e) {
+function Yu(e) {
   var t;
   return e != null && e.__panoLegacyPreviewHooked ? "legacy_draw" : (t = e == null ? void 0 : e.__panoDomPreview) != null && t.widget ? "dom" : "none";
 }
-function zc(e) {
+function $c(e) {
   return String((e == null ? void 0 : e.comfyClass) || (e == null ? void 0 : e.type) || (e == null ? void 0 : e.title) || "");
 }
-function Vm(e) {
-  return Hs(zc(e));
+function Gm(e) {
+  return Hs($c(e));
 }
-function gh(e = null) {
+function _h(e = null) {
   var o, c;
   const t = String((window == null ? void 0 : window.__COMFYUI_FRONTEND_VERSION__) || "unknown"), n = String((window == null ? void 0 : window.__PANO_PREVIEW_FORCE_PATH__) || ""), r = typeof (e == null ? void 0 : e.addDOMWidget) == "function" ? "dom_widget" : "no_dom_widget", a = String(((c = (o = $t == null ? void 0 : $t.canvas) == null ? void 0 : o.constructor) == null ? void 0 : c.name) || "");
   return [t, r, n, a].join("|");
 }
-function Hm(e) {
+function Km(e) {
   if (e != null && e.__panoPreviewController) return e.__panoPreviewController;
   const t = {
     activeBackend: "none",
     attach(n = {}) {
-      const r = String(n.mode || "stickers") === "cutout" ? "cutout" : "stickers", a = "dom", o = Wu(e);
+      const r = String(n.mode || "stickers") === "cutout" ? "cutout" : "stickers", a = "dom", o = Yu(e);
       this.activeBackend = o;
       const c = String(e.__panoPreviewMode || "stickers") === "cutout" ? "cutout" : "stickers", f = e.__panoPreviewNoPreview === !0, h = n.noPreview === !0;
       if (o === a && o !== "none" && c === r && f === h) {
         e.__panoAttachOptions = { ...n, mode: r }, e.__panoPreviewMode = r, e.__panoPreviewNoPreview = h, e.__panoPreviewButtonText = String(n.buttonText || (r === "cutout" ? "Open Cutout Editor" : "Open Stickers Editor")), e.__panoOpenEditor = typeof n.onOpen == "function" ? n.onOpen : e.__panoOpenEditor;
         return;
       }
-      o !== "none" && Cs(e), vS(e, { ...n, mode: r, __panoForcedPath: a }), this.activeBackend = Wu(e);
+      o !== "none" && Cs(e), wS(e, { ...n, mode: r, __panoForcedPath: a }), this.activeBackend = Yu(e);
     },
     rebind(n = {}) {
       const r = String(n.mode || (e == null ? void 0 : e.__panoPreviewMode) || "stickers") === "cutout" ? "cutout" : "stickers";
@@ -8635,7 +8642,7 @@ function Hm(e) {
   };
   return e.__panoPreviewController = t, t;
 }
-function Ix(e) {
+function Fx(e) {
   if (!(e != null && e.__panoDomMountProbe)) return;
   const t = e.__panoDomMountProbe;
   t.cancelled = !0, t.timeoutId && (clearTimeout(t.timeoutId), t.timeoutId = 0), e.__panoDomMountProbe = null;
@@ -8643,7 +8650,7 @@ function Ix(e) {
 function Cs(e, t = {}) {
   var r, a, o, c, f;
   if (!e) return;
-  Yu.unregister(e), Ix(e), e.__panoDomPreview, e.__panoLegacyPreviewHooked, e.__panoDomRestore, e.__panoLegacyRestore;
+  qu.unregister(e), Fx(e), e.__panoDomPreview, e.__panoLegacyPreviewHooked, e.__panoDomRestore, e.__panoLegacyRestore;
   const n = e.__panoDomPreview;
   try {
     (r = e.__panoDomRestore) == null || r.call(e);
@@ -8667,9 +8674,9 @@ function Cs(e, t = {}) {
   try {
     Array.isArray(e.widgets) && e.widgets.filter((g) => {
       if (g === (n == null ? void 0 : n.widget)) return !0;
-      const v = String((g == null ? void 0 : g.name) || ""), x = String((g == null ? void 0 : g.type) || ""), S = Gu();
+      const v = String((g == null ? void 0 : g.name) || ""), x = String((g == null ? void 0 : g.type) || ""), S = Ku();
       return v === S || x === S || v === "pano_preview" || x === "pano_preview" ? !0 : v === "preview" && x === "pano_preview";
-    }).forEach((g) => Jx(e, g));
+    }).forEach((g) => tS(e, g));
   } catch {
   }
   e.__panoDomPreview = null, e.__panoLegacyPreviewHooked = !1, e.__panoPreviewHooked = !1, e.__panoPreviewDrag = null, e.__panoPreviewInertia = null, e.__panoDomHealth = null, e.__panoDomProbePending = !1, e.__panoDomMountProbe = null, e.__panoPreviewNoPreview = !1, e.__panoBootMinHeightTimer && (clearTimeout(e.__panoBootMinHeightTimer), e.__panoBootMinHeightTimer = null), e.__panoBootMinHeightActive = !1, e.__panoActiveBackend = "none", String(t.reason || ""), t.keepMonitor;
@@ -8677,7 +8684,7 @@ function Cs(e, t = {}) {
 function Ci(e, t, n) {
   return { x: e, y: t, z: n };
 }
-function bh(e, t) {
+function xh(e, t) {
   return Ci(e.x + t.x, e.y + t.y, e.z + t.z);
 }
 function ns(e, t) {
@@ -8686,7 +8693,7 @@ function ns(e, t) {
 function pu(e, t) {
   return e.x * t.x + e.y * t.y + e.z * t.z;
 }
-function yh(e, t) {
+function Sh(e, t) {
   return Ci(
     e.y * t.z - e.z * t.y,
     e.z * t.x - e.x * t.z,
@@ -8701,15 +8708,15 @@ function yi(e, t) {
   const n = e * Ys, r = t * Ys, a = Math.cos(r);
   return Ci(a * Math.sin(n), Math.sin(r), a * Math.cos(n));
 }
-function Ex(e, t, n = 0) {
+function Rx(e, t, n = 0) {
   const r = yi(e, t), a = Ci(0, 1, 0);
-  let o = yh(a, r);
+  let o = Sh(a, r);
   Math.hypot(o.x, o.y, o.z) < 1e-6 && (o = Ci(1, 0, 0)), o = rs(o);
-  let c = rs(yh(r, o));
-  const f = n * Ys, h = Math.cos(f), g = Math.sin(f), v = bh(ns(o, h), ns(c, g)), x = bh(ns(o, -g), ns(c, h));
+  let c = rs(Sh(r, o));
+  const f = n * Ys, h = Math.cos(f), g = Math.sin(f), v = xh(ns(o, h), ns(c, g)), x = xh(ns(o, -g), ns(c, h));
   return { fwd: r, right: rs(v), up: rs(x) };
 }
-function Dx(e, t = "#00ff00") {
+function Lx(e, t = "#00ff00") {
   const n = {
     version: 1,
     projection_model: "pinhole_rectilinear",
@@ -8750,33 +8757,33 @@ function Dx(e, t = "#00ff00") {
     return n;
   }
 }
-function Ox(e) {
+function zx(e) {
   var n;
   const t = e == null ? void 0 : e.__panoLiveStateOverride;
   return t && typeof t == "object" || typeof t == "string" && t.trim() ? t : String(((n = ba(e, "state_json")) == null ? void 0 : n.value) || "");
 }
 function Wn(e) {
   var f, h;
-  const t = Ox(e), n = Number((e == null ? void 0 : e.__panoLiveStateVersion) || 0), r = String(((f = ba(e, "bg_color")) == null ? void 0 : f.value) || "#1a1a1e"), a = Number(((h = ba(e, "coverage")) == null ? void 0 : h.value) || 360) === 180 ? 180 : 360, o = e.__panoStateCache;
+  const t = zx(e), n = Number((e == null ? void 0 : e.__panoLiveStateVersion) || 0), r = String(((f = ba(e, "bg_color")) == null ? void 0 : f.value) || "#1a1a1e"), a = Number(((h = ba(e, "coverage")) == null ? void 0 : h.value) || 360) === 180 ? 180 : 360, o = e.__panoStateCache;
   if (o && o.source === t && o.liveVersion === n && o.bg === r && o.coverage === a)
     return o.parsed;
-  const c = Dx(t, r);
+  const c = Lx(t, r);
   return c.coverage = a, e.__panoStateCache = { source: t, liveVersion: n, bg: r, coverage: a, parsed: c }, c;
 }
 function ba(e, t) {
   var n;
   return ((n = e.widgets) == null ? void 0 : n.find((r) => r.name === t)) || null;
 }
-function Um(e, t) {
+function Wm(e, t) {
   if (!e || t == null) return null;
   const n = e.links;
   return n ? n instanceof Map ? n.get(t) || n.get(Number(t)) || n.get(String(t)) || null : n[t] || n[String(t)] || null : null;
 }
-function Fx(e, t) {
+function $x(e, t) {
   var n, r;
   return !e || t == null ? null : typeof e.getNodeById == "function" ? e.getNodeById(t) : ((n = e._nodes_by_id) == null ? void 0 : n[t]) || ((r = e._nodes_by_id) == null ? void 0 : r[String(t)]) || null;
 }
-function Bm(e) {
+function Ym(e) {
   return e ? typeof e == "object" && !Array.isArray(e) ? {
     originId: e.origin_id ?? null,
     originSlot: Number(e.origin_slot ?? 0)
@@ -8785,7 +8792,7 @@ function Bm(e) {
     originSlot: Number(e[2] ?? 0)
   } : { originId: null, originSlot: 0 } : { originId: null, originSlot: 0 };
 }
-function Gm(e, t, n = null) {
+function qm(e, t, n = null) {
   var a, o;
   let r = null;
   try {
@@ -8799,48 +8806,48 @@ function Gm(e, t, n = null) {
       f != null && f.outputNode && (r = f.outputNode);
     } catch {
     }
-  return !r && n != null && (r = Fx(e == null ? void 0 : e.graph, n)), r;
+  return !r && n != null && (r = $x(e == null ? void 0 : e.graph, n)), r;
 }
-function Rx(e) {
+function jx(e) {
   return (Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs : []).map((n) => String((n == null ? void 0 : n.name) || "")).filter(Boolean);
 }
-function Km(e, t = []) {
-  const n = Rx(e), r = [];
+function Xm(e, t = []) {
+  const n = jx(e), r = [];
   return t.forEach((a) => {
     n.includes(String(a)) && r.push(String(a));
   }), n.forEach((a) => {
     (a === "erp_image" || a === "bg_erp") && !r.includes(a) && r.push(a);
   }), r.length ? r : t;
 }
-function vh(e) {
+function wh(e) {
   const t = String(e ?? "").trim();
   if (!t) return { full: "", tail: "" };
   const n = t.split(":").map((r) => String(r).trim()).filter(Boolean);
   return { full: t, tail: n.length ? n[n.length - 1] : t };
 }
 function qs(e, t) {
-  const n = vh(e), r = vh(t);
+  const n = wh(e), r = wh(t);
   return !n.full || !r.full ? !1 : n.full === r.full || n.tail === r.full || n.full === r.tail || n.tail === r.tail;
 }
-function Lx(e, t = ["erp_image", "bg_erp"]) {
+function Vx(e, t = ["erp_image", "bg_erp"]) {
   var h;
   const n = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs : [];
   if (!n.length) return [];
-  const a = Km(e, t).map((g) => n.findIndex((v) => String((v == null ? void 0 : v.name) || "") === String(g))).filter((g) => g >= 0), o = n.map((g, v) => ({ input: g, idx: v })).filter(({ input: g }) => String((g == null ? void 0 : g.type) || "").toUpperCase() === "IMAGE").map(({ idx: g }) => g), c = [.../* @__PURE__ */ new Set([...a, ...o])], f = [];
+  const a = Xm(e, t).map((g) => n.findIndex((v) => String((v == null ? void 0 : v.name) || "") === String(g))).filter((g) => g >= 0), o = n.map((g, v) => ({ input: g, idx: v })).filter(({ input: g }) => String((g == null ? void 0 : g.type) || "").toUpperCase() === "IMAGE").map(({ idx: g }) => g), c = [.../* @__PURE__ */ new Set([...a, ...o])], f = [];
   for (const g of c) {
-    const v = Gm(e, g);
+    const v = qm(e, g);
     if ((v == null ? void 0 : v.id) != null) {
       f.push(String(v.id));
       continue;
     }
     const x = (h = n[g]) == null ? void 0 : h.link;
     if (x == null) continue;
-    const S = Um(e == null ? void 0 : e.graph, x), { originId: M } = Bm(S);
+    const S = Wm(e == null ? void 0 : e.graph, x), { originId: M } = Ym(S);
     M != null && f.push(String(M));
   }
   return [...new Set(f)];
 }
-const Yu = {
+const qu = {
   nodes: /* @__PURE__ */ new Set(),
   bound: !1,
   listener: null,
@@ -8852,7 +8859,7 @@ const Yu = {
         var g, v, x, S, M;
         if (!o) return;
         const c = qs(r, o == null ? void 0 : o.id);
-        Lx(o, ["erp_image", "bg_erp"]).some((b) => qs(r, b)), !(String(o.__panoPreviewMode || "") === "cutout" && !c) && (Ym(o), (v = (g = o.__panoDomPreview) == null ? void 0 : g.requestDraw) == null || v.call(g), (x = o.setDirtyCanvas) == null || x.call(o, !0, !0), (M = (S = o.graph) == null ? void 0 : S.setDirtyCanvas) == null || M.call(S, !0, !0), String(o.__panoPreviewMode || ""), String(o.__panoPreviewMode || ""), void 0);
+        Vx(o, ["erp_image", "bg_erp"]).some((b) => qs(r, b)), !(String(o.__panoPreviewMode || "") === "cutout" && !c) && (Zm(o), (v = (g = o.__panoDomPreview) == null ? void 0 : g.requestDraw) == null || v.call(g), (x = o.setDirtyCanvas) == null || x.call(o, !0, !0), (M = (S = o.graph) == null ? void 0 : S.setDirtyCanvas) == null || M.call(S, !0, !0), String(o.__panoPreviewMode || ""), String(o.__panoPreviewMode || ""), void 0);
       });
     }, bn.addEventListener("executed", this.listener), this.bound = !0);
   },
@@ -8881,11 +8888,11 @@ function Xs(e) {
   const a = `/view?${n.toString()}`;
   return typeof ((o = bn) == null ? void 0 : o.apiURL) == "function" ? bn.apiURL(a) : a;
 }
-function zx(e) {
+function Hx(e) {
   const t = String(e || "").trim();
   return t ? /^https?:\/\//i.test(t) || t.startsWith("/") || t.startsWith("blob:") || t.startsWith("data:") : !1;
 }
-function $x(e) {
+function Ux(e) {
   const n = String(e || "").trim().replaceAll("\\", "/").replace(/^\.\/+/, "").replace(/^\/+/, "");
   if (!n) return { filename: "", subfolder: "" };
   const r = n.split("/").filter(Boolean);
@@ -8893,27 +8900,27 @@ function $x(e) {
   const a = String(r.pop() || "").trim(), o = r.join("/");
   return { filename: a, subfolder: o };
 }
-function jx(e) {
+function Bx(e) {
   const t = [], n = /* @__PURE__ */ new Set();
   return e.forEach((r) => {
     const a = String(r || "").trim();
     !a || n.has(a) || (n.add(a), t.push(a));
   }), t;
 }
-function Vx(e) {
+function Gx(e) {
   const t = String(e || "").trim();
   if (!t) return [];
-  if (zx(t)) return [t];
-  const { filename: n, subfolder: r } = $x(t);
+  if (Hx(t)) return [t];
+  const { filename: n, subfolder: r } = Ux(t);
   if (!n) return [t];
   const a = ["temp", "output", "input"].map((o) => Xs({
     filename: n,
     subfolder: r,
     type: o
   }));
-  return jx([...a, t]);
+  return Bx([...a, t]);
 }
-function Hx(e) {
+function Kx(e) {
   if (!e || typeof e != "object") return "";
   const t = String(e.type || "").trim().toLowerCase();
   if (t === "dataurl") return String(e.value || "");
@@ -8944,7 +8951,7 @@ function bo(e) {
   }
   return null;
 }
-function qu(e, t, n = null) {
+function Xu(e, t, n = null) {
   const r = n || (e == null ? void 0 : e.__panoLastExecutedOutput) || bo(e == null ? void 0 : e.id), a = r != null && r.ui && Object.prototype.hasOwnProperty.call(r.ui, t) ? r.ui[t] : r == null ? void 0 : r[t];
   return Array.isArray(a) ? a[0] : a;
 }
@@ -8968,10 +8975,10 @@ function gr(e) {
   }
   return typeof (e == null ? void 0 : e.src) == "string" && e.src ? e.src : typeof (e == null ? void 0 : e.url) == "string" && e.url ? e.url : Xs(e);
 }
-function _h(e) {
+function kh(e) {
   return e ? typeof HTMLCanvasElement < "u" && e instanceof HTMLCanvasElement ? Number(e.width || 0) > 0 && Number(e.height || 0) > 0 : e instanceof HTMLVideoElement ? Number(e.videoWidth || 0) > 0 && Number(e.videoHeight || 0) > 0 && Number(e.readyState || 0) >= 2 : !!e.complete && Number(e.naturalWidth || e.width || 0) > 0 : !1;
 }
-function Wm(e) {
+function Jm(e) {
   return e ? e instanceof HTMLVideoElement ? [
     String(e.currentSrc || e.src || ""),
     Number(e.videoWidth || 0),
@@ -8985,7 +8992,7 @@ function Wm(e) {
     Number(e.naturalHeight || e.height || 0)
   ].join("|") : "";
 }
-function $c(e, t) {
+function jc(e, t) {
   var r;
   const n = String(e || "").trim();
   if (!n) return "";
@@ -8997,7 +9004,7 @@ function $c(e, t) {
     return t > 0 ? `${n}${a}pano_rev=${t}` : n;
   }
 }
-function Ux(e) {
+function Wx(e) {
   const t = [], n = /* @__PURE__ */ new Set(), r = (o) => {
     Array.isArray(o) && o.forEach((c) => t.push(c));
   }, a = (o, c = 0) => {
@@ -9005,14 +9012,14 @@ function Ux(e) {
   };
   return a(e, 0), t;
 }
-function Bx(e, t) {
+function Yx(e, t) {
   try {
-    e.__panoOwnOutputRev = U_(e.__panoOwnOutputRev);
-    const n = Ux(t);
+    e.__panoOwnOutputRev = W_(e.__panoOwnOutputRev);
+    const n = Wx(t);
     let r = "";
     for (const a of n)
       if (r = gr(a), r) break;
-    r ? (e.__panoOwnOutputSrc = String(r || ""), $c(e.__panoOwnOutputSrc, e.__panoOwnOutputRev), e.__panoOwnOutputRev, void 0) : (Object.keys(t || {}), void 0);
+    r ? (e.__panoOwnOutputSrc = String(r || ""), jc(e.__panoOwnOutputSrc, e.__panoOwnOutputRev), e.__panoOwnOutputRev, void 0) : (Object.keys(t || {}), void 0);
   } catch {
   }
 }
@@ -9020,35 +9027,35 @@ function ya(e) {
   var t, n;
   (n = (t = e == null ? void 0 : e.__panoOwnOutputVideoCache) == null ? void 0 : t.destroy) == null || n.call(t), e && (e.__panoOwnOutputVideoCache = null);
 }
-function xh(e, t = ["pano_videos"], n = null) {
+function Nh(e, t = ["pano_videos"], n = null) {
   const r = e == null ? void 0 : e.id;
   if (r == null) return null;
   if (!hl(e, "background"))
     return ya(e), null;
-  const a = bo(r), o = W_(a, t, gr);
+  const a = bo(r), o = J_(a, t, gr);
   if (!o)
     return ya(e), null;
-  const c = Number((e == null ? void 0 : e.__panoOwnOutputRev) || 0), f = $c(o, c), h = `${t.join("|")}:${f}`, g = e.__panoOwnOutputVideoCache;
+  const c = Number((e == null ? void 0 : e.__panoOwnOutputRev) || 0), f = jc(o, c), h = `${t.join("|")}:${f}`, g = e.__panoOwnOutputVideoCache;
   if (g != null && g.video && g.key === h) return g.video;
   ya(e);
-  const v = Y_({
+  const v = Z_({
     documentRef: document,
     src: f,
     onFrame: n
   });
   return v ? (e.__panoOwnOutputVideoCache = { key: h, ...v }, v.video) : null;
 }
-function Gx(e, t = []) {
+function qx(e, t = []) {
   var g, v;
   const n = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs : [];
   if (!n.length) return { src: "", sourceType: "", inputName: "" };
-  const a = Km(e, t).map((x) => n.findIndex((S) => String((S == null ? void 0 : S.name) || "") === String(x))).filter((x) => x >= 0), o = n.map((x, S) => ({ input: x, idx: S })).filter(({ input: x }) => String((x == null ? void 0 : x.type) || "").toUpperCase() === "IMAGE").map(({ idx: x }) => x), c = [.../* @__PURE__ */ new Set([...a, ...o])];
+  const a = Xm(e, t).map((x) => n.findIndex((S) => String((S == null ? void 0 : S.name) || "") === String(x))).filter((x) => x >= 0), o = n.map((x, S) => ({ input: x, idx: S })).filter(({ input: x }) => String((x == null ? void 0 : x.type) || "").toUpperCase() === "IMAGE").map(({ idx: x }) => x), c = [.../* @__PURE__ */ new Set([...a, ...o])];
   for (const x of c) {
     const S = n[x], M = S == null ? void 0 : S.link;
     if (M == null) continue;
-    const b = Um(e.graph, M), { originId: O, originSlot: j } = Bm(b);
+    const b = Wm(e.graph, M), { originId: O, originSlot: j } = Ym(b);
     if (O == null) continue;
-    const z = Gm(e, x, O);
+    const z = qm(e, x, O);
     if (!z) continue;
     const P = Number(j || 0), $ = bo((z == null ? void 0 : z.id) ?? O), I = Array.isArray($ == null ? void 0 : $.images) ? $.images : [];
     if (I.length) {
@@ -9101,10 +9108,10 @@ function Gx(e, t = []) {
     }
   return { src: "", sourceType: "", inputName: "" };
 }
-function Kx(e, t = [], n = {}) {
-  const r = Gx(e, t), a = String((r == null ? void 0 : r.src) || "").trim();
+function Xx(e, t = [], n = {}) {
+  const r = qx(e, t), a = String((r == null ? void 0 : r.src) || "").trim();
   if (!a) return null;
-  const o = Vx(a);
+  const o = Gx(a);
   if (!o.length) return null;
   const c = (n == null ? void 0 : n.preserveReadyWhilePending) !== !1;
   e.__panoLinkedInputImageCache || (e.__panoLinkedInputImageCache = /* @__PURE__ */ new Map());
@@ -9146,14 +9153,14 @@ function Kx(e, t = [], n = {}) {
     String(v.pendingResolvedSrc || v.resolvedSrc || ""), String((r == null ? void 0 : r.sourceType) || ""), String((M == null ? void 0 : M.type) || "error");
   }, S(), c && v.img && (v.img.complete || v.img.naturalWidth || v.img.width) ? v.img : g;
 }
-function Sh(e, t = [], n = null, r = {}) {
-  const a = Kx(e, t, r);
+function Mh(e, t = [], n = null, r = {}) {
+  const a = Xx(e, t, r);
   return a ? (typeof n == "function" && (a.complete && (a.naturalWidth || a.width) || a.addEventListener("load", () => n(), { once: !0 })), a) : null;
 }
-function Ym(e) {
+function Zm(e) {
   var t, n, r, a;
   if (e) {
-    Lc.disposeOwner(e);
+    zc.disposeOwner(e);
     try {
       (n = (t = e.__panoLinkedInputImageCache) == null ? void 0 : t.clear) == null || n.call(t);
     } catch {
@@ -9165,7 +9172,7 @@ function Ym(e) {
     e.__panoOwnOutputImageCache = null, ya(e), e.__panoWrappedErpCache = null;
   }
 }
-function Wx(e) {
+function Jx(e) {
   var t, n;
   if (e) {
     try {
@@ -9175,7 +9182,7 @@ function Wx(e) {
     e.__panoOwnOutputImageCache = null, ya(e), e.__panoWrappedErpCache = null;
   }
 }
-function Yx(e) {
+function Zx(e) {
   var t, n;
   if (e)
     try {
@@ -9183,7 +9190,7 @@ function Yx(e) {
     } catch {
     }
 }
-function qm(e, t) {
+function Qm(e, t) {
   e.__panoRenderCache || (e.__panoRenderCache = {
     mode: String(t || ""),
     isLoading: !1,
@@ -9193,14 +9200,14 @@ function qm(e, t) {
   return n.mode !== r && (n.mode = r, n.isLoading = !1, n.loadingSinceTs = 0), n;
 }
 function Ka(e, t, n = "") {
-  const r = qm(e, (e == null ? void 0 : e.__panoPreviewMode) || "unknown"), a = performance.now();
-  return t ? (r.isLoading || (r.isLoading = !0, r.loadingSinceTs = a), !0) : r.isLoading ? a - Number(r.loadingSinceTs || 0) < Px ? !0 : (r.isLoading = !1, r.loadingSinceTs = 0, !1) : !1;
+  const r = Qm(e, (e == null ? void 0 : e.__panoPreviewMode) || "unknown"), a = performance.now();
+  return t ? (r.isLoading || (r.isLoading = !0, r.loadingSinceTs = a), !0) : r.isLoading ? a - Number(r.loadingSinceTs || 0) < Ix ? !0 : (r.isLoading = !1, r.loadingSinceTs = 0, !1) : !1;
 }
 function mu(e, t) {
   const n = Math.max(1, Number((t == null ? void 0 : t.w) || 1)), r = Math.max(1, Number((t == null ? void 0 : t.h) || 1)), a = Math.max(1, Number((e == null ? void 0 : e.clientWidth) || n)), o = Math.max(1, Number((e == null ? void 0 : e.clientHeight) || r)), c = n / a, f = r / o, h = Math.min(c, f);
   return Number.isFinite(h) && h > 0 ? h : 1;
 }
-function qx(e, t, n = 1) {
+function Qx(e, t, n = 1) {
   const r = Number((t == null ? void 0 : t.x) || 0), a = Number((t == null ? void 0 : t.y) || 0), o = Number((t == null ? void 0 : t.w) || 0), c = Number((t == null ? void 0 : t.h) || 0);
   if (o <= 0 || c <= 0) return;
   const f = Math.max(14, Math.round(14 * n)), h = Math.min(Math.round(220 * n), Math.max(Math.round(120 * n), o * 0.44)), g = Math.max(Math.round(34 * n), f + Math.round(14 * n)), v = r + (o - h) * 0.5, x = a + (c - g) * 0.5;
@@ -9211,7 +9218,7 @@ function ta(e, t, n = "Connect ERP image") {
   const r = (a = e == null ? void 0 : e.__panoDomPreview) == null ? void 0 : a.emptyHintEl;
   r && (r.textContent = String(n || "Connect ERP image"), r.style.display = t ? "flex" : "none");
 }
-function Xx(e) {
+function eS(e) {
   var r;
   const t = Array.isArray(e == null ? void 0 : e.shots) ? e.shots : [];
   if (!t.length) return null;
@@ -9222,13 +9229,13 @@ function Xx(e) {
   }
   return t[0] || null;
 }
-function Jx(e, t) {
-  return $m(e, t);
+function tS(e, t) {
+  return Um(e, t);
 }
-function Xm(e, t, n, r = null) {
+function eg(e, t, n, r = null) {
   var S;
   if (!String(t || "")) return null;
-  let o = Hx(n);
+  let o = Kx(n);
   if (!o && (r != null && r.external)) {
     if (!hl(e, "external-sticker")) return null;
     const M = e.__panoLastExecutedOutput || bo(e == null ? void 0 : e.id), b = ((S = M == null ? void 0 : M.ui) == null ? void 0 : S.pano_sticker_input_images) || (M == null ? void 0 : M.pano_sticker_input_images) || [];
@@ -9236,28 +9243,28 @@ function Xm(e, t, n, r = null) {
       if (o = gr(O), o) break;
   }
   if (!o) return null;
-  const c = qu(e, "pano_sticker_input_state_hash"), f = r != null && r.external ? String(c ?? "") : "", h = r != null && r.external ? Number(e.__panoOwnOutputRev || 0) : 0, g = r != null && r.external ? $c(o, h) : o, v = B_(o, f, h);
-  return Lc.get(e, v, g, (M, b) => {
+  const c = Xu(e, "pano_sticker_input_state_hash"), f = r != null && r.external ? String(c ?? "") : "", h = r != null && r.external ? Number(e.__panoOwnOutputRev || 0) : 0, g = r != null && r.external ? jc(o, h) : o, v = Y_(o, f, h);
+  return zc.get(e, v, g, (M, b) => {
     var O, j;
     b && (r != null && r.external && Qa(e, "image-loaded"), (j = (O = e.__panoDomPreview) == null ? void 0 : O.requestDraw) == null || j.call(O));
   }) || null;
 }
-function Zx(e, t) {
+function nS(e, t) {
   return fl(t, {
     selectedId: null,
     hoveredId: null
   });
 }
-function Qx(e, t, n) {
-  return im(
+function rS(e, t, n) {
+  return lm(
     t,
-    (r, a, o) => Xm(e, r, a, o),
+    (r, a, o) => eg(e, r, a, o),
     { scene: n }
   );
 }
-function eS(e, t) {
+function iS(e, t) {
   var x, S, M, b;
-  const n = aS(e, t), r = oS(t), a = Array.isArray((x = t == null ? void 0 : t.painting) == null ? void 0 : x.groups) ? t.painting.groups : [], o = new Map(
+  const n = uS(e, t), r = cS(t), a = Array.isArray((x = t == null ? void 0 : t.painting) == null ? void 0 : x.groups) ? t.painting.groups : [], o = new Map(
     a.filter((O) => O && typeof O == "object").map((O) => [String((O == null ? void 0 : O.actionGroupId) || (O == null ? void 0 : O.id) || "").trim(), Number((O == null ? void 0 : O.z_index) || 0)])
   ), c = n ? r.map((O) => {
     const j = n.getGroupDisplayCanvas(O);
@@ -9272,11 +9279,11 @@ function eS(e, t) {
   }).filter(Boolean) : [], f = Array.isArray((S = t == null ? void 0 : t.painting) == null ? void 0 : S.raster_objects) ? t.painting.raster_objects : [];
   if (f.length === 0)
     return (b = (M = e.__panoRasterObjectSurfaceCache) == null ? void 0 : M.retain) == null || b.call(M, []), c;
-  e.__panoRasterObjectSurfaceCache || (e.__panoRasterObjectSurfaceCache = H_()), e.__panoRasterObjectReady || (e.__panoRasterObjectReady = () => {
+  e.__panoRasterObjectSurfaceCache || (e.__panoRasterObjectSurfaceCache = K_()), e.__panoRasterObjectReady || (e.__panoRasterObjectReady = () => {
     var O, j;
     return (j = (O = e.__panoDomPreview) == null ? void 0 : O.requestDraw) == null ? void 0 : j.call(O);
   });
-  const h = $_(t == null ? void 0 : t.output_preset), g = f.filter((O) => (O == null ? void 0 : O.visible) !== !1 && String((O == null ? void 0 : O.layerKind) || "paint") === "paint").map((O) => String((O == null ? void 0 : O.id) || ""));
+  const h = U_(t == null ? void 0 : t.output_preset), g = f.filter((O) => (O == null ? void 0 : O.visible) !== !1 && String((O == null ? void 0 : O.layerKind) || "paint") === "paint").map((O) => String((O == null ? void 0 : O.id) || ""));
   e.__panoRasterObjectSurfaceCache.retain(g);
   const v = f.map((O) => {
     const j = e.__panoRasterObjectSurfaceCache.get(
@@ -9297,7 +9304,7 @@ function eS(e, t) {
   return [...c, ...v];
 }
 function gu(e, t, n, r = "") {
-  const a = Zx(e, t), o = Qx(e, t, a), c = eS(e, t), f = Wm(n), h = Zm(n), g = Xa({
+  const a = nS(e, t), o = rS(e, t, a), c = iS(e, t), f = Jm(n), h = ng(n), g = Xa({
     stateRevision: [
       "runtime_cutout_scene",
       f,
@@ -9319,13 +9326,13 @@ function gu(e, t, n, r = "") {
   });
   return e.__panoRuntimeCore || (e.__panoRuntimeCore = ko()), e.__panoRuntimeCore.syncState(g), e.__panoRuntimeCore;
 }
-function Jm(e, t, n, r) {
+function tg(e, t, n, r) {
   const a = pu(e, t.right), o = pu(e, t.up), c = pu(e, t.fwd);
   if (c <= 1e-4) return null;
   const f = o / c / r, h = a / c / r;
   return { x: n.x + n.w * 0.5 + h * n.h * 0.5, y: n.y + n.h * 0.5 - f * n.h * 0.5 };
 }
-function tS(e, t, n, r) {
+function aS(e, t, n, r) {
   var o, c, f, h, g, v;
   if (Array.isArray(n) && n.length >= 2) return { x: n[0], y: n[1] };
   if (n && typeof n == "object" && Number.isFinite(Number(n.x)) && Number.isFinite(Number(n.y)))
@@ -9350,10 +9357,10 @@ function tS(e, t, n, r) {
       x: Number(t.canvasX) - Number(((g = e == null ? void 0 : e.pos) == null ? void 0 : g[0]) || 0),
       y: Number(t.canvasY) - Number(((v = e == null ? void 0 : e.pos) == null ? void 0 : v[1]) || 0)
     };
-  const a = rS(e, t, r);
+  const a = sS(e, t, r);
   return a || null;
 }
-function nS(e, t) {
+function oS(e, t) {
   var x, S;
   const n = Number(e == null ? void 0 : e.clientX), r = Number(e == null ? void 0 : e.clientY);
   if (!Number.isFinite(n) || !Number.isFinite(r)) return null;
@@ -9364,15 +9371,15 @@ function nS(e, t) {
   const h = Array.isArray(c.offset) ? c.offset : [0, 0], g = (n - Number(o.left || 0)) / f - Number(h[0] || 0), v = (r - Number(o.top || 0)) / f - Number(h[1] || 0);
   return !Number.isFinite(g) || !Number.isFinite(v) ? null : { x: g, y: v };
 }
-function rS(e, t, n) {
+function sS(e, t, n) {
   var a, o;
-  const r = nS(t, n || ($t == null ? void 0 : $t.canvas));
+  const r = oS(t, n || ($t == null ? void 0 : $t.canvas));
   return r ? {
     x: r.x - Number(((a = e == null ? void 0 : e.pos) == null ? void 0 : a[0]) || 0),
     y: r.y - Number(((o = e == null ? void 0 : e.pos) == null ? void 0 : o[1]) || 0)
   } : null;
 }
-function iS(e, t) {
+function lS(e, t) {
   const n = Math.max(1, Number((t == null ? void 0 : t.output_preset) || 2048));
   return {
     kind: "ERP_GLOBAL",
@@ -9380,11 +9387,11 @@ function iS(e, t) {
     height: Math.max(1, Math.round(n * 0.5))
   };
 }
-function aS(e, t) {
+function uS(e, t) {
   var g, v, x, S, M, b, O, j, z, P, $, I;
   const n = (v = (g = t == null ? void 0 : t.painting) == null ? void 0 : g.paint) == null ? void 0 : v.strokes, r = (S = (x = t == null ? void 0 : t.painting) == null ? void 0 : x.mask) == null ? void 0 : S.strokes, a = Array.isArray(n) && n.length > 0, o = Array.isArray(r) && r.length > 0;
   if (!a && !o) return null;
-  const c = iS(e, t), f = `${c.width}x${c.height}`;
+  const c = lS(e, t), f = `${c.width}x${c.height}`;
   (!e.__panoPreviewPaintEngine || e.__panoPreviewPaintDescriptorKey !== f) && (e.__panoPreviewPaintEngine = Ru(c), e.__panoPreviewPaintDescriptorKey = f, e.__panoPreviewPaintRevision = null, e.__panoPreviewPaintRevisionKey = "");
   const h = {
     paint: n || null,
@@ -9399,39 +9406,39 @@ function aS(e, t) {
     String(Array.isArray((I = t == null ? void 0 : t.painting) == null ? void 0 : I.raster_objects) ? t.painting.raster_objects.length : 0)
   ].join(":"), e.__panoPreviewPaintEngine.rebuildCommitted(t)), e.__panoPreviewPaintEngine;
 }
-function oS(e) {
+function cS(e) {
   var n;
   return (Array.isArray((n = e == null ? void 0 : e.painting) == null ? void 0 : n.groups) ? e.painting.groups : []).filter((r) => r && typeof r == "object").slice().sort((r, a) => Number((r == null ? void 0 : r.z_index) || 0) - Number((a == null ? void 0 : a.z_index) || 0)).map((r) => String((r == null ? void 0 : r.actionGroupId) || (r == null ? void 0 : r.id) || "").trim()).filter(Boolean);
 }
-function Zm(e) {
+function ng(e) {
   return {
     width: Math.max(1, Number((e == null ? void 0 : e.naturalWidth) || (e == null ? void 0 : e.videoWidth) || (e == null ? void 0 : e.width) || 0)),
     height: Math.max(1, Number((e == null ? void 0 : e.naturalHeight) || (e == null ? void 0 : e.videoHeight) || (e == null ? void 0 : e.height) || 0))
   };
 }
-function sS(e, t, n, r) {
-  const a = Fm(t, n, r);
+function fS(e, t, n, r) {
+  const a = $m(t, n, r);
   if (!a.visible) return null;
-  const o = E_(t);
-  return e.save(), Im(e, a.boundaryEdges, { selected: !0 }), Em(e, a, { accent: o }), e.restore(), a;
+  const o = R_(t);
+  return e.save(), Fm(e, a.boundaryEdges, { selected: !0 }), Rm(e, a, { accent: o }), e.restore(), a;
 }
-function lS(e, t, n, r = null) {
+function dS(e, t, n, r = null) {
   var M, b, O, j, z, P, $, I, R, G, H, se, ie, T, q, re;
   const a = String(e.__panoPreviewMode || "stickers");
-  qm(e, a);
+  Qm(e, a);
   const o = Wn(e);
   a === "cutout" && e.__panoCutoutNodeSurfaceState !== o ? (e.__panoCutoutNodeSurfaceState = o, (O = (b = (M = e.__panoCutoutNodeSurface) == null ? void 0 : M.session) == null ? void 0 : b.refresh) == null || O.call(b)) : a === "stickers" && e.__panoStickersNodeSurfaceState !== o && (e.__panoStickersNodeSurfaceState = o, (P = (z = (j = e.__panoStickersNodeSurface) == null ? void 0 : j.session) == null ? void 0 : z.refresh) == null || P.call(z));
   const c = t.parentElement, f = 1, h = Math.max(1, Number((c == null ? void 0 : c.clientWidth) || t.clientWidth || 0)), g = Math.max(1, Number((c == null ? void 0 : c.clientHeight) || t.clientHeight || 0)), v = Math.max(64, Math.round(h * f)), x = Math.max(64, Math.round(g * f)), S = t.getContext("2d");
   if (S)
     if (a === "cutout") {
-      const J = Xx(o), de = xh(
+      const J = eS(o), de = Nh(
         e,
         ["pano_input_videos"],
         () => {
           var Ye, Ve;
           return (Ve = (Ye = e.__panoDomPreview) == null ? void 0 : Ye.requestDraw) == null ? void 0 : Ve.call(Ye);
         }
-      ) || Sh(
+      ) || Mh(
         e,
         ["erp_image", "bg_erp"],
         () => {
@@ -9439,16 +9446,16 @@ function lS(e, t, n, r = null) {
           return (Ve = (Ye = e.__panoDomPreview) == null ? void 0 : Ye.requestDraw) == null ? void 0 : Ve.call(Ye);
         },
         { preserveReadyWhilePending: !1 }
-      ), ce = _h(de);
+      ), ce = kh(de);
       (t.width !== v || t.height !== x) && (t.width = v, t.height = x);
-      const we = { x: 0, y: 0, w: v, h: x }, A = Zm(de), xe = ce ? W(Number(A.width / A.height), 0.05, 20) : 1, Ae = J ? vr(J) : null, Ne = W(Number((Ae == null ? void 0 : Ae.aspect) || xe || 1), 0.05, 20), U = Tc(we, Ne);
+      const we = { x: 0, y: 0, w: v, h: x }, A = ng(de), xe = ce ? W(Number(A.width / A.height), 0.05, 20) : 1, Ae = J ? vr(J) : null, Ne = W(Number((Ae == null ? void 0 : Ae.aspect) || xe || 1), 0.05, 20), U = Ic(we, Ne);
       e.__panoCutoutNodeFrame = U, mu(t, we), S.setTransform(1, 0, 0, 1, 0, 0), S.fillStyle = "#070707", S.fillRect(0, 0, v, x);
       let je = "none", mt = "Connect ERP image", nt = "";
       if (nt = String((de == null ? void 0 : de.currentSrc) || (de == null ? void 0 : de.src) || ""), J)
         if (de && !ce)
           je = "loading";
         else if (ce) {
-          const Ye = gu(e, o, de, (J == null ? void 0 : J.id) || ""), Ve = t_({ width: v, height: x }, U, J), qt = Ve.rect, An = vr(Ve.shot);
+          const Ye = gu(e, o, de, (J == null ? void 0 : J.id) || ""), Ve = a_({ width: v, height: x }, U, J), qt = Ve.rect, An = vr(Ve.shot);
           let Sn = !0;
           if (Ve.fallback) {
             const L = Ve.fallback.rect, V = vr(Ve.fallback.shot);
@@ -9476,7 +9483,7 @@ function lS(e, t, n, r = null) {
           je = "empty", mt = "Connect ERP image";
       else {
         const Ye = e.__panoLastCutoutShot;
-        if (Ye ? (e.__panoPreviewView = ym(Ye, { width: v, height: x }), e.__panoLastCutoutShot = null) : e.__panoPreviewView || (e.__panoPreviewView = { yaw: 0, pitch: 0, fov: 100 }), ce) {
+        if (Ye ? (e.__panoPreviewView = Sm(Ye, { width: v, height: x }), e.__panoLastCutoutShot = null) : e.__panoPreviewView || (e.__panoPreviewView = { yaw: 0, pitch: 0, fov: 100 }), ce) {
           const Ve = gu(e, o, de, "zero_shot_viewer"), qt = ((I = ($ = r == null ? void 0 : r.state) == null ? void 0 : $.drag) == null ? void 0 : I.active) === !0 || ((G = (R = r == null ? void 0 : r.state) == null ? void 0 : R.inertia) == null ? void 0 : G.active) === !0 ? 0.5 : 1;
           Ve.renderToContext(
             S,
@@ -9491,14 +9498,14 @@ function lS(e, t, n, r = null) {
       ta(e, !1), (t.width !== v || t.height !== x) && (t.width = v, t.height = x);
       const J = { x: 0, y: 0, w: v, h: x };
       S.setTransform(1, 0, 0, 1, 0, 0), S.fillStyle = "#070707", S.fillRect(0, 0, v, x), e.__panoPreviewView || (e.__panoPreviewView = { yaw: 0, pitch: 0, fov: 100 });
-      const de = xh(
+      const de = Nh(
         e,
         ["pano_input_videos"],
         () => {
           var Ae, Ne;
           return (Ne = (Ae = e.__panoDomPreview) == null ? void 0 : Ae.requestDraw) == null ? void 0 : Ne.call(Ae);
         }
-      ) || Sh(
+      ) || Mh(
         e,
         ["erp_image", "bg_erp"],
         () => {
@@ -9506,10 +9513,10 @@ function lS(e, t, n, r = null) {
           return (Ne = (Ae = e.__panoDomPreview) == null ? void 0 : Ae.requestDraw) == null ? void 0 : Ne.call(Ae);
         },
         { preserveReadyWhilePending: !1 }
-      ), ce = de || null, we = !de || _h(ce), A = mo(e.__panoPreviewView, o == null ? void 0 : o.coverage);
+      ), ce = de || null, we = !de || kh(ce), A = mo(e.__panoPreviewView, o == null ? void 0 : o.coverage);
       let xe = !1;
       if (we) {
-        const Ne = gu(e, o, ce, de ? "stickers_surface|background:input" : "stickers_surface|background:none"), U = hS(e) || ((se = (H = r == null ? void 0 : r.state) == null ? void 0 : H.drag) == null ? void 0 : se.active) === !0 || ((T = (ie = r == null ? void 0 : r.state) == null ? void 0 : ie.inertia) == null ? void 0 : T.active) === !0 || ((q = e.__panoStickerDrag) == null ? void 0 : q.active) === !0;
+        const Ne = gu(e, o, ce, de ? "stickers_surface|background:input" : "stickers_surface|background:none"), U = bS(e) || ((se = (H = r == null ? void 0 : r.state) == null ? void 0 : H.drag) == null ? void 0 : se.active) === !0 || ((T = (ie = r == null ? void 0 : r.state) == null ? void 0 : ie.inertia) == null ? void 0 : T.active) === !0 || ((q = e.__panoStickerDrag) == null ? void 0 : q.active) === !0;
         xe = Ne.renderToContext(
           S,
           J,
@@ -9521,24 +9528,24 @@ function lS(e, t, n, r = null) {
         Ka(e, !1, "");
       else {
         const Ae = !!de && !we;
-        Ka(e, Ae, String((ce == null ? void 0 : ce.currentSrc) || (ce == null ? void 0 : ce.src) || "")), Ae && qx(S, J, mu(t, J)), ta(e, !1);
+        Ka(e, Ae, String((ce == null ? void 0 : ce.currentSrc) || (ce == null ? void 0 : ce.src) || "")), Ae && Qx(S, J, mu(t, J)), ta(e, !1);
       }
       if (!de && xe) {
-        const Ae = W(Number(A.fovDeg || 100), 1, 179) * Ys, Ne = Math.tan(Ae * 0.5) * (J.h / Math.max(1, J.w)), U = Ex(Number(A.yawDeg || 0), Number(A.pitchDeg || 0), 0);
-        cS(S, J, U, Ne, mu(t, J));
+        const Ae = W(Number(A.fovDeg || 100), 1, 179) * Ys, Ne = Math.tan(Ae * 0.5) * (J.h / Math.max(1, J.w)), U = Rx(Number(A.yawDeg || 0), Number(A.pitchDeg || 0), 0);
+        pS(S, J, U, Ne, mu(t, J));
       }
       if (xe) {
         ta(e, !1);
         const Ae = String(((re = o == null ? void 0 : o.active) == null ? void 0 : re.selected_sticker_id) || ""), Ne = (Array.isArray(o == null ? void 0 : o.stickers) ? o.stickers : []).find((U) => String((U == null ? void 0 : U.id) || "") === Ae && (U == null ? void 0 : U.visible) !== !1);
-        e.__panoSelectedStickerGeometry = Ne ? sS(S, Ne, A, { width: v, height: x }) : null;
+        e.__panoSelectedStickerGeometry = Ne ? fS(S, Ne, A, { width: v, height: x }) : null;
       } else
         e.__panoSelectedStickerGeometry = null;
     }
 }
-function uS(e, t, n, r, a, o, c = kx) {
+function hS(e, t, n, r, a, o, c = Ax) {
   const f = Wn(e), h = (e == null ? void 0 : e.__panoPreviewView) || { yaw: 0, pitch: 0, fov: 100 };
   e.__panoBackgroundCore || (e.__panoBackgroundCore = ko());
-  const g = Wm(o), v = em({
+  const g = Jm(o), v = im({
     stateRevision: [
       "runtime_bg_only",
       g,
@@ -9568,11 +9575,11 @@ function uS(e, t, n, r, a, o, c = kx) {
   });
   S && t.drawImage(S, n.x, n.y, n.w, n.h);
 }
-function wh(e, t, n, r, a, o, c = 1) {
+function Ph(e, t, n, r, a, o, c = 1) {
   let f = !1;
   e.strokeStyle = o, e.lineWidth = c, e.beginPath();
   for (const h of t) {
-    const g = Jm(h, n, r, a);
+    const g = tg(h, n, r, a);
     if (!g) {
       f = !1;
       continue;
@@ -9581,18 +9588,18 @@ function wh(e, t, n, r, a, o, c = 1) {
   }
   e.stroke();
 }
-function cS(e, t, n, r, a = 1) {
+function pS(e, t, n, r, a = 1) {
   e.save();
   const o = "#3f3f46", c = "rgba(250, 250, 250, 0.86)";
   for (let g = -75; g <= 75; g += 15) {
     const v = [];
     for (let x = -180; x <= 180; x += 4) v.push(yi(x, g));
-    wh(e, v, n, t, r, g === 0 ? c : o, g === 0 ? 1.5 : 1);
+    Ph(e, v, n, t, r, g === 0 ? c : o, g === 0 ? 1.5 : 1);
   }
   for (let g = -180; g <= 180; g += 15) {
     const v = [];
     for (let x = -89; x <= 89; x += 4) v.push(yi(g, x));
-    wh(e, v, n, t, r, o, g % 90 === 0 ? 1.3 : 1);
+    Ph(e, v, n, t, r, o, g % 90 === 0 ? 1.3 : 1);
   }
   const f = [
     { name: "Front", dir: yi(0, 0) },
@@ -9603,28 +9610,28 @@ function cS(e, t, n, r, a = 1) {
   e.fillStyle = "rgba(250, 250, 250, 0.42)";
   const h = Math.max(9, Math.round(11 * a));
   e.font = `500 ${h}px Plus Jakarta Sans, Geist, sans-serif`, e.textAlign = "center", e.textBaseline = "middle", f.forEach((g) => {
-    const v = Jm(g.dir, n, t, r);
+    const v = tg(g.dir, n, t, r);
     v && e.fillText(g.name, v.x, v.y + 24 * a);
   }), e.restore();
 }
-function fS(e) {
+function mS(e) {
   return e.__panoStandaloneRenderState || (e.__panoStandaloneRenderState = { dragging: !1, hqFrames: 0, frameEmaMs: 0, lastFrameTs: 0, qualityTier: "balanced" }), e.__panoStandaloneRenderState;
 }
-function dS(e) {
-  const t = fS(e);
-  t.dragging = !1, t.hqFrames = Nx;
+function gS(e) {
+  const t = mS(e);
+  t.dragging = !1, t.hqFrames = Cx;
 }
-function Xu(e, t = 150, n = performance.now()) {
+function Ju(e, t = 150, n = performance.now()) {
   e && (e.__panoResizeUntil = Number(n || performance.now()) + Math.max(0, Number(t || 0)));
 }
-function hS(e, t = performance.now()) {
+function bS(e, t = performance.now()) {
   return Number(t || performance.now()) < Number((e == null ? void 0 : e.__panoResizeUntil) || 0);
 }
-function Ju(e) {
+function Zu(e) {
   var t;
   e.preventDefault(), e.stopPropagation(), (t = e.stopImmediatePropagation) == null || t.call(e);
 }
-function pS(e, t, n = 20) {
+function yS(e, t, n = 20) {
   var c;
   if (!e || !t || !Number.isFinite(Number(e.clientX)) || !Number.isFinite(Number(e.clientY))) return !1;
   const r = (c = t.getBoundingClientRect) == null ? void 0 : c.call(t);
@@ -9633,23 +9640,23 @@ function pS(e, t, n = 20) {
   return a >= r.width - n && o >= r.height - n;
 }
 function Bn(e, t) {
-  return pS(e, t) ? !1 : (Ju(e), !0);
+  return yS(e, t) ? !1 : (Zu(e), !0);
 }
-function kh() {
+function Ah() {
   var n;
   const e = (n = $t == null ? void 0 : $t.canvas) == null ? void 0 : n.ds;
   if (!e) return null;
   const t = Array.isArray(e.offset) ? [Number(e.offset[0] || 0), Number(e.offset[1] || 0)] : [0, 0];
   return { scale: Number(e.scale || 1), offset: t };
 }
-function mS(e) {
+function vS(e) {
   var n;
   if (!e) return;
   const t = (n = $t == null ? void 0 : $t.canvas) == null ? void 0 : n.ds;
   t && (t.scale = e.scale, Array.isArray(t.offset) && (t.offset[0] = e.offset[0], t.offset[1] = e.offset[1]));
 }
-function gS(e, t = 360, n = 260) {
-  if (!e || e.__panoUserResized === !0 || e.__panoStandaloneBootSized === !0 || !jm(e)) return;
+function _S(e, t = 360, n = 260) {
+  if (!e || e.__panoUserResized === !0 || e.__panoStandaloneBootSized === !0 || !Bm(e)) return;
   const r = [Math.max(1, Number(t || 1)), Math.max(1, Number(n || 1))];
   try {
     typeof e.setSize == "function" ? e.setSize(r) : e.size = r, e.__panoStandaloneBootSized = !0;
@@ -9657,14 +9664,14 @@ function gS(e, t = 360, n = 260) {
     String((a == null ? void 0 : a.message) || a || "unknown");
   }
 }
-function bS(e, t = 0, n = null, r = 1200) {
+function xS(e, t = 0, n = null, r = 1200) {
   const a = Math.max(0, Number(t || 0));
   e != null && e.__panoBootMinHeightTimer && (clearTimeout(e.__panoBootMinHeightTimer), e.__panoBootMinHeightTimer = null), e.__panoBootMinHeightActive = a > 0, !(a <= 0) && (e.__panoBootMinHeightTimer = setTimeout(() => {
     var o, c;
     e.__panoBootMinHeightTimer = null, (o = e == null ? void 0 : e.__panoDomPreview) != null && o.widget && e.__panoBootMinHeightActive && (e.__panoBootMinHeightActive = !1, n == null || n(), (c = e.setDirtyCanvas) == null || c.call(e, !0, !0));
   }, Math.max(0, Number(r || 0))));
 }
-function Nh(e, t = null, n = 0, r = 0, a = !0) {
+function Ch(e, t = null, n = 0, r = 0, a = !0) {
   const o = Math.max(0, Number(r || 0));
   return {
     serialize: !1,
@@ -9683,11 +9690,11 @@ function Nh(e, t = null, n = 0, r = 0, a = !0) {
       return e != null && e.__panoBootMinHeightActive ? Math.max(o, Math.max(0, Number(n || 0))) : o > 0 ? o : "auto";
     },
     afterResize() {
-      e.__panoUserResized = !0, Xu(e, 150), t == null || t(), a && yS(e, 180, t);
+      e.__panoUserResized = !0, Ju(e, 150), t == null || t(), a && SS(e, 180, t);
     }
   };
 }
-function yS(e, t = 180, n = null) {
+function SS(e, t = 180, n = null) {
   e && (e.__panoResizeSettleTimer && (clearTimeout(e.__panoResizeSettleTimer), e.__panoResizeSettleTimer = null), e.__panoResizeSettleTimer = setTimeout(() => {
     var r;
     e.__panoResizeSettleTimer = null, n == null || n(), (r = e.setDirtyCanvas) == null || r.call(e, !0, !0);
@@ -9696,23 +9703,23 @@ function yS(e, t = 180, n = null) {
 function Wa(e) {
   e && Array.isArray(e.imgs) && e.imgs.length && (e.imgs = []);
 }
-function vS(e, t = {}) {
+function wS(e, t = {}) {
   var Pt;
-  const n = t.__allowStandalone === !0, r = Vm(e);
+  const n = t.__allowStandalone === !0, r = Gm(e);
   if (r && !n) {
-    zc(e);
+    $c(e);
     return;
   }
-  r && gS(e), e.__panoPreviewMode = String(t.mode || "stickers") === "cutout" ? "cutout" : "stickers";
+  r && _S(e), e.__panoPreviewMode = String(t.mode || "stickers") === "cutout" ? "cutout" : "stickers";
   const a = e.__panoPreviewMode === "stickers", o = e.__panoPreviewMode !== "cutout";
   e.__panoAttachOptions = { ...t, mode: e.__panoPreviewMode }, e.__panoPreviewNoPreview = t.noPreview === !0, e.__panoPreviewButtonText = String(t.buttonText || (e.__panoPreviewMode === "cutout" ? "Open Cutout Editor" : "Open Stickers Editor")), e.__panoOpenEditor = typeof t.onOpen == "function" ? t.onOpen : null, String((e == null ? void 0 : e.comfyClass) || (e == null ? void 0 : e.type) || (e == null ? void 0 : e.title) || ""), String(t.__panoForcedPath || "").trim();
   const c = {
-    signature: gh(e)
-  }, f = "dom", h = c.signature || gh(e);
-  if (Number(e.__panoRebindGeneration || 0), Wu(e), e == null || e.id, e.__panoPreviewMode, e.addDOMWidget, Ku(e), e.__panoFrontendSig = h, e.__panoStickersPath = f, (Pt = e.__panoDomPreview) != null && Pt.widget || (e.__panoLegacyPreviewHooked && Cs(e, { keepMonitor: !0 }), typeof e.addDOMWidget != "function"))
+    signature: _h(e)
+  }, f = "dom", h = c.signature || _h(e);
+  if (Number(e.__panoRebindGeneration || 0), Yu(e), e == null || e.id, e.__panoPreviewMode, e.addDOMWidget, Wu(e), e.__panoFrontendSig = h, e.__panoStickersPath = f, (Pt = e.__panoDomPreview) != null && Pt.widget || (e.__panoLegacyPreviewHooked && Cs(e, { keepMonitor: !0 }), typeof e.addDOMWidget != "function"))
     return;
-  const g = t.noPreview === !0, v = g ? 0 : 56, x = g ? 0 : J1, S = document.createElement("div");
-  if (Cx(), S.className = "pano-node-preview-dom", S.classList.add(a ? "pano-node-preview--stickers" : "pano-node-preview--cutout"), g && S.classList.add("pano-node-preview--no-preview"), S.setAttribute("data-capture-wheel", "true"), S.tabIndex = 0, S.style.cssText = [
+  const g = t.noPreview === !0, v = g ? 0 : 56, x = g ? 0 : t_, S = document.createElement("div");
+  if (Dx(), S.className = "pano-node-preview-dom", S.classList.add(a ? "pano-node-preview--stickers" : "pano-node-preview--cutout"), g && S.classList.add("pano-node-preview--no-preview"), S.setAttribute("data-capture-wheel", "true"), S.tabIndex = 0, S.style.cssText = [
     "width:100%",
     g ? "height:auto" : "height:100%",
     x > 0 ? `min-height:${x}px` : "min-height:0",
@@ -9724,9 +9731,9 @@ function vS(e, t = {}) {
     "contain:layout paint style",
     "background:transparent"
   ].join(";"), g) {
-    const E = Ws(
-      e.addDOMWidget(Gu(), "preview", S, Nh(e, null))
-    );
+    const E = Ws(Gu(
+      e.addDOMWidget(Ku(), "preview", S, Ch(e, null))
+    ));
     Wa(e), e.__panoDomPreview = { widget: E, root: S, requestDraw: () => {
     } }, e.__panoPreviewHooked = !0, e.__panoActiveBackend = "dom";
     return;
@@ -9767,18 +9774,18 @@ function vS(e, t = {}) {
     "padding:0 10px",
     "z-index:2"
   ].join(";"), O.textContent = "Connect ERP image", M.appendChild(b), M.appendChild(O), S.appendChild(M);
-  const j = nm(S), z = document.createElement("div");
-  z && (z.className = a ? "pano-stickers-node-surface-host" : "pano-cutout-node-surface-host", z.style.cssText = "position:absolute;inset:0;z-index:3;pointer-events:none", S.appendChild(z)), Tx(e, 120, 120), Wa(e);
+  const j = om(S), z = document.createElement("div");
+  z && (z.className = a ? "pano-stickers-node-surface-host" : "pano-cutout-node-surface-host", z.style.cssText = "position:absolute;inset:0;z-index:3;pointer-events:none", S.appendChild(z)), Ox(e, 120, 120), Wa(e);
   let P = null;
   try {
-    bS(e, v, () => {
+    xS(e, v, () => {
       var E, Se;
       return (Se = (E = e.__panoDomPreview) == null ? void 0 : E.requestDraw) == null ? void 0 : Se.call(E);
-    }), P = Ws(e.addDOMWidget(
-      Gu(),
+    }), P = Ws(Gu(e.addDOMWidget(
+      Ku(),
       "preview",
       S,
-      Nh(
+      Ch(
         e,
         () => {
           var E, Se;
@@ -9788,7 +9795,7 @@ function vS(e, t = {}) {
         x,
         !1
       )
-    ));
+    )));
   } catch {
     return;
   }
@@ -9803,13 +9810,13 @@ function vS(e, t = {}) {
     lastTs: 0
   }, I = () => {
     $.destroyed || ($.needsDraw = !0, !$.inTick && !$.raf && ($.raf = requestAnimationFrame(mt)));
-  }, R = /* @__PURE__ */ ka(a ? { ...Tm(Wn(e)), importing: !1, dropActive: !1 } : {
-    ...gm(Wn(e)),
+  }, R = /* @__PURE__ */ ka(a ? { ...Om(Wn(e)), importing: !1, dropActive: !1 } : {
+    ..._m(Wn(e)),
     aspectOpen: !1,
     aspectChoices: ["1:1", "4:3", "3:2", "16:9"].map((E) => ({ value: E, label: E }))
   });
   let G = null;
-  const H = (a ? I_ : r_)({
+  const H = (a ? F_ : s_)({
     readState: () => Wn(e),
     publishLiveState: (E) => {
       E ? (G = E, e.__panoLiveStateOverride = E) : (e.__panoLiveStateOverride === G && (e.__panoLiveStateOverride = null), G = null), e.__panoLiveStateVersion = Number(e.__panoLiveStateVersion || 0) + 1, e.__panoStateCache = null, I();
@@ -9828,7 +9835,7 @@ function vS(e, t = {}) {
     if (Le == null)
       return H.apply({ type: "sync-external", value: { connected: !1 } });
     if (!hl(e, "external-sticker")) return !1;
-    const Je = qu(e, "pano_sticker_input_pose", Se), Ke = Array.isArray(Je) ? Je[0] : Je, Ft = String(qu(e, "pano_sticker_input_state_hash", Se) ?? ""), Gt = e.__panoPreviewView || { yaw: 0, pitch: 0 }, Kt = Wn(e), Ct = (Array.isArray(Kt == null ? void 0 : Kt.stickers) ? Kt.stickers : []).find((Fn) => String((Fn == null ? void 0 : Fn.id) || "") === "sticker_image_1"), Tt = Xm(e, "sticker_image_1", null, { external: !0 }), li = Ke && typeof Ke == "object" ? Ke : Ct || { yaw_deg: Gt.yaw, pitch_deg: Gt.pitch, hFOV_deg: 30, rot_deg: 0 };
+    const Je = Xu(e, "pano_sticker_input_pose", Se), Ke = Array.isArray(Je) ? Je[0] : Je, Ft = String(Xu(e, "pano_sticker_input_state_hash", Se) ?? ""), Gt = e.__panoPreviewView || { yaw: 0, pitch: 0 }, Kt = Wn(e), Ct = (Array.isArray(Kt == null ? void 0 : Kt.stickers) ? Kt.stickers : []).find((Fn) => String((Fn == null ? void 0 : Fn.id) || "") === "sticker_image_1"), Tt = eg(e, "sticker_image_1", null, { external: !0 }), li = Ke && typeof Ke == "object" ? Ke : Ct || { yaw_deg: Gt.yaw, pitch_deg: Gt.pitch, hFOV_deg: 30, rot_deg: 0 };
     return H.apply({
       type: "sync-external",
       value: {
@@ -9840,7 +9847,7 @@ function vS(e, t = {}) {
         imageHeight: Number((Tt == null ? void 0 : Tt.naturalHeight) || (Tt == null ? void 0 : Tt.height) || 0)
       }
     });
-  }, ie = a ? zm(e, se) : () => {
+  }, ie = a ? Hm(e, se) : () => {
   };
   let T = 0;
   const q = async (E) => {
@@ -9905,7 +9912,7 @@ function vS(e, t = {}) {
   let Ne = null, U = !1;
   if (z && H)
     try {
-      Oc(), Ne = _c(a ? P_ : __, {
+      Fc(), Ne = xc(a ? I_ : k_, {
         model: R,
         onAction: (E) => {
           var Le, Je;
@@ -9934,14 +9941,14 @@ function vS(e, t = {}) {
             const Ke = e.__panoPreviewView || { yaw: 0, pitch: 0, fov: 100 };
             Se = {
               ...E,
-              ...Q1(Ke, {
+              ...r_(Ke, {
                 width: b.width,
                 height: b.height
               })
             };
           } else if ((E == null ? void 0 : E.type) === "delete-frame") {
             const Ke = Ai(Wn(e));
-            Ke && (e.__panoPreviewView = ym(Ke, {
+            Ke && (e.__panoPreviewView = Sm(Ke, {
               width: b.width,
               height: b.height
             }));
@@ -9954,7 +9961,7 @@ function vS(e, t = {}) {
       Ne = null, U = !1;
     }
   const je = typeof ResizeObserver < "u" ? new ResizeObserver(() => {
-    Xu(e, 150), I();
+    Ju(e, 150), I();
   }) : null;
   je == null || je.observe(M);
   const mt = (E) => {
@@ -9962,12 +9969,12 @@ function vS(e, t = {}) {
     $.raf = 0, $.inTick = !0;
     let Se = !1;
     try {
-      Se = nt.stepInertia(E), ($.needsDraw || Se) && ($.needsDraw = !1, (Ie = e.flags) != null && Ie.collapsed || lS(e, b, null, nt));
+      Se = nt.stepInertia(E), ($.needsDraw || Se) && ($.needsDraw = !1, (Ie = e.flags) != null && Ie.collapsed || dS(e, b, null, nt));
     } finally {
       $.inTick = !1;
     }
-    (Se || $.needsDraw) && !$.raf && ($.raf = requestAnimationFrame(mt)), Ax() && (!e.__panoDebugLastTs || E - e.__panoDebugLastTs > 1200) && (e.__panoDebugLastTs = E, e.__panoPreviewMode, Ku(e), Ga(S), Ga(M), Ga(b), Ga(S.parentElement), Ga((Le = S.parentElement) == null ? void 0 : Le.parentElement), Number(b.width || 0), Number(b.height || 0), void 0);
-  }, nt = Pc({
+    (Se || $.needsDraw) && !$.raf && ($.raf = requestAnimationFrame(mt)), Ex() && (!e.__panoDebugLastTs || E - e.__panoDebugLastTs > 1200) && (e.__panoDebugLastTs = E, e.__panoPreviewMode, Wu(e), Ga(S), Ga(M), Ga(b), Ga(S.parentElement), Ga((Le = S.parentElement) == null ? void 0 : Le.parentElement), Number(b.width || 0), Number(b.height || 0), void 0);
+  }, nt = Ac({
     getView: () => (e.__panoPreviewView || (e.__panoPreviewView = { yaw: 0, pitch: 0, fov: 100 }), e.__panoPreviewView),
     setView: (E) => {
       e.__panoPreviewView = E;
@@ -9980,7 +9987,7 @@ function vS(e, t = {}) {
       };
     },
     getInvert: () => {
-      const E = mh();
+      const E = vh();
       return {
         x: E.invert_view_x ? -1 : 1,
         y: E.invert_view_y ? -1 : 1
@@ -9998,7 +10005,7 @@ function vS(e, t = {}) {
   }, qt = (E) => {
     var Le, Je;
     if (!a || !o) return;
-    const Se = Wn(e), Ie = sh(
+    const Se = Wn(e), Ie = uh(
       Se == null ? void 0 : Se.stickers,
       String(((Le = Se == null ? void 0 : Se.active) == null ? void 0 : Le.selected_sticker_id) || ""),
       Ve(E),
@@ -10028,7 +10035,7 @@ function vS(e, t = {}) {
       const Di = Ve(E);
       let Rn;
       if (E.shiftKey) {
-        const Rt = _m({
+        const Rt = km({
           frame: rn,
           point: Di,
           startRollDeg: Number(cn.roll_deg ?? cn.rot_deg ?? 0),
@@ -10037,7 +10044,7 @@ function vS(e, t = {}) {
         if (!Rt) return;
         Rn = { kind: "roll", pointerId: E.pointerId, rollGesture: Rt };
       } else {
-        const Rt = ((Kt = Wn(e)) == null ? void 0 : Kt.ui_settings) || mh();
+        const Rt = ((Kt = Wn(e)) == null ? void 0 : Kt.ui_settings) || vh();
         Rn = {
           kind: "pan",
           pointerId: E.pointerId,
@@ -10052,7 +10059,7 @@ function vS(e, t = {}) {
       return;
     }
     if (!o) return;
-    const Se = Ve(E), Ie = Wn(e), Le = String(((li = Ie == null ? void 0 : Ie.active) == null ? void 0 : li.selected_sticker_id) || ""), Je = mo(e.__panoPreviewView, Ie == null ? void 0 : Ie.coverage), Ke = sh(
+    const Se = Ve(E), Ie = Wn(e), Le = String(((li = Ie == null ? void 0 : Ie.active) == null ? void 0 : li.selected_sticker_id) || ""), Je = mo(e.__panoPreviewView, Ie == null ? void 0 : Ie.coverage), Ke = uh(
       Ie == null ? void 0 : Ie.stickers,
       Le,
       Se,
@@ -10101,7 +10108,7 @@ function vS(e, t = {}) {
         });
         return;
       }
-      const Se = xm(re.rollGesture, Ve(E), E);
+      const Se = Nm(re.rollGesture, Ve(E), E);
       if (!Se) return;
       re.rollGesture = Se.gesture, H.updateGesture({ type: "set-roll", value: Se.rollDeg });
       return;
@@ -10116,7 +10123,7 @@ function vS(e, t = {}) {
       const Se = Ve(E);
       let Ie = J.startSticker;
       if (J.kind === "move")
-        Ie = R_(
+        Ie = j_(
           J.startSticker,
           {
             x: J.startCenter.x + Se.x - J.startPoint.x,
@@ -10127,10 +10134,10 @@ function vS(e, t = {}) {
         );
       else if (J.kind === "scale") {
         const Le = Math.hypot(Se.x - J.startCenter.x, Se.y - J.startCenter.y);
-        Ie = L_(J.startSticker, J.startDistance, Le);
+        Ie = V_(J.startSticker, J.startDistance, Le);
       } else if (J.kind === "rotate") {
         const Le = Math.atan2(Se.y - J.startCenter.y, Se.x - J.startCenter.x);
-        Ie = z_(J.startSticker, J.startAngle, Le, E.shiftKey === !0);
+        Ie = H_(J.startSticker, J.startAngle, Le, E.shiftKey === !0);
       }
       H.updateGesture({ type: "set-transform", value: Ie }), I();
       return;
@@ -10169,7 +10176,7 @@ function vS(e, t = {}) {
       Bn(E, Ye), J = null, e.__panoStickerDrag = null, (Je = b.releasePointerCapture) == null || Je.call(b, E.pointerId), b.style.cursor = "grab", Se ? H.cancelGesture() : H.commitGesture(), I();
       return;
     }
-    !o || !nt.state.drag.active || (Bn(E, Ye), (Ke = b.releasePointerCapture) == null || Ke.call(b, E.pointerId), b.style.cursor = "grab", nt.endDrag(), dS(e), I());
+    !o || !nt.state.drag.active || (Bn(E, Ye), (Ke = b.releasePointerCapture) == null || Ke.call(b, E.pointerId), b.style.cursor = "grab", nt.endDrag(), gS(e), I());
   };
   b.addEventListener("pointerup", Sn), b.addEventListener("pointercancel", (E) => Sn(E, !0)), b.addEventListener("lostpointercapture", An), b.addEventListener("pointerleave", (E) => {
     !a && re || J || nt.state.drag.active && Sn(E);
@@ -10178,38 +10185,38 @@ function vS(e, t = {}) {
     const Se = document.activeElement;
     if (Se !== S && !S.contains(Se)) return;
     if (E.key === "Escape" && (re || J) && H) {
-      An(), Ju(E);
+      An(), Zu(E);
       return;
     }
     if (!a || E.key !== "Delete" && E.key !== "Backspace" || !H) return;
     const Ie = E.target, Le = String((Ie == null ? void 0 : Ie.tagName) || "").toUpperCase();
-    Le === "INPUT" || Le === "TEXTAREA" || Ie != null && Ie.isContentEditable || R.canDelete === !0 && (A(), H.apply({ type: "delete-selected" }) && I(), Ju(E));
+    Le === "INPUT" || Le === "TEXTAREA" || Ie != null && Ie.isContentEditable || R.canDelete === !0 && (A(), H.apply({ type: "delete-selected" }) && I(), Zu(E));
   };
   window.addEventListener("keydown", nn, !0);
-  const un = Sx({
+  const un = Mx({
     requestFrame: (E) => requestAnimationFrame(E),
     cancelFrame: (E) => cancelAnimationFrame(E),
-    restore: (E) => mS(E)
+    restore: (E) => vS(E)
   }), L = (E) => {
     var Ie, Le, Je, Ke, Ft, Gt;
     if (!Bn(E, Ye)) return;
     if (!a) {
       const Kt = Ai(Wn(e));
       if (Kt && Kt.locked !== !0 && H) {
-        const Ct = Mc(E);
+        const Ct = Pc(E);
         Ct !== 0 && (ce || (A(), H.beginGesture(), ce = !0), H.updateGesture({
           type: "step-fov",
           direction: Ct
         }) ? (de && clearTimeout(de), de = setTimeout(we, 180), I()) : H.hasGestureChanges() || (H.cancelGesture(), ce = !1));
       } else if (!Kt) {
-        const Ct = kh();
+        const Ct = Ah();
         nt.applyWheelEvent(E) && I(), un.schedule(Ct);
       }
       (Ie = E.preventDefault) == null || Ie.call(E), (Le = E.stopPropagation) == null || Le.call(E), (Je = E.stopImmediatePropagation) == null || Je.call(E);
       return;
     }
     if (!o) return;
-    const Se = kh();
+    const Se = Ah();
     nt.applyWheelEvent(E) && I(), (Ke = E.preventDefault) == null || Ke.call(E), (Ft = E.stopPropagation) == null || Ft.call(E), (Gt = E.stopImmediatePropagation) == null || Gt.call(E), un.schedule(Se);
   }, V = a ? [M, b] : [M];
   ["wheel", "mousewheel", "DOMMouseScroll"].forEach((E) => {
@@ -10236,7 +10243,7 @@ function vS(e, t = {}) {
       d = null, R.dropActive = !1;
     }, 140));
   }, Re = a ? function(E) {
-    return (ge ? ge.apply(this, arguments) : !1) === !0 ? !0 : Rc(E == null ? void 0 : E.dataTransfer) ? (De(), !0) : !1;
+    return (ge ? ge.apply(this, arguments) : !1) === !0 ? !0 : Lc(E == null ? void 0 : E.dataTransfer) ? (De(), !0) : !1;
   } : null, Ue = a ? function(E) {
     var Le;
     if ((Ce ? Ce.apply(this, arguments) : !1) === !0) return !0;
@@ -10244,7 +10251,7 @@ function vS(e, t = {}) {
     return Ie ? (d && clearTimeout(d), d = null, R.dropActive = !1, q(Ie), !0) : !1;
   } : null;
   a && (e.onDragOver = Re, e.onDragDrop = Ue);
-  const et = a ? xx(S, {
+  const et = a ? Nx(S, {
     onActive: (E) => {
       if (E) {
         De();
@@ -10257,35 +10264,35 @@ function vS(e, t = {}) {
     }
   }) : () => {
   }, gt = function(E) {
-    Bx(e, E), e.__panoLastExecutedOutput = E || null, Ym(e), K_(e), se("executed", E), Wa(e), I();
+    Yx(e, E), e.__panoLastExecutedOutput = E || null, Zm(e), X_(e), se("executed", E), Wa(e), I();
     const Se = Me ? Me.apply(this, arguments) : void 0;
     return Wa(e), Se;
   };
   e.onExecuted = gt;
   const at = e.onConnectionsChange, oe = function(E, Se) {
-    const Ie = uh(e, E, Se, ["sticker_image"]), Le = uh(
+    const Ie = fh(e, E, Se, ["sticker_image"]), Le = fh(
       e,
       E,
       Se,
       ["erp_image", "bg_erp"]
     ), Je = arguments, Ke = at ? at.apply(this, Je) : void 0, Ft = () => {
-      $.destroyed || ((Le || Ie) && (Le && (lh(e, "background"), Wx(e)), Ie && (lh(e, "external-sticker"), e.__panoLastExecutedOutput = null, Yx(e))), Ie && se("connection-change"), Wa(e), I());
+      $.destroyed || ((Le || Ie) && (Le && (ch(e, "background"), Jx(e)), Ie && (ch(e, "external-sticker"), e.__panoLastExecutedOutput = null, Zx(e))), Ie && se("connection-change"), Wa(e), I());
     };
     return Ft(), queueMicrotask(Ft), Ke;
   };
   e.onConnectionsChange = oe;
   const Xt = function() {
     const E = ne ? ne.apply(this, arguments) : void 0;
-    return this.__panoUserResized = !0, Xu(this, 150), I(), E;
+    return this.__panoUserResized = !0, Ju(this, 150), I(), E;
   };
   e.onResize = Xt;
   const Nt = function() {
-    return Ge(), Yu.unregister(this), fe ? fe.apply(this, arguments) : void 0;
+    return Ge(), qu.unregister(this), fe ? fe.apply(this, arguments) : void 0;
   };
   e.onRemoved = Nt;
   const Ge = () => {
     var E, Se, Ie, Le, Je, Ke, Ft, Gt, Kt, Ct, Tt;
-    $.destroyed = !0, (E = je == null ? void 0 : je.disconnect) == null || E.call(je), a ? A() : xe(), b.removeEventListener("lostpointercapture", An), et(), j(), window.removeEventListener("keydown", nn, !0), (Ie = (Se = e.__panoStateFlushers) == null ? void 0 : Se.delete) == null || Ie.call(Se, Ae), e.__panoStateFlushers instanceof Set && e.__panoStateFlushers.size === 0 && (e.__panoStateFlushers = null), (Le = H == null ? void 0 : H.destroy) == null || Le.call(H), (Je = Ne == null ? void 0 : Ne.unmount) == null || Je.call(Ne), (Ft = (Ke = e.__panoRuntimeCore) == null ? void 0 : Ke.dispose) == null || Ft.call(Ke), e.__panoRuntimeCore = null, (Kt = (Gt = e.__panoRasterObjectSurfaceCache) == null ? void 0 : Gt.dispose) == null || Kt.call(Gt), e.__panoRasterObjectSurfaceCache = null, e.__panoRasterObjectReady = null, ie(), un.dispose(), d && clearTimeout(d), d = null, Lc.disposeOwner(e), ya(e), $.raf && cancelAnimationFrame($.raf), $.raf = 0, ((Ct = e.__panoCutoutNodeSurface) == null ? void 0 : Ct.session) === H && (e.__panoCutoutNodeSurface = null), ((Tt = e.__panoStickersNodeSurface) == null ? void 0 : Tt.session) === H && (e.__panoStickersNodeSurface = null), e.__panoCutoutNodeSurfaceState = null, e.__panoStickersNodeSurfaceState = null, e.__panoCutoutNodeFrame = null, e.__panoResizeSettleTimer && (clearTimeout(e.__panoResizeSettleTimer), e.__panoResizeSettleTimer = null), e.__panoDomPreview = null, e.__panoDomRestore = null, e.onResize === Xt && (e.onResize = ne), e.onExecuted === gt && (e.onExecuted = Me), e.onConnectionsChange === oe && (e.onConnectionsChange = at), he && (te == null ? void 0 : te.callback) === he && (te.callback = ye), he && (te == null ? void 0 : te.__panoPreviewPatchedCb) === he && delete te.__panoPreviewPatchedCb, ee && (D == null ? void 0 : D.callback) === ee && (D.callback = Q), ee && (D == null ? void 0 : D.__panoPreviewPatchedCb) === ee && delete D.__panoPreviewPatchedCb, e.onDragOver === Re && (e.onDragOver = ge), e.onDragDrop === Ue && (e.onDragDrop = Ce), e.onRemoved === Nt && (e.onRemoved = fe);
+    $.destroyed = !0, (E = je == null ? void 0 : je.disconnect) == null || E.call(je), a ? A() : xe(), b.removeEventListener("lostpointercapture", An), et(), j(), window.removeEventListener("keydown", nn, !0), (Ie = (Se = e.__panoStateFlushers) == null ? void 0 : Se.delete) == null || Ie.call(Se, Ae), e.__panoStateFlushers instanceof Set && e.__panoStateFlushers.size === 0 && (e.__panoStateFlushers = null), (Le = H == null ? void 0 : H.destroy) == null || Le.call(H), (Je = Ne == null ? void 0 : Ne.unmount) == null || Je.call(Ne), (Ft = (Ke = e.__panoRuntimeCore) == null ? void 0 : Ke.dispose) == null || Ft.call(Ke), e.__panoRuntimeCore = null, (Kt = (Gt = e.__panoRasterObjectSurfaceCache) == null ? void 0 : Gt.dispose) == null || Kt.call(Gt), e.__panoRasterObjectSurfaceCache = null, e.__panoRasterObjectReady = null, ie(), un.dispose(), d && clearTimeout(d), d = null, zc.disposeOwner(e), ya(e), $.raf && cancelAnimationFrame($.raf), $.raf = 0, ((Ct = e.__panoCutoutNodeSurface) == null ? void 0 : Ct.session) === H && (e.__panoCutoutNodeSurface = null), ((Tt = e.__panoStickersNodeSurface) == null ? void 0 : Tt.session) === H && (e.__panoStickersNodeSurface = null), e.__panoCutoutNodeSurfaceState = null, e.__panoStickersNodeSurfaceState = null, e.__panoCutoutNodeFrame = null, e.__panoResizeSettleTimer && (clearTimeout(e.__panoResizeSettleTimer), e.__panoResizeSettleTimer = null), e.__panoDomPreview = null, e.__panoDomRestore = null, e.onResize === Xt && (e.onResize = ne), e.onExecuted === gt && (e.onExecuted = Me), e.onConnectionsChange === oe && (e.onConnectionsChange = at), he && (te == null ? void 0 : te.callback) === he && (te.callback = ye), he && (te == null ? void 0 : te.__panoPreviewPatchedCb) === he && delete te.__panoPreviewPatchedCb, ee && (D == null ? void 0 : D.callback) === ee && (D.callback = Q), ee && (D == null ? void 0 : D.__panoPreviewPatchedCb) === ee && delete D.__panoPreviewPatchedCb, e.onDragOver === Re && (e.onDragOver = ge), e.onDragDrop === Ue && (e.onDragDrop = Ce), e.onRemoved === Nt && (e.onRemoved = fe);
   };
   e.__panoDomRestore = Ge, e.__panoPreviewHooked = !0, e.__panoActiveBackend = "dom", e.__panoCutoutNodeSurface = H && U && !a ? { session: H, model: R } : null, e.__panoStickersNodeSurface = H && U && a ? { session: H, model: R } : null, e.__panoDomPreview = {
     widget: P,
@@ -10295,33 +10302,33 @@ function vS(e, t = {}) {
     state: $,
     emptyHintEl: O,
     nodeSurface: e.__panoCutoutNodeSurface
-  }, Yu.register(e), se("attach"), I();
+  }, qu.register(e), se("attach"), I();
 }
-function Mh(e, t = {}) {
-  Hm(e).attach({
+function Th(e, t = {}) {
+  Km(e).attach({
     ...t,
     mode: "cutout"
   });
 }
-function Ph(e, t = {}) {
+function Ih(e, t = {}) {
   const n = t.__allowStandalone === !0;
-  if (Vm(e) && !n) {
-    zc(e);
+  if (Gm(e) && !n) {
+    $c(e);
     return;
   }
-  Hm(e).attach(t);
+  Km(e).attach(t);
 }
-function _S(e, t) {
+function kS(e, t) {
   return !e || e.target !== t ? !1 : e.key === " " || e.key === "Spacebar";
 }
-function xS(e, t = 1) {
+function NS(e, t = 1) {
   const n = Number(t), r = Number.isFinite(n) && n > 0 ? n : 1, a = Number(e == null ? void 0 : e.width), o = Number(e == null ? void 0 : e.height);
   return {
     width: Math.max(1, Math.round((Number.isFinite(a) ? a : 0) * r)),
     height: Math.max(1, Math.round((Number.isFinite(o) ? o : 0) * r))
   };
 }
-function SS({
+function MS({
   root: e,
   documentRef: t = typeof document < "u" ? document : null,
   onChange: n = null,
@@ -10368,7 +10375,7 @@ function SS({
     }
   } };
 }
-const wS = { class: "pano-preview-node-surface" }, kS = {
+const PS = { class: "pano-preview-node-surface" }, AS = {
   __name: "PanoPreviewNodeSurface",
   props: {
     model: { type: Object, default: () => ({ fullscreen: !1 }) },
@@ -10376,7 +10383,7 @@ const wS = { class: "pano-preview-node-surface" }, kS = {
   },
   setup(e) {
     const t = e;
-    return (n, r) => (ke(), Pe("div", wS, [
+    return (n, r) => (ke(), Pe("div", PS, [
       $e(tn, {
         icon: e.model.fullscreen ? pt(Te).fullscreen_close : pt(Te).fullscreen,
         label: e.model.fullscreen ? "Exit Fullscreen" : "Fullscreen",
@@ -10391,18 +10398,18 @@ const wS = { class: "pano-preview-node-surface" }, kS = {
       }, null, 8, ["icon", "label", "tip", "pressed"])
     ]));
   }
-}, is = 140, NS = 180, Ah = 40, bu = 10;
-function Ch(e) {
+}, is = 140, CS = 180, Eh = 40, bu = 10;
+function Dh(e) {
   const t = String(e ?? "").trim();
   if (!t) return { full: "", tail: "" };
   const n = t.split(":");
   return { full: t, tail: String(n[n.length - 1] || "").trim() };
 }
-function Th(e, t) {
-  const n = Ch(e), r = Ch(t);
+function Oh(e, t) {
+  const n = Dh(e), r = Dh(t);
   return !n.full || !r.full ? !1 : n.full === r.full || n.tail === r.full || n.full === r.tail || n.tail === r.tail;
 }
-function Ih(e) {
+function Fh(e) {
   var o;
   if (!e || typeof e != "object") return "";
   const t = String(e.filename || "").trim();
@@ -10424,7 +10431,7 @@ function va(e) {
     if (e.length === 1) return va(e[0]);
     const t = typeof e[0] == "string" ? String(e[0] || "").trim() : "";
     if (t)
-      return Ih({
+      return Fh({
         filename: t,
         subfolder: String(e[1] || "").trim(),
         type: String(e[2] || "output").trim() || "output"
@@ -10435,12 +10442,12 @@ function va(e) {
     }
     return "";
   }
-  return typeof (e == null ? void 0 : e.src) == "string" && e.src ? e.src : typeof (e == null ? void 0 : e.url) == "string" && e.url ? e.url : Ih(e);
+  return typeof (e == null ? void 0 : e.src) == "string" && e.src ? e.src : typeof (e == null ? void 0 : e.url) == "string" && e.url ? e.url : Fh(e);
 }
-function Qm(e) {
+function rg(e) {
   return e ? e instanceof HTMLVideoElement ? Number(e.videoWidth || 0) > 0 && Number(e.videoHeight || 0) > 0 && Number(e.readyState || 0) >= 2 : !!e.complete && Number(e.naturalWidth || e.width || 0) > 0 : !1;
 }
-function MS(e) {
+function TS(e) {
   return e instanceof HTMLVideoElement ? [
     String(e.currentSrc || e.src || ""),
     Number(e.videoWidth || 0),
@@ -10454,7 +10461,7 @@ function MS(e) {
     Number((e == null ? void 0 : e.naturalHeight) || (e == null ? void 0 : e.height) || 0)
   ].join("|");
 }
-function Zu(e) {
+function Qu(e) {
   var a;
   const t = (a = nr) == null ? void 0 : a.nodeOutputs;
   if (!t || e == null) return null;
@@ -10463,15 +10470,15 @@ function Zu(e) {
   if (t instanceof Map ? r = t.get(e) || t.get(n) || t.get(Number(n)) || null : r = t[e] || t[n] || null, r) return r;
   if (t instanceof Map) {
     for (const o of t.keys())
-      if (Th(o, n)) return t.get(o);
+      if (Oh(o, n)) return t.get(o);
   } else
     for (const o of Object.keys(t))
-      if (Th(o, n)) return t[o];
+      if (Oh(o, n)) return t[o];
   return null;
 }
-function PS(e) {
+function IS(e) {
   var r, a;
-  const t = Zu(e == null ? void 0 : e.id), n = [
+  const t = Qu(e == null ? void 0 : e.id), n = [
     (r = t == null ? void 0 : t.ui) == null ? void 0 : r.pano_videos,
     t == null ? void 0 : t.pano_videos,
     (a = t == null ? void 0 : t.ui) == null ? void 0 : a.images,
@@ -10485,7 +10492,7 @@ function PS(e) {
       }
   return "";
 }
-function AS(e, t = "erp_image") {
+function ES(e, t = "erp_image") {
   var b, O, j, z, P, $, I, R, G, H, se, ie;
   const n = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs : [];
   let r = null;
@@ -10499,7 +10506,7 @@ function AS(e, t = "erp_image") {
   if (!o) return "";
   const c = Number(o.origin_id);
   if (!Number.isFinite(c)) return "";
-  const f = (R = (I = ($ = nr) == null ? void 0 : $.graph) == null ? void 0 : I.getNodeById) == null ? void 0 : R.call(I, c), h = Zu(c), g = Zu(e == null ? void 0 : e.id), v = [
+  const f = (R = (I = ($ = nr) == null ? void 0 : $.graph) == null ? void 0 : I.getNodeById) == null ? void 0 : R.call(I, c), h = Qu(c), g = Qu(e == null ? void 0 : e.id), v = [
     (G = g == null ? void 0 : g.ui) == null ? void 0 : G.pano_input_images,
     g == null ? void 0 : g.pano_input_images,
     h == null ? void 0 : h.images,
@@ -10533,18 +10540,18 @@ function AS(e, t = "erp_image") {
   const S = (ie = f == null ? void 0 : f.widgets) == null ? void 0 : ie.find((T) => String((T == null ? void 0 : T.name) || "").toLowerCase() === "image"), M = String((S == null ? void 0 : S.value) || "").trim();
   return M ? bn.apiURL(`/view?filename=${encodeURIComponent(M)}&type=input&subfolder=`) : "";
 }
-function Eh(e, t, n) {
+function Rh(e, t, n) {
   e.strokeStyle = "rgba(255,255,255,0.16)", e.lineWidth = 1, e.beginPath(), e.moveTo(t * 0.5, 0), e.lineTo(t * 0.5, n), e.moveTo(0, n * 0.5), e.lineTo(t, n * 0.5), e.stroke();
 }
-function Dh(e, t, n, r, a, o) {
+function Lh(e, t, n, r, a, o) {
   var S, M, b;
-  if (t.clearRect(0, 0, n, r), t.fillStyle = "#070707", t.fillRect(0, 0, n, r), !Qm(o) || n <= 1 || r <= 1) {
-    Eh(t, n, r);
+  if (t.clearRect(0, 0, n, r), t.fillStyle = "#070707", t.fillRect(0, 0, n, r), !rg(o) || n <= 1 || r <= 1) {
+    Rh(t, n, r);
     return;
   }
   const c = No(Number(a.yaw || 0), Number(a.pitch || 0), 0), f = Math.tan(Number(a.fov || 100) * _n * 0.5), h = Number(((b = (M = (S = e == null ? void 0 : e.widgets) == null ? void 0 : S.find) == null ? void 0 : M.call(S, (O) => (O == null ? void 0 : O.name) === "coverage")) == null ? void 0 : b.value) || 360) === 180 ? 180 : 360;
   e.__panoStandaloneCore || (e.__panoStandaloneCore = ko());
-  const g = MS(o), v = em({
+  const g = TS(o), v = im({
     stateRevision: [
       "standalone_preview_scene",
       g,
@@ -10561,18 +10568,18 @@ function Dh(e, t, n, r, a, o) {
   !!e.__panoStandaloneCore.syncState(v) && (() => {
     const O = e.__panoStandaloneCore.renderToTarget(
       "preview_node",
-      W1(a, h),
+      J1(a, h),
       { width: n, height: r, dpr: window.devicePixelRatio || 1 }
     );
     return O ? (t.drawImage(O, 0, 0, n, r), !0) : !1;
-  })() || (uS(e, t, { x: 0, y: 0, w: n, h: r }, c, f, o, wx), Eh(t, n, r));
+  })() || (hS(e, t, { x: 0, y: 0, w: n, h: r }, c, f, o, Px), Rh(t, n, r));
 }
-function Oh(e, t, n) {
+function zh(e, t, n) {
   return e >= n.x && e <= n.x + n.w && t >= n.y && t <= n.y + n.h;
 }
-class CS {
+class DS {
   constructor(t, n = {}) {
-    this.node = t, this.options = n, this.imageInputName = String(n.imageInputName || "erp_image"), this.buttonText = String(n.buttonText || "Open Preview"), this.errorText = "", this.root = null, this.canvas = null, this.ctx = null, this.widget = null, this.surfaceHost = null, this.surfaceApp = null, this.surfaceModel = null, this.fullscreenController = null, this.wheelCaptureCleanup = null, this.tearingDown = !1, this.resizeObserver = null, this.rafId = 0, this.needsDraw = !1, this.inTick = !1, this.queuedDuringTick = !1, this.img = null, this.imgSrc = "", this.mediaCleanup = null, this.videoPaused = !1, this.view = { yaw: 0, pitch: 0, fov: 100 }, this.controller = Pc({
+    this.node = t, this.options = n, this.imageInputName = String(n.imageInputName || "erp_image"), this.buttonText = String(n.buttonText || "Open Preview"), this.errorText = "", this.root = null, this.canvas = null, this.ctx = null, this.widget = null, this.surfaceHost = null, this.surfaceApp = null, this.surfaceModel = null, this.fullscreenController = null, this.wheelCaptureCleanup = null, this.tearingDown = !1, this.resizeObserver = null, this.rafId = 0, this.needsDraw = !1, this.inTick = !1, this.queuedDuringTick = !1, this.img = null, this.imgSrc = "", this.mediaCleanup = null, this.videoPaused = !1, this.view = { yaw: 0, pitch: 0, fov: 100 }, this.controller = Ac({
       getView: () => this.view,
       setView: (r) => {
         this.view = {
@@ -10669,9 +10676,9 @@ class CS {
         },
         afterResize: () => this.requestDraw()
       };
-      if (this.widget = Ws(
+      if (this.widget = Ws(Gu(
         this.node.addDOMWidget("preview", "preview", this.root, n)
-      ), this.widget) {
+      )), this.widget) {
         this.widget.serialize = !1;
         const r = typeof this.widget.computeLayoutSize == "function" ? this.widget.computeLayoutSize.bind(this.widget) : null;
         this.widget.computeLayoutSize = (a) => {
@@ -10679,7 +10686,7 @@ class CS {
           return {
             ...o,
             minHeight: Math.max(is, Number(o.minHeight || 0)),
-            minWidth: Math.max(NS, Number(o.minWidth || 0))
+            minWidth: Math.max(CS, Number(o.minWidth || 0))
           };
         };
       }
@@ -10692,7 +10699,7 @@ class CS {
     var t, n, r, a, o, c;
     if (!this.root || this.surfaceApp) return !1;
     try {
-      return Oc(), this.surfaceHost = document.createElement("div"), this.surfaceHost.className = "pano-preview-node-surface-host", this.root.appendChild(this.surfaceHost), this.surfaceModel = /* @__PURE__ */ ka({ fullscreen: !1 }), this.fullscreenController = SS({
+      return Fc(), this.surfaceHost = document.createElement("div"), this.surfaceHost.className = "pano-preview-node-surface-host", this.root.appendChild(this.surfaceHost), this.surfaceModel = /* @__PURE__ */ ka({ fullscreen: !1 }), this.fullscreenController = MS({
         root: this.root,
         documentRef: document,
         onChange: (f) => {
@@ -10702,7 +10709,7 @@ class CS {
           var f, h;
           return (h = (f = this.options).onOpen) == null ? void 0 : h.call(f, this.node);
         }
-      }), this.surfaceApp = _c(kS, {
+      }), this.surfaceApp = xc(AS, {
         model: this.surfaceModel,
         onAction: (f) => {
           var h, g;
@@ -10721,7 +10728,7 @@ class CS {
   }
   bindDomInput(t, n) {
     var a;
-    (a = this.wheelCaptureCleanup) == null || a.call(this), this.wheelCaptureCleanup = nm(n), t.addEventListener("pointerdown", (o) => {
+    (a = this.wheelCaptureCleanup) == null || a.call(this), this.wheelCaptureCleanup = om(n), t.addEventListener("pointerdown", (o) => {
       var c, f, h;
       o.button === 0 && ((c = n.focus) == null || c.call(n, { preventScroll: !0 }), (f = t.setPointerCapture) == null || f.call(t, o.pointerId), t.style.cursor = "grabbing", this.controller.startDrag(o.clientX, o.clientY, o.pointerId), o.preventDefault(), o.stopPropagation(), (h = o.stopImmediatePropagation) == null || h.call(o));
     }), t.addEventListener("pointermove", (o) => {
@@ -10740,11 +10747,11 @@ class CS {
       this.togglePlayback(), o.preventDefault(), o.stopPropagation(), (c = o.stopImmediatePropagation) == null || c.call(o);
     }), n.addEventListener("keydown", (o) => {
       var c;
-      _S(o, n) && (this.togglePlayback(), o.preventDefault(), o.stopPropagation(), (c = o.stopImmediatePropagation) == null || c.call(o));
+      kS(o, n) && (this.togglePlayback(), o.preventDefault(), o.stopPropagation(), (c = o.stopImmediatePropagation) == null || c.call(o));
     });
   }
   togglePlayback() {
-    !(this.img instanceof HTMLVideoElement) || !Qm(this.img) || (this.img.paused ? (this.videoPaused = !1, this.img.play().catch(() => {
+    !(this.img instanceof HTMLVideoElement) || !rg(this.img) || (this.img.paused ? (this.videoPaused = !1, this.img.play().catch(() => {
     })) : (this.videoPaused = !0, this.img.pause()), this.requestDraw());
   }
   attachLegacy() {
@@ -10757,7 +10764,7 @@ class CS {
       const a = t.localPoint(r);
       if (!a) return t.orig.onMouseDown ? t.orig.onMouseDown.apply(this, arguments) : void 0;
       const o = t.getLegacyPreviewRect();
-      return Oh(a.x, a.y, o) ? (t.legacyDragPointer = !0, t.controller.startDrag(a.x - o.x, a.y - o.y), (c = this.setDirtyCanvas) == null || c.call(this, !0, !1), !0) : t.orig.onMouseDown ? t.orig.onMouseDown.apply(this, arguments) : void 0;
+      return zh(a.x, a.y, o) ? (t.legacyDragPointer = !0, t.controller.startDrag(a.x - o.x, a.y - o.y), (c = this.setDirtyCanvas) == null || c.call(this, !0, !1), !0) : t.orig.onMouseDown ? t.orig.onMouseDown.apply(this, arguments) : void 0;
     }, this.node.onMouseMove = function(n, r) {
       var c;
       if (!t.legacyDragPointer || !t.controller.state.drag.active)
@@ -10771,8 +10778,8 @@ class CS {
       return !t.legacyDragPointer && !t.controller.state.drag.active ? t.orig.onMouseUp ? t.orig.onMouseUp.apply(this, arguments) : void 0 : (t.legacyDragPointer = !1, t.controller.endDrag(), (n = this.setDirtyCanvas) == null || n.call(this, !0, !1), !0);
     }, this.node.onMouseWheel = function(n, r, a) {
       var h, g, v, x, S, M;
-      const o = tS(this, n, r, a), c = t.getLegacyPreviewRect();
-      if (!o || !Oh(o.x, o.y, c))
+      const o = aS(this, n, r, a), c = t.getLegacyPreviewRect();
+      if (!o || !zh(o.x, o.y, c))
         return t.orig.onMouseWheel ? t.orig.onMouseWheel.apply(this, arguments) : void 0;
       Number(((h = t.view) == null ? void 0 : h.fov) || 100);
       const f = t.controller.applyWheelEvent(n, typeof r == "number" ? r : 0);
@@ -10784,26 +10791,26 @@ class CS {
   }
   getLegacyPreviewRect() {
     var r, a, o, c;
-    const t = Math.max(80, Number(((a = (r = this.node) == null ? void 0 : r.size) == null ? void 0 : a[0]) || 0) - bu * 2), n = Math.max(60, Number(((c = (o = this.node) == null ? void 0 : o.size) == null ? void 0 : c[1]) || 0) - Ah - bu);
-    return { x: bu, y: Ah, w: t, h: n };
+    const t = Math.max(80, Number(((a = (r = this.node) == null ? void 0 : r.size) == null ? void 0 : a[0]) || 0) - bu * 2), n = Math.max(60, Number(((c = (o = this.node) == null ? void 0 : o.size) == null ? void 0 : c[1]) || 0) - Eh - bu);
+    return { x: bu, y: Eh, w: t, h: n };
   }
   drawLegacy(t) {
     var r, a;
     if (!t || (a = (r = this.node) == null ? void 0 : r.flags) != null && a.collapsed) return;
     const n = this.getLegacyPreviewRect();
-    n.w <= 2 || n.h <= 2 || (t.save(), t.translate(n.x, n.y), Dh(this.node, t, n.w, n.h, this.view, this.img), this.errorText && (t.fillStyle = "rgba(18,18,22,0.92)", t.fillRect(0, 0, n.w, n.h), t.fillStyle = "rgba(236,236,242,0.92)", t.font = "600 12px sans-serif", t.textAlign = "center", t.textBaseline = "middle", t.fillText(this.errorText, n.w * 0.5, n.h * 0.5)), t.restore());
+    n.w <= 2 || n.h <= 2 || (t.save(), t.translate(n.x, n.y), Lh(this.node, t, n.w, n.h, this.view, this.img), this.errorText && (t.fillStyle = "rgba(18,18,22,0.92)", t.fillRect(0, 0, n.w, n.h), t.fillStyle = "rgba(236,236,242,0.92)", t.font = "600 12px sans-serif", t.textAlign = "center", t.textBaseline = "middle", t.fillText(this.errorText, n.w * 0.5, n.h * 0.5)), t.restore());
   }
   onResizeDom() {
     !this.root || !this.canvas || this.requestDraw();
   }
   syncCanvasSize() {
     if (!this.root || !this.canvas) return !1;
-    const t = this.root.getBoundingClientRect(), { width: n, height: r } = xS(t, window.devicePixelRatio || 1);
+    const t = this.root.getBoundingClientRect(), { width: n, height: r } = NS(t, window.devicePixelRatio || 1);
     return this.canvas.width !== n || this.canvas.height !== r ? (this.canvas.width = n, this.canvas.height = r, !0) : !1;
   }
   refreshImage() {
     var a, o, c;
-    const t = PS(this.node);
+    const t = IS(this.node);
     if (t) {
       if (t === this.imgSrc && this.img instanceof HTMLVideoElement) return;
       (a = this.mediaCleanup) == null || a.call(this), this.imgSrc = t, this.videoPaused = !1;
@@ -10818,7 +10825,7 @@ class CS {
       };
       return;
     }
-    const n = AS(this.node, this.imageInputName);
+    const n = ES(this.node, this.imageInputName);
     if (!n) {
       (o = this.mediaCleanup) == null || o.call(this), this.mediaCleanup = null, this.img = null, this.imgSrc = "", this.requestDraw();
       return;
@@ -10848,7 +10855,7 @@ class CS {
     var a, o;
     this.rafId = 0, this.inTick = !0, this.queuedDuringTick = !1, this.needsDraw = !1;
     const n = this.controller.stepInertia(t);
-    this.canvas && this.ctx ? (this.syncCanvasSize(), Dh(this.node, this.ctx, this.canvas.width, this.canvas.height, this.view, this.img), this.errorText && (this.ctx.fillStyle = "rgba(18,18,22,0.92)", this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height), this.ctx.fillStyle = "rgba(236,236,242,0.92)", this.ctx.font = "600 14px sans-serif", this.ctx.textAlign = "center", this.ctx.textBaseline = "middle", this.ctx.fillText(this.errorText, this.canvas.width * 0.5, this.canvas.height * 0.5))) : (o = (a = this.node).setDirtyCanvas) == null || o.call(a, !0, !1), this.inTick = !1, (n || this.needsDraw || this.queuedDuringTick || this.img instanceof HTMLVideoElement && !this.img.paused && !this.img.ended) && !this.rafId && (this.rafId = requestAnimationFrame(this.tick));
+    this.canvas && this.ctx ? (this.syncCanvasSize(), Lh(this.node, this.ctx, this.canvas.width, this.canvas.height, this.view, this.img), this.errorText && (this.ctx.fillStyle = "rgba(18,18,22,0.92)", this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height), this.ctx.fillStyle = "rgba(236,236,242,0.92)", this.ctx.font = "600 14px sans-serif", this.ctx.textAlign = "center", this.ctx.textBaseline = "middle", this.ctx.fillText(this.errorText, this.canvas.width * 0.5, this.canvas.height * 0.5))) : (o = (a = this.node).setDirtyCanvas) == null || o.call(a, !0, !1), this.inTick = !1, (n || this.needsDraw || this.queuedDuringTick || this.img instanceof HTMLVideoElement && !this.img.paused && !this.img.ended) && !this.rafId && (this.rafId = requestAnimationFrame(this.tick));
   }
   teardown() {
     var n, r, a, o, c, f, h, g, v, x, S, M, b, O, j, z, P, $;
@@ -10859,7 +10866,7 @@ class CS {
     } catch {
     }
     try {
-      $m(this.node, this.widget);
+      Um(this.node, this.widget);
     } catch {
     }
     this.node.onDrawForeground = this.orig.onDrawForeground, this.node.onMouseDown = this.orig.onMouseDown, this.node.onMouseMove = this.orig.onMouseMove, this.node.onMouseUp = this.orig.onMouseUp, this.node.onMouseWheel = this.orig.onMouseWheel, this.node.onExecuted = this.orig.onExecuted, this.node.onConnectionsChange = this.orig.onConnectionsChange, this.node.onResize = this.orig.onResize, this.node.onRemoved = this.orig.onRemoved;
@@ -10867,12 +10874,12 @@ class CS {
     t && (t.callback = this.orig.coverageWidgetCallback), ($ = (P = this.node.__panoStandaloneCore) == null ? void 0 : P.dispose) == null || $.call(P), this.node.__panoStandaloneCore = null, this.node.__panoPreviewNodeRuntime = null;
   }
 }
-function TS(e, t = {}) {
+function OS(e, t = {}) {
   if (!e || e.__panoPreviewNodeRuntime) return;
-  const n = new CS(e, t);
+  const n = new DS(e, t);
   e.__panoPreviewNodeRuntime = n, n.attach();
 }
-function eg(e, t, n) {
+function ig(e, t, n) {
   if (!(e != null && e.prototype) || typeof n != "function") return;
   const r = `__panoLifecyclePatched_${String(t || "default")}`;
   if (e[r]) return;
@@ -10905,48 +10912,48 @@ function eg(e, t, n) {
     return f;
   };
 }
-function jc(e) {
+function Vc(e) {
   return !!(e != null && e.prototype);
 }
 function yo(e, t) {
   return typeof t == "function" ? (...n) => t(e, ...n) : t;
 }
-function IS(e, t = {}) {
-  jc(e) || TS(e, {
+function FS(e, t = {}) {
+  Vc(e) || OS(e, {
     ...t,
     onOpen: yo(e, t.onOpen)
   });
 }
-function ES(e, t = {}) {
+function RS(e, t = {}) {
   const n = (t == null ? void 0 : t.enabled) === !0, r = {
     ...t,
     mode: "stickers",
     noPreview: !n
   };
-  if (!jc(e)) {
-    Ph(e, {
+  if (!Vc(e)) {
+    Ih(e, {
       ...r,
       onOpen: yo(e, t.onOpen)
     });
     return;
   }
-  eg(e, "stickers_node_preview", (a) => {
-    Ph(a, {
+  ig(e, "stickers_node_preview", (a) => {
+    Ih(a, {
       ...r,
       onOpen: yo(a, t.onOpen)
     });
   });
 }
-function DS(e, t = {}) {
-  if (!jc(e)) {
-    Mh(e, {
+function LS(e, t = {}) {
+  if (!Vc(e)) {
+    Th(e, {
       ...t,
       onOpen: yo(e, t.onOpen)
     });
     return;
   }
-  eg(e, "cutout_preview", (n) => {
-    Mh(n, {
+  ig(e, "cutout_preview", (n) => {
+    Th(n, {
       ...t,
       onOpen: yo(n, t.onOpen)
     });
@@ -11031,10 +11038,10 @@ const En = {
     sizeScale: 0.92
   }
 }, Dr = "pen";
-function Fh(e, t) {
+function $h(e, t) {
   e.brushPresetId = t.id, e.stampKind = t.stampKind, e.hardness = t.hardness, e.spacing = t.spacing, e.flow = t.flow, e.opacity = t.opacity, e.opacityMode = t.opacityMode, e.aspect = t.aspect, e.angle = { ...t.angle }, e.velocityWidthFactor = t.velocityWidthFactor, e.chiselEdgeLift = t.chiselEdgeLift, e.chiselCenterDip = t.chiselCenterDip, e.chiselFiber = t.chiselFiber ?? 0, e.crayonGrain = t.crayonGrain ?? 0, e.scatter = t.scatter ? { ...t.scatter } : null;
 }
-function OS(e = 80, t = null, n = 8) {
+function zS(e = 80, t = null, n = 8) {
   const r = [];
   let a = -1;
   const o = Math.max(1, Number(e || 80)), c = Math.max(1, Number(n || 8));
@@ -11083,7 +11090,7 @@ function OS(e = 80, t = null, n = 8) {
     hydrate: f
   };
 }
-function Rh(e = {}) {
+function jh(e = {}) {
   return {
     type: String((e == null ? void 0 : e.type) || "erp_image"),
     source: (e == null ? void 0 : e.source) || null,
@@ -11093,7 +11100,7 @@ function Rh(e = {}) {
     visible: (e == null ? void 0 : e.visible) !== !1
   };
 }
-function FS(e = {}) {
+function $S(e = {}) {
   return {
     yawDeg: Number((e == null ? void 0 : e.yawDeg) || 0),
     pitchDeg: Number((e == null ? void 0 : e.pitchDeg) || 0),
@@ -11102,7 +11109,7 @@ function FS(e = {}) {
     vFovDeg: W(Number((e == null ? void 0 : e.vFovDeg) || 30), 1, 179)
   };
 }
-function Lh(e = {}, t = 0) {
+function Vh(e = {}, t = 0) {
   var a;
   const n = String((e == null ? void 0 : e.type) || "");
   if (!n) return null;
@@ -11115,25 +11122,25 @@ function Lh(e = {}, t = 0) {
     opacity: Number((e == null ? void 0 : e.opacity) ?? 1),
     zIndex: Number((e == null ? void 0 : e.zIndex) ?? (e == null ? void 0 : e.z_index) ?? t)
   };
-  return n === "sticker" ? (r.transform = FS((e == null ? void 0 : e.transform) || e), r.params = {
+  return n === "sticker" ? (r.transform = $S((e == null ? void 0 : e.transform) || e), r.params = {
     ...e != null && e.params && typeof e.params == "object" ? e.params : {},
     crop: (e == null ? void 0 : e.crop) || ((a = e == null ? void 0 : e.params) == null ? void 0 : a.crop) || { x0: 0, y0: 0, x1: 1, y1: 1 }
   }) : (r.transform = e != null && e.transform && typeof e.transform == "object" ? { ...e.transform } : null, r.params = e != null && e.params && typeof e.params == "object" ? { ...e.params } : {}), r;
 }
-function RS(e = {}) {
+function jS(e = {}) {
   var r, a;
   if (e != null && e.objectPass && Array.isArray(e.objectPass.objects))
     return Sa({
       stateRevision: String((e == null ? void 0 : e.stateRevision) || ""),
-      background: Rh((e == null ? void 0 : e.background) || {}),
+      background: jh((e == null ? void 0 : e.background) || {}),
       objectPass: {
         selectedId: ((r = e == null ? void 0 : e.objectPass) == null ? void 0 : r.selectedId) ?? null,
         hoveredId: ((a = e == null ? void 0 : e.objectPass) == null ? void 0 : a.hoveredId) ?? null,
-        objects: e.objectPass.objects.map((o, c) => Lh(o, c)).filter(Boolean)
+        objects: e.objectPass.objects.map((o, c) => Vh(o, c)).filter(Boolean)
       },
       overlay: e != null && e.overlay && typeof e.overlay == "object" ? { ...e.overlay } : {}
     });
-  const t = Rh((e == null ? void 0 : e.background) || {}), n = (Array.isArray(e == null ? void 0 : e.objects) ? e.objects : []).map((o, c) => Lh(o, c)).filter(Boolean);
+  const t = jh((e == null ? void 0 : e.background) || {}), n = (Array.isArray(e == null ? void 0 : e.objects) ? e.objects : []).map((o, c) => Vh(o, c)).filter(Boolean);
   return Sa({
     stateRevision: String((e == null ? void 0 : e.stateRevision) || ""),
     background: t,
@@ -11177,7 +11184,7 @@ function Js(e = {}) {
     dpr: Math.max(0.1, Number((e == null ? void 0 : e.dpr) || 1))
   };
 }
-function LS(e = {}) {
+function VS(e = {}) {
   const t = String((e == null ? void 0 : e.targetId) || "panorama_scene_camera"), n = (e == null ? void 0 : e.renderCore) || ko((e == null ? void 0 : e.coreOptions) || {});
   let r = null, a = "";
   function o(x) {
@@ -11199,7 +11206,7 @@ function LS(e = {}) {
     });
   }
   function c(x = {}) {
-    const S = RS(x), M = o(S);
+    const S = jS(x), M = o(S);
     return a === M || !n.syncState(S) ? !1 : (r = S, a = M, !0);
   }
   function f(x = {}, S = {}) {
@@ -11234,14 +11241,14 @@ function LS(e = {}) {
     dispose: v
   };
 }
-function zS(e, t, n) {
+function HS(e, t, n) {
   return new Promise((r, a) => {
     e.toBlob((o) => {
       o ? r(o) : a(new Error("Failed to export panorama scene camera frame."));
     }, t, n);
   });
 }
-async function $S(e, t = {}) {
+async function US(e, t = {}) {
   var h, g;
   if (!e || typeof e.renderFrame != "function")
     throw new Error("exportPanoramaSceneCameraFrame requires a valid camera instance.");
@@ -11254,9 +11261,9 @@ async function $S(e, t = {}) {
   ), o = e.renderFrame(n, a);
   if (!o) throw new Error("Panorama scene camera render returned null.");
   const c = String((t == null ? void 0 : t.format) || "png").toLowerCase() === "jpeg" ? "image/jpeg" : "image/png", f = (t == null ? void 0 : t.quality) == null ? 0.92 : Number(t.quality);
-  return zS(o, c, f);
+  return HS(o, c, f);
 }
-function jS(e, t, n = {}) {
+function BS(e, t, n = {}) {
   if (!e || !t || typeof t.appendChild != "function")
     throw new Error("mountPanoramaSceneCamera requires a camera and container.");
   const r = document.createElement("canvas");
@@ -11298,8 +11305,8 @@ function jS(e, t, n = {}) {
     }
   };
 }
-function VS(e = {}) {
-  const t = LS({
+function GS(e = {}) {
+  const t = VS({
     ...e,
     targetId: String((e == null ? void 0 : e.targetId) || "cutout_camera")
   });
@@ -11313,11 +11320,11 @@ function VS(e = {}) {
     },
     mount(n, r = {}) {
       const a = r != null && r.shot ? vr(r.shot) : r == null ? void 0 : r.view;
-      return jS(t, n, { ...r, view: a });
+      return BS(t, n, { ...r, view: a });
     },
     exportFrame(n = {}) {
       const r = n != null && n.shot ? { ...n, camera: vr(n.shot) } : n;
-      return $S(t, r);
+      return US(t, r);
     }
   };
 }
@@ -11325,7 +11332,7 @@ function na(e, t, n, r) {
   const a = Array.isArray(e) ? e.find((o) => String((o == null ? void 0 : o[t]) || "") === String(n || "")) : null;
   a && Object.assign(a, r);
 }
-function HS(e = {}) {
+function KS(e = {}) {
   const t = String(e.preview_quality || "balanced"), n = [
     { value: "draft", label: "Draft" },
     { value: "balanced", label: "Balanced" },
@@ -11340,7 +11347,7 @@ function HS(e = {}) {
     qualityOptions: n.map((r) => ({ ...r, active: r.value === t }))
   };
 }
-function US({
+function WS({
   editor: e,
   swatches: t,
   paintColorPopOpen: n,
@@ -11408,7 +11415,7 @@ function US({
     activeTools: { paint: e.paintTool, mask: e.maskTool }
   };
 }
-function BS({ coverage: e, uiSettings: t, normalizeCoverageValue: n }) {
+function YS({ coverage: e, uiSettings: t, normalizeCoverageValue: n }) {
   return {
     coverage: { value: n(e), disabled: !1 },
     transformTitle: !1,
@@ -11420,7 +11427,7 @@ function BS({ coverage: e, uiSettings: t, normalizeCoverageValue: n }) {
     footerButtons: [{ action: "close-preview", label: "Close", primary: !0 }]
   };
 }
-function GS({
+function qS({
   coverage: e,
   readOnly: t,
   selectionPicker: n,
@@ -11452,7 +11459,7 @@ function GS({
     ]
   };
 }
-function KS({
+function XS({
   type: e,
   selected: t,
   selectedItems: n,
@@ -11532,10 +11539,10 @@ function KS({
     anchor: { minX: P, maxX: $, minY: I, maxY: R }
   };
 }
-const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-ready", "data-settled"], XS = ["aria-label", "data-tip"], JS = {
+const JS = { class: "pano-floating-right" }, ZS = ["data-settled"], QS = ["data-ready", "data-settled"], ew = ["aria-label", "data-tip"], tw = {
   key: 1,
   class: "pano-camera-preview-label"
-}, ZS = {
+}, nw = {
   __name: "PanoFloatingRight",
   props: {
     buttons: { type: Array, default: () => [] },
@@ -11544,7 +11551,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
   },
   setup(e) {
     return (t, n) => (ke(), Pe(ot, null, [
-      X("div", WS, [
+      X("div", JS, [
         (ke(!0), Pe(ot, null, jt(e.buttons, (r) => (ke(), Ii(tn, {
           key: r.action,
           icon: r.icon,
@@ -11582,18 +11589,18 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             $e(en, {
               icon: e.previewToggle.icon
             }, null, 8, ["icon"])
-          ], 8, XS)) : zt("", !0),
-          e.preview.ready !== !0 && e.preview.settled !== !0 ? (ke(), Pe("div", JS, ct(e.preview.label || "Preview unavailable"), 1)) : zt("", !0)
-        ], 14, qS)
-      ], 8, YS), [
+          ], 8, ew)) : zt("", !0),
+          e.preview.ready !== !0 && e.preview.settled !== !0 ? (ke(), Pe("div", tw, ct(e.preview.label || "Preview unavailable"), 1)) : zt("", !0)
+        ], 14, QS)
+      ], 8, ZS), [
         [wo, e.preview.visible]
       ])
     ], 64));
   }
-}, QS = {
+}, rw = {
   viewBox: "0 0 40 40",
   "aria-hidden": "true"
-}, ew = ["y2", "transform"], tw = ["transform"], nw = {
+}, iw = ["y2", "transform"], aw = ["transform"], ow = {
   __name: "PanoFrameRollKnob",
   props: { model: { type: Object, default: () => ({}) } },
   setup(e) {
@@ -11604,7 +11611,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       "data-tip": "Roll",
       "aria-hidden": "true"
     }, [
-      (ke(), Pe("svg", QS, [
+      (ke(), Pe("svg", rw, [
         o[1] || (o[1] = X("circle", {
           class: "pano-frame-roll-knob-ring",
           cx: "20",
@@ -11619,7 +11626,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
           x2: "20",
           y2: c % 45 === 0 ? 7 : 6,
           transform: `rotate(${c} 20 20)`
-        }, null, 10, ew))), 128)),
+        }, null, 10, iw))), 128)),
         X("g", { transform: r.value }, [...o[0] || (o[0] = [
           X("line", {
             class: "pano-frame-roll-knob-needle",
@@ -11628,7 +11635,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             x2: "20",
             y2: "8"
           }, null, -1)
-        ])], 8, tw),
+        ])], 8, aw),
         o[2] || (o[2] = X("circle", {
           class: "pano-frame-roll-knob-center",
           cx: "20",
@@ -11640,7 +11647,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       [wo, e.model.visible === !0]
     ]);
   }
-}, rw = {
+}, sw = {
   __name: "PanoFrameRail",
   props: {
     model: { type: Object, default: () => ({}) }
@@ -11650,7 +11657,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       class: ft(["pano-frame-rail", { "is-hidden": e.model.visible !== !0 }]),
       "data-frame-rail": ""
     }, [
-      $e(wm, {
+      $e(Pm, {
         model: e.model,
         mode: "rail",
         "data-aspect-action": "frame-aspect-set"
@@ -11661,16 +11668,16 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
         tip: "Toggle portrait/landscape",
         attrs: { "data-action": "frame-rotate-90", disabled: e.model.disabled === !0 }
       }, null, 8, ["icon", "attrs"]),
-      $e(nw, {
+      $e(ow, {
         model: e.model.rollKnob || {}
       }, null, 8, ["model"])
     ], 2));
   }
-}, iw = ["aria-label"], aw = { class: "pano-canvas-confirm-title" }, ow = { class: "pano-canvas-confirm-text" }, sw = { class: "pano-canvas-confirm-actions" }, lw = {
+}, lw = ["aria-label"], uw = { class: "pano-canvas-confirm-title" }, cw = { class: "pano-canvas-confirm-text" }, fw = { class: "pano-canvas-confirm-actions" }, dw = {
   class: "pano-btn pano-btn-primary",
   type: "button",
   "data-action": "confirm-accept"
-}, uw = {
+}, hw = {
   __name: "PanoConfirmDialog",
   props: {
     model: { type: Object, default: () => ({}) }
@@ -11730,7 +11737,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
     }
     return wi(() => t.model.visible, (x, S) => {
       if (x) {
-        a = document.activeElement, hc(() => {
+        a = document.activeElement, pc(() => {
           f();
         });
         return;
@@ -11757,32 +11764,32 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
         tabindex: "-1",
         onKeydown: g
       }, [
-        X("div", aw, ct(e.model.title), 1),
-        X("div", ow, ct(e.model.text), 1),
-        X("div", sw, [
+        X("div", uw, ct(e.model.title), 1),
+        X("div", cw, ct(e.model.text), 1),
+        X("div", fw, [
           S[0] || (S[0] = X("button", {
             class: "pano-btn",
             type: "button",
             "data-action": "confirm-cancel"
           }, "Cancel", -1)),
-          X("button", lw, ct(e.model.confirmLabel || "Confirm"), 1)
+          X("button", dw, ct(e.model.confirmLabel || "Confirm"), 1)
         ])
-      ], 40, iw)
+      ], 40, lw)
     ], 512)) : zt("", !0);
   }
-}, cw = ["data-paint-pane"], fw = ["hidden"], dw = ["data-paint-color-swatch", "aria-label", "aria-pressed", "disabled"], hw = ["aria-pressed", "disabled"], pw = ["hidden"], mw = { class: "pano-paint-color-pop-head" }, gw = { class: "pano-paint-color-field" }, bw = {
+}, pw = ["data-paint-pane"], mw = ["hidden"], gw = ["data-paint-color-swatch", "aria-label", "aria-pressed", "disabled"], bw = ["aria-pressed", "disabled"], yw = ["hidden"], vw = { class: "pano-paint-color-pop-head" }, _w = { class: "pano-paint-color-field" }, xw = {
   class: "pano-paint-sv-panel",
   "data-paint-color-sv": ""
-}, yw = {
+}, Sw = {
   class: "pano-paint-hue-strip",
   "data-paint-hue-strip": ""
-}, vw = { class: "pano-paint-color-field" }, _w = { class: "pano-paint-alpha-wrap" }, xw = ["value"], Sw = { "data-paint-alpha-value": "" }, ww = ["hidden"], kw = {
+}, ww = { class: "pano-paint-color-field" }, kw = { class: "pano-paint-alpha-wrap" }, Nw = ["value"], Mw = { "data-paint-alpha-value": "" }, Pw = ["hidden"], Aw = {
   class: "pano-paint-color-history-list",
   "data-paint-color-history": ""
-}, Nw = ["data-paint-history-index", "aria-label", "disabled"], Mw = ["data-paint-footer"], Pw = ["data-paint-group"], Aw = ["hidden"], Cw = ["value", "disabled"], Tw = {
+}, Cw = ["data-paint-history-index", "aria-label", "disabled"], Tw = ["data-paint-footer"], Iw = ["data-paint-group"], Ew = ["hidden"], Dw = ["value", "disabled"], Ow = {
   class: "pano-paint-size-value",
   "data-paint-size-value": ""
-}, Iw = ["hidden"], Ew = {
+}, Fw = ["hidden"], Rw = {
   __name: "PanoPaintDock",
   props: {
     paintSwatches: { type: Array, default: () => [] },
@@ -11822,7 +11829,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
               style: Bt(t(f)),
               "aria-pressed": e.state.activeSwatchId === f.id ? "true" : "false",
               disabled: e.state.colorEnabled === !1
-            }, null, 14, dw))), 128)),
+            }, null, 14, gw))), 128)),
             X("button", {
               class: ft(["pano-paint-color-dot pano-paint-color-dot-rainbow", { active: e.state.customColorActive === !0 }]),
               type: "button",
@@ -11831,7 +11838,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
               "aria-pressed": e.state.customColorActive === !0 ? "true" : "false",
               disabled: e.state.colorEnabled === !1,
               style: Bt({ "--custom-color": String(e.state.customColorCss || "") })
-            }, null, 14, hw),
+            }, null, 14, bw),
             X("div", {
               class: "pano-paint-color-pop",
               "data-paint-color-pop": "",
@@ -11843,7 +11850,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 "--picker-hue": String(e.state.pickerHue || "0%")
               })
             }, [
-              X("div", mw, [
+              X("div", vw, [
                 X("span", {
                   class: "pano-paint-color-preview",
                   "data-paint-color-preview": "",
@@ -11851,15 +11858,15 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 }, null, 4),
                 a[0] || (a[0] = X("span", { class: "pano-paint-color-pop-label" }, "Custom Color", -1))
               ]),
-              X("div", gw, [
-                X("div", bw, [
+              X("div", _w, [
+                X("div", xw, [
                   X("div", {
                     class: "pano-paint-sv-cursor",
                     "data-paint-color-sv-cursor": "",
                     style: Bt({ left: String(e.state.pickerSvLeft || "0%"), top: String(e.state.pickerSvTop || "0%") })
                   }, null, 4)
                 ]),
-                X("div", yw, [
+                X("div", Sw, [
                   X("div", {
                     class: "pano-paint-hue-handle",
                     "data-paint-hue-handle": "",
@@ -11867,9 +11874,9 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   }, null, 4)
                 ])
               ]),
-              X("label", vw, [
+              X("label", ww, [
                 a[1] || (a[1] = X("span", null, "Opacity", -1)),
-                X("div", _w, [
+                X("div", kw, [
                   X("input", {
                     type: "range",
                     min: "0",
@@ -11877,8 +11884,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                     step: "1",
                     value: e.state.alphaValue ?? 100,
                     "data-paint-alpha-slider": ""
-                  }, null, 8, xw),
-                  X("span", Sw, ct(e.state.alphaText || "100%"), 1)
+                  }, null, 8, Nw),
+                  X("span", Mw, ct(e.state.alphaText || "100%"), 1)
                 ])
               ]),
               X("div", {
@@ -11886,7 +11893,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 "data-paint-color-history-wrap": "",
                 hidden: e.state.historyVisible === !1
               }, [
-                X("div", kw, [
+                X("div", Aw, [
                   (ke(!0), Pe(ot, null, jt(e.state.historyEntries || [], (f) => (ke(), Pe("button", {
                     key: f.index,
                     class: ft(["pano-paint-color-history-dot", { empty: !f.color }]),
@@ -11895,11 +11902,11 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                     "aria-label": `Recent color ${f.index + 1}`,
                     disabled: !f.color,
                     style: Bt(n(f.color))
-                  }, null, 14, Nw))), 128))
+                  }, null, 14, Cw))), 128))
                 ])
-              ], 8, ww)
-            ], 12, pw)
-          ], 10, fw)) : zt("", !0),
+              ], 8, Pw)
+            ], 12, yw)
+          ], 10, mw)) : zt("", !0),
           X("div", {
             class: "pano-paint-footer",
             "data-paint-footer": o.footer
@@ -11919,7 +11926,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   attrs: { [f.attr]: f.key }
                 }, null, 8, ["icon", "label", "tip", "extra-class", "attrs"]);
               }), 128))
-            ], 8, Pw),
+            ], 8, Iw),
             X("div", {
               class: ft(["pano-paint-size-row", { disabled: e.state.sizeDisabled === !0 }]),
               "data-paint-size-row": "",
@@ -11935,9 +11942,9 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 value: e.state.sizeValue ?? 10,
                 disabled: e.state.sizeDisabled === !0,
                 style: Bt({ "--v": String(e.state.sizeFill || "0%") })
-              }, null, 12, Cw),
-              X("span", Tw, ct(e.state.sizeText || "10"), 1)
-            ], 10, Aw),
+              }, null, 12, Dw),
+              X("span", Ow, ct(e.state.sizeText || "10"), 1)
+            ], 10, Ew),
             X("div", {
               class: "pano-paint-clear-row",
               "data-paint-clear-row": "",
@@ -11950,13 +11957,13 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 "extra-class": "pano-paint-layer-clear",
                 attrs: { "data-paint-layer-clear-current": o.clearTarget }
               }, null, 8, ["icon", "label", "tip", "attrs"])
-            ], 8, Iw)
-          ], 8, Mw)
-        ], 10, cw);
+            ], 8, Fw)
+          ], 8, Tw)
+        ], 10, pw);
       }), 128))
     ], 2));
   }
-}, Dw = {
+}, Lw = {
   __name: "PanoPaintOverlays",
   setup(e, { expose: t }) {
     const n = /* @__PURE__ */ vn(null), r = /* @__PURE__ */ vn(null), a = /* @__PURE__ */ vn(null);
@@ -11988,16 +11995,16 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       ], 512)
     ], 64));
   }
-}, Ow = {
+}, zw = {
   key: 0,
   class: "pano-cutout-menu"
-}, Fw = {
+}, $w = {
   class: "pano-btn pano-btn-icon",
   type: "button",
   "data-action": "aspect",
   "aria-label": "Aspect Ratio",
   "data-tip": "Aspect ratio"
-}, Rw = ["data-aspect"], Lw = ["data-action", "aria-label", "data-tip", "disabled"], zw = {
+}, jw = ["data-aspect"], Vw = ["data-action", "aria-label", "data-tip", "disabled"], Hw = {
   __name: "PanoSelectionMenu",
   props: {
     model: { type: Object, default: () => ({}) }
@@ -12011,8 +12018,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       (ke(!0), Pe(ot, null, jt(e.model.items || [], (r) => (ke(), Pe(ot, {
         key: r.key
       }, [
-        r.kind === "aspect" ? (ke(), Pe("div", Ow, [
-          X("button", Fw, [
+        r.kind === "aspect" ? (ke(), Pe("div", zw, [
+          X("button", $w, [
             $e(en, {
               icon: r.icon
             }, null, 8, ["icon"])
@@ -12028,7 +12035,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
               type: "button",
               "data-action": "aspect-set",
               "data-aspect": a.value
-            }, ct(a.label), 11, Rw))), 128))
+            }, ct(a.label), 11, jw))), 128))
           ], 2)
         ])) : (ke(), Pe("button", {
           key: 1,
@@ -12042,57 +12049,57 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
           $e(en, {
             icon: r.icon
           }, null, 8, ["icon"])
-        ], 8, Lw))
+        ], 8, Vw))
       ], 64))), 128))
     ], 4));
   }
-}, $w = {
+}, Uw = {
   class: "pano-side",
   "data-side": ""
-}, jw = { class: "pano-side-head" }, Vw = { class: "pano-side-title" }, Hw = {
+}, Bw = { class: "pano-side-head" }, Gw = { class: "pano-side-title" }, Kw = {
   class: "pano-side-title-icon",
   "aria-hidden": "true"
-}, Uw = {
+}, Ww = {
   key: 0,
   class: "pano-side-scroll"
-}, Bw = { class: "pano-inspector" }, Gw = { class: "pano-ui-row pano-coverage-row" }, Kw = ["data-selected"], Ww = ["aria-pressed", "disabled"], Yw = ["aria-pressed", "disabled"], qw = {
+}, Yw = { class: "pano-inspector" }, qw = { class: "pano-ui-row pano-coverage-row" }, Xw = ["data-selected"], Jw = ["aria-pressed", "disabled"], Zw = ["aria-pressed", "disabled"], Qw = {
   key: 0,
   class: "pano-section-title"
-}, Xw = {
+}, ek = {
   key: 1,
   class: "pano-field-wide pano-target-row"
-}, Jw = {
+}, tk = {
   class: "pano-picker",
   "data-picker": "selection"
-}, Zw = ["disabled"], Qw = { class: "pano-picker-label" }, ek = {
+}, nk = ["disabled"], rk = { class: "pano-picker-label" }, ik = {
   key: 0,
   class: "pano-picker-item-icon",
   "aria-hidden": "true"
-}, tk = ["hidden"], nk = ["data-selection-id"], rk = {
+}, ak = ["hidden"], ok = ["data-selection-id"], sk = {
   key: 0,
   class: "pano-picker-item-icon",
   "aria-hidden": "true"
-}, ik = {
+}, lk = {
   key: 2,
   class: "pano-state-actions"
-}, ak = ["disabled"], ok = ["data-key"], sk = ["min", "max", "step", "value", "disabled", "data-param-key"], lk = ["min", "max", "step", "value", "disabled", "data-param-key"], uk = { class: "pano-visibility-section" }, ck = { class: "pano-visibility-stack" }, fk = ["data-visibility-row"], dk = { class: "pano-visibility-name" }, hk = {
+}, uk = ["disabled"], ck = ["data-key"], fk = ["min", "max", "step", "value", "disabled", "data-param-key"], dk = ["min", "max", "step", "value", "disabled", "data-param-key"], hk = { class: "pano-visibility-section" }, pk = { class: "pano-visibility-stack" }, mk = ["data-visibility-row"], gk = { class: "pano-visibility-name" }, bk = {
   class: "pano-visibility-name-icon",
   "aria-hidden": "true"
-}, pk = ["data-visibility", "aria-label", "aria-pressed", "data-tip", "disabled"], mk = ["open"], gk = {
+}, yk = ["data-visibility", "aria-label", "aria-pressed", "data-tip", "disabled"], vk = ["open"], _k = {
   class: "pano-ui-caret",
   "aria-hidden": "true"
-}, bk = { class: "pano-ui-settings-body" }, yk = { class: "pano-ui-row" }, vk = ["data-selected"], _k = ["aria-pressed"], xk = ["aria-pressed"], Sk = { class: "pano-ui-row" }, wk = ["data-selected"], kk = ["aria-pressed"], Nk = ["aria-pressed"], Mk = { class: "pano-ui-row" }, Pk = {
+}, xk = { class: "pano-ui-settings-body" }, Sk = { class: "pano-ui-row" }, wk = ["data-selected"], kk = ["aria-pressed"], Nk = ["aria-pressed"], Mk = { class: "pano-ui-row" }, Pk = ["data-selected"], Ak = ["aria-pressed"], Ck = ["aria-pressed"], Tk = { class: "pano-ui-row" }, Ik = {
   class: "pano-picker pano-ui-picker",
   "data-ui-picker": "quality"
-}, Ak = {
+}, Ek = {
   id: "pano-ui-quality",
   class: "pano-picker-trigger",
   type: "button",
   "data-action": "toggle-quality-picker"
-}, Ck = { class: "pano-picker-label" }, Tk = ["hidden"], Ik = ["data-quality"], Ek = {
+}, Dk = { class: "pano-picker-label" }, Ok = ["hidden"], Fk = ["data-quality"], Rk = {
   key: 1,
   class: "pano-side-footer"
-}, Dk = ["data-action"], Ok = {
+}, Lk = ["data-action"], zk = {
   __name: "PanoSidePanel",
   props: {
     nodeTitle: { type: String, default: "Panorama Stickers" },
@@ -12111,10 +12118,10 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
     }
     return (o, c) => {
       var f, h, g, v, x;
-      return ke(), Pe("div", $w, [
-        X("div", jw, [
-          X("div", Vw, [
-            X("span", Hw, [
+      return ke(), Pe("div", Uw, [
+        X("div", Bw, [
+          X("div", Gw, [
+            X("span", Kw, [
               $e(en, {
                 icon: pt(Te).globe
               }, null, 8, ["icon"])
@@ -12124,12 +12131,12 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
           c[0] || (c[0] = X("div", { class: "pano-side-actions" }, null, -1))
         ]),
         c[13] || (c[13] = X("div", { class: "pano-divider" }, null, -1)),
-        n.value ? (ke(), Pe("div", Uw, [
-          X("div", Bw, [
+        n.value ? (ke(), Pe("div", Ww, [
+          X("div", Yw, [
             c[12] || (c[12] = X("div", { class: "pano-section-title" }, [
               X("span", null, "Scene")
             ], -1)),
-            X("div", Gw, [
+            X("div", qw, [
               c[1] || (c[1] = X("label", null, "Coverage", -1)),
               X("div", {
                 class: "pano-segment",
@@ -12143,7 +12150,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   "data-coverage": "360",
                   "aria-pressed": ((h = e.model.coverage) == null ? void 0 : h.value) === 360 ? "true" : "false",
                   disabled: ((g = e.model.coverage) == null ? void 0 : g.disabled) === !0
-                }, "360", 8, Ww),
+                }, "360", 8, Jw),
                 X("button", {
                   class: "pano-segment-btn",
                   type: "button",
@@ -12151,23 +12158,23 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   "data-coverage": "180",
                   "aria-pressed": ((v = e.model.coverage) == null ? void 0 : v.value) === 180 ? "true" : "false",
                   disabled: ((x = e.model.coverage) == null ? void 0 : x.disabled) === !0
-                }, "180", 8, Yw)
-              ], 8, Kw)
+                }, "180", 8, Zw)
+              ], 8, Xw)
             ]),
-            e.model.transformTitle !== !1 ? (ke(), Pe("div", qw, [...c[2] || (c[2] = [
+            e.model.transformTitle !== !1 ? (ke(), Pe("div", Qw, [...c[2] || (c[2] = [
               X("span", null, "Transform", -1)
             ])])) : zt("", !0),
-            e.model.selectionPicker ? (ke(), Pe("div", Xw, [
+            e.model.selectionPicker ? (ke(), Pe("div", ek, [
               X("label", null, ct(e.model.selectionPicker.label), 1),
-              X("div", Jw, [
+              X("div", tk, [
                 X("button", {
                   class: "pano-picker-trigger",
                   type: "button",
                   "data-action": "toggle-selection-picker",
                   disabled: e.model.selectionPicker.disabled === !0
                 }, [
-                  X("span", Qw, [
-                    e.model.selectionPicker.currentIcon ? (ke(), Pe("span", ek, [
+                  X("span", rk, [
+                    e.model.selectionPicker.currentIcon ? (ke(), Pe("span", ik, [
                       $e(en, {
                         icon: e.model.selectionPicker.currentIcon
                       }, null, 8, ["icon"])
@@ -12175,7 +12182,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                     X("span", null, ct(e.model.selectionPicker.currentLabel), 1)
                   ]),
                   c[3] || (c[3] = X("span", { class: "pano-picker-caret" }, "▾", -1))
-                ], 8, Zw),
+                ], 8, nk),
                 X("div", {
                   class: "pano-picker-pop",
                   hidden: e.model.selectionPicker.open !== !0
@@ -12187,17 +12194,17 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                     "data-action": "select-picker-item",
                     "data-selection-id": S.id
                   }, [
-                    S.icon ? (ke(), Pe("span", rk, [
+                    S.icon ? (ke(), Pe("span", sk, [
                       $e(en, {
                         icon: S.icon
                       }, null, 8, ["icon"])
                     ])) : zt("", !0),
                     X("span", null, ct(S.label), 1)
-                  ], 10, nk))), 128))
-                ], 8, tk)
+                  ], 10, ok))), 128))
+                ], 8, ak)
               ])
             ])) : zt("", !0),
-            e.model.copyStateButton ? (ke(), Pe("div", ik, [
+            e.model.copyStateButton ? (ke(), Pe("div", lk, [
               X("button", {
                 class: "pano-btn subtle pano-btn-tight pano-btn-copy",
                 type: "button",
@@ -12208,7 +12215,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   icon: pt(Te).copy
                 }, null, 8, ["icon"]),
                 X("span", null, ct(e.model.copyStateButton.label), 1)
-              ], 8, ak)
+              ], 8, uk)
             ])) : zt("", !0),
             X("div", {
               class: ft(["pano-params", { disabled: e.model.paramsDisabled === !0 }])
@@ -12233,7 +12240,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   "data-action": "param-input",
                   "data-input-kind": "range",
                   "data-param-key": S.key
-                }, null, 12, sk),
+                }, null, 12, fk),
                 X("input", {
                   type: "number",
                   min: S.min,
@@ -12244,23 +12251,23 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   "data-action": "param-input",
                   "data-input-kind": "number",
                   "data-param-key": S.key
-                }, null, 8, lk)
-              ], 8, ok))), 128))
+                }, null, 8, dk)
+              ], 8, ck))), 128))
             ], 2),
             (e.model.visibilityRows || []).length ? (ke(), Pe(ot, { key: 3 }, [
               c[5] || (c[5] = X("div", { class: "pano-divider" }, null, -1)),
-              X("div", uk, [
+              X("div", hk, [
                 c[4] || (c[4] = X("div", { class: "pano-section-title" }, [
                   X("span", null, "Layers")
                 ], -1)),
-                X("div", ck, [
+                X("div", pk, [
                   (ke(!0), Pe(ot, null, jt(e.model.visibilityRows, (S) => (ke(), Pe("div", {
                     key: S.key,
                     class: ft(["pano-visibility-row", { "is-hidden": S.visible === !1, "is-disabled": S.enabled === !1 }]),
                     "data-visibility-row": S.key
                   }, [
-                    X("span", dk, [
-                      X("span", hk, [
+                    X("span", gk, [
+                      X("span", bk, [
                         $e(en, {
                           icon: S.icon
                         }, null, 8, ["icon"])
@@ -12280,8 +12287,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                       $e(en, {
                         icon: S.visible === !0 ? pt(Te).eye : pt(Te).eye_dashed
                       }, null, 8, ["icon"])
-                    ], 10, pk)
-                  ], 10, fk))), 128))
+                    ], 10, yk)
+                  ], 10, mk))), 128))
                 ])
               ])
             ], 64)) : zt("", !0),
@@ -12292,14 +12299,14 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             }, [
               X("summary", null, [
                 c[6] || (c[6] = X("span", { class: "pano-ui-summary-label" }, "UI Settings", -1)),
-                X("span", gk, [
+                X("span", _k, [
                   $e(en, {
                     icon: pt(Te).chevron
                   }, null, 8, ["icon"])
                 ])
               ]),
-              X("div", bk, [
-                X("div", yk, [
+              X("div", xk, [
+                X("div", Sk, [
                   c[7] || (c[7] = X("label", null, "Drag X", -1)),
                   X("div", {
                     class: "pano-segment",
@@ -12312,17 +12319,17 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                       "data-action": "set-invert-x",
                       "data-value": "0",
                       "aria-pressed": e.model.uiSettings.invertX ? "false" : "true"
-                    }, "Normal", 8, _k),
+                    }, "Normal", 8, kk),
                     X("button", {
                       class: "pano-segment-btn",
                       type: "button",
                       "data-action": "set-invert-x",
                       "data-value": "1",
                       "aria-pressed": e.model.uiSettings.invertX ? "true" : "false"
-                    }, "Inverted", 8, xk)
-                  ], 8, vk)
+                    }, "Inverted", 8, Nk)
+                  ], 8, wk)
                 ]),
-                X("div", Sk, [
+                X("div", Mk, [
                   c[8] || (c[8] = X("label", null, "Drag Y", -1)),
                   X("div", {
                     class: "pano-segment",
@@ -12335,21 +12342,21 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                       "data-action": "set-invert-y",
                       "data-value": "0",
                       "aria-pressed": e.model.uiSettings.invertY ? "false" : "true"
-                    }, "Normal", 8, kk),
+                    }, "Normal", 8, Ak),
                     X("button", {
                       class: "pano-segment-btn",
                       type: "button",
                       "data-action": "set-invert-y",
                       "data-value": "1",
                       "aria-pressed": e.model.uiSettings.invertY ? "true" : "false"
-                    }, "Inverted", 8, Nk)
-                  ], 8, wk)
+                    }, "Inverted", 8, Ck)
+                  ], 8, Pk)
                 ]),
-                X("div", Mk, [
+                X("div", Tk, [
                   c[10] || (c[10] = X("label", { for: "pano-ui-quality" }, "Render Quality", -1)),
-                  X("div", Pk, [
-                    X("button", Ak, [
-                      X("span", Ck, ct(e.model.uiSettings.qualityLabel), 1),
+                  X("div", Ik, [
+                    X("button", Ek, [
+                      X("span", Dk, ct(e.model.uiSettings.qualityLabel), 1),
                       c[9] || (c[9] = X("span", { class: "pano-picker-caret" }, "▾", -1))
                     ]),
                     X("div", {
@@ -12362,8 +12369,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                         class: ft(["pano-picker-item", { active: S.active === !0 }]),
                         "data-action": "set-quality",
                         "data-quality": S.value
-                      }, ct(S.label), 11, Ik))), 128))
-                    ], 8, Tk)
+                      }, ct(S.label), 11, Fk))), 128))
+                    ], 8, Ok)
                   ])
                 ]),
                 c[11] || (c[11] = X("div", { class: "pano-ui-row" }, [
@@ -12375,21 +12382,21 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                   }, "Reset Defaults")
                 ], -1))
               ])
-            ], 8, mk)) : zt("", !0)
+            ], 8, vk)) : zt("", !0)
           ])
         ])) : zt("", !0),
-        (e.model.footerButtons || []).length ? (ke(), Pe("div", Ek, [
+        (e.model.footerButtons || []).length ? (ke(), Pe("div", Rk, [
           (ke(!0), Pe(ot, null, jt(e.model.footerButtons, (S) => (ke(), Pe("button", {
             key: S.action,
             class: ft(["pano-btn", { "pano-btn-primary": S.primary === !0 }]),
             type: "button",
             "data-action": S.action
-          }, ct(S.label), 11, Dk))), 128))
+          }, ct(S.label), 11, Lk))), 128))
         ])) : zt("", !0)
       ]);
     };
   }
-}, Fk = {
+}, $k = {
   __name: "PanoTooltip",
   props: {
     model: { type: Object, default: () => ({}) }
@@ -12407,16 +12414,16 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       style: Bt({ left: `${e.model.left || 0}px`, top: `${e.model.top || 0}px` })
     }, ct(e.model.text || ""), 7));
   }
-}, Rk = {
+}, jk = {
   class: "pano-floating-left",
   "data-tool-rail": ""
-}, Lk = {
+}, Vk = {
   __name: "PanoToolRail",
   props: {
     buttons: { type: Array, default: () => [] }
   },
   setup(e) {
-    return (t, n) => (ke(), Pe("div", Rk, [
+    return (t, n) => (ke(), Pe("div", jk, [
       (ke(!0), Pe(ot, null, jt(e.buttons, (r) => Si((ke(), Ii(tn, {
         key: r.key,
         "extra-class": {
@@ -12433,13 +12440,13 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
       ])), 128))
     ]));
   }
-}, zk = ["data-video-ready"], $k = { class: "pano-video-transport-shell" }, jk = { class: "pano-video-controls-left" }, Vk = { class: "pano-video-filmstrip" }, Hk = {
+}, Hk = ["data-video-ready"], Uk = { class: "pano-video-transport-shell" }, Bk = { class: "pano-video-controls-left" }, Gk = { class: "pano-video-filmstrip" }, Kk = {
   class: "pano-video-filmstrip-track",
   "aria-hidden": "true"
-}, Uk = ["src", "onLoad"], Bk = {
+}, Wk = ["src", "onLoad"], Yk = {
   key: 1,
   class: "pano-video-thumb-placeholder"
-}, Gk = ["max", "value", "disabled"], Kk = { class: "pano-video-controls-right" }, Wk = ["data-has-audio"], Yk = { class: "pano-video-volume-pop" }, qk = ["value", "disabled"], Xk = {
+}, qk = ["max", "value", "disabled"], Xk = { class: "pano-video-controls-right" }, Jk = ["data-has-audio"], Zk = { class: "pano-video-volume-pop" }, Qk = ["value", "disabled"], eN = {
   __name: "PanoVideoTransport",
   props: {
     state: { type: Object, default: () => ({}) }
@@ -12523,8 +12530,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
         playsinline: "",
         crossorigin: "anonymous"
       }, null, -1)),
-      X("div", $k, [
-        X("div", jk, [
+      X("div", Uk, [
+        X("div", Bk, [
           $e(tn, {
             "extra-class": [
               "pano-video-control",
@@ -12540,8 +12547,8 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             style: Bt(b.value)
           }, ct(e.state.currentTimeLabel || "0:00"), 5)
         ]),
-        X("div", Vk, [
-          X("div", Hk, [
+        X("div", Gk, [
+          X("div", Kk, [
             (ke(!0), Pe(ot, null, jt(O.value, (H) => (ke(), Pe("div", {
               key: z(H),
               class: ft(["pano-video-thumb", {
@@ -12555,7 +12562,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 alt: "",
                 draggable: "false",
                 onLoad: (se) => $(H)
-              }, null, 40, Uk)) : (ke(), Pe("span", Bk))
+              }, null, 40, Wk)) : (ke(), Pe("span", Yk))
             ], 2))), 128))
           ]),
           X("div", {
@@ -12576,9 +12583,9 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             value: Math.max(0, Number(e.state.currentTime || 0)),
             disabled: e.state.ready !== !0,
             "aria-label": "Seek video"
-          }, null, 8, Gk)
+          }, null, 8, qk)
         ]),
-        X("div", Kk, [
+        X("div", Xk, [
           X("div", {
             class: "pano-video-time pano-video-time-end",
             style: Bt(b.value)
@@ -12598,7 +12605,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             class: "pano-video-volume-stack",
             "data-has-audio": e.state.hasAudio === !0 ? "true" : "false"
           }, [
-            X("div", Yk, [
+            X("div", Zk, [
               X("input", {
                 class: "pano-video-volume-slider",
                 "data-video-volume": "",
@@ -12610,7 +12617,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 style: Bt(S.value),
                 disabled: e.state.ready !== !0 || e.state.hasAudio !== !0,
                 "aria-label": "Volume"
-              }, null, 12, qk)
+              }, null, 12, Qk)
             ]),
             $e(tn, {
               "extra-class": "pano-video-control",
@@ -12622,12 +12629,12 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
                 "data-muted": e.state.muted === !0 ? "true" : "false"
               }
             }, null, 8, ["icon", "label", "attrs"])
-          ], 8, Wk)
+          ], 8, Jk)
         ])
       ])
-    ], 14, zk));
+    ], 14, Hk));
   }
-}, Jk = { class: "pano-floating-top" }, Zk = ["data-selected", "data-view-count"], Qk = ["data-view", "aria-pressed", "aria-label", "disabled"], eN = { class: "label" }, tN = {
+}, tN = { class: "pano-floating-top" }, nN = ["data-selected", "data-view-count"], rN = ["data-view", "aria-pressed", "aria-label", "disabled"], iN = { class: "label" }, aN = {
   __name: "PanoViewToggle",
   props: {
     buttons: { type: Array, default: () => [] }
@@ -12635,7 +12642,7 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
   setup(e) {
     return (t, n) => {
       var r;
-      return ke(), Pe("div", Jk, [
+      return ke(), Pe("div", tN, [
         X("div", {
           class: "pano-view-toggle",
           "data-selected": ((r = e.buttons.find((a) => a.pressed === "true")) == null ? void 0 : r.key) || "pano",
@@ -12652,16 +12659,16 @@ const WS = { class: "pano-floating-right" }, YS = ["data-settled"], qS = ["data-
             $e(en, {
               icon: a.icon
             }, null, 8, ["icon"]),
-            X("span", eN, ct(a.label), 1)
-          ], 10, Qk)), [
+            X("span", iN, ct(a.label), 1)
+          ], 10, rN)), [
             [wo, a.visible !== !1]
           ])), 128))
-        ], 8, Zk)
+        ], 8, nN)
       ]);
     };
   }
 };
-function tg(e = "stickers") {
+function ag(e = "stickers") {
   const t = String(e || "stickers") === "cutout";
   return {
     viewButtons: [
@@ -12724,11 +12731,11 @@ function tg(e = "stickers") {
     ]
   };
 }
-const nN = ["aria-label"], rN = { class: "pano-stage-wrap" }, iN = {
+const oN = ["aria-label"], sN = { class: "pano-stage-wrap" }, lN = {
   key: 0,
   class: "pano-stage-failed",
   role: "status"
-}, aN = {
+}, uN = {
   __name: "PanoModal",
   props: {
     open: { type: Boolean, default: !0 },
@@ -12764,7 +12771,7 @@ const nN = ["aria-label"], rN = { class: "pano-stage-wrap" }, iN = {
       a("image-file-cancelled", T);
     }
     t({ getPaintOverlayRefs: x, openImagePicker: S });
-    const O = wt(() => r.readOnly === !0), j = wt(() => r.shellPreset || tg(r.type)), z = wt(() => {
+    const O = wt(() => r.readOnly === !0), j = wt(() => r.shellPreset || ag(r.type)), z = wt(() => {
       var q, re, J;
       const T = String((((q = r.uiState) == null ? void 0 : q.stageStatus) === "failed" ? (re = r.uiState) == null ? void 0 : re.stageStatusDetail : (J = r.uiState) == null ? void 0 : J.stageWarningDetail) ?? "");
       return T === "background" ? "Background preview unavailable. Re-run the node to refresh it." : T === "stickers" ? "One or more sticker previews are unavailable." : T === "frame" ? "The editor hit a rendering error. Check the browser console for details." : T.startsWith("boot:") ? "Part of the editor failed to initialize. Check the browser console for details." : "Some image previews are unavailable. Re-run the node to refresh them.";
@@ -12821,11 +12828,11 @@ const nN = ["aria-label"], rN = { class: "pano-stage-wrap" }, iN = {
       c && (document.body.style.overflow = o, c = !1);
     }
     function ie(T) {
-      document.removeEventListener("keydown", G), T ? (f || (f = document.activeElement), H(), document.addEventListener("keydown", G), hc(() => {
+      document.removeEventListener("keydown", G), T ? (f || (f = document.activeElement), H(), document.addEventListener("keydown", G), pc(() => {
         I();
       })) : (se(), R());
     }
-    return gc(() => {
+    return bc(() => {
       ie(r.open);
     }), sl(() => {
       se(), document.removeEventListener("keydown", G), R();
@@ -12845,7 +12852,7 @@ const nN = ["aria-label"], rN = { class: "pano-stage-wrap" }, iN = {
         "aria-label": e.nodeTitle,
         tabindex: "-1"
       }, [
-        X("div", rN, [
+        X("div", sN, [
           q[1] || (q[1] = X("canvas", {
             class: "pano-stage pano-stage-bg",
             "data-stage-background": "",
@@ -12862,83 +12869,83 @@ const nN = ["aria-label"], rN = { class: "pano-stage-wrap" }, iN = {
             class: "pano-stage-loading",
             "aria-hidden": "true"
           }, null, -1)),
-          e.uiState.stageStatus === "failed" || e.uiState.stageStatus === "ready" && e.uiState.stageWarningDetail ? (ke(), Pe("div", iN, ct(z.value), 1)) : zt("", !0),
+          e.uiState.stageStatus === "failed" || e.uiState.stageStatus === "ready" && e.uiState.stageWarningDetail ? (ke(), Pe("div", lN, ct(z.value), 1)) : zt("", !0),
           q[4] || (q[4] = X("div", {
             class: "pano-stage-drop-hint",
             "aria-hidden": "true"
           }, [
             X("div", { class: "pano-stage-drop-hint-text" }, "Drag and drop image here")
           ], -1)),
-          $e(Dw, {
+          $e(Lw, {
             ref_key: "paintOverlaysRef",
             ref: v
           }, null, 512),
-          $e(km, {
+          $e(Am, {
             ref_key: "imageFilePickerRef",
             ref: g,
             onFileSelected: M,
             onFileCancelled: b
           }, null, 512),
           O.value ? zt("", !0) : (ke(), Pe(ot, { key: 1 }, [
-            $e(Lk, {
+            $e(Vk, {
               buttons: e.uiState.toolButtons || j.value.toolButtons || []
             }, null, 8, ["buttons"]),
-            $e(rw, {
+            $e(sw, {
               model: e.uiState.frameRail || {}
             }, null, 8, ["model"]),
-            $e(Ew, {
+            $e(Rw, {
               "paint-swatches": e.paintSwatches,
               panes: j.value.paintPanes || [],
               state: e.uiState.paintDock || {}
             }, null, 8, ["paint-swatches", "panes", "state"])
           ], 64)),
-          $e(Xk, {
+          $e(eN, {
             state: e.uiState.videoTransport || {}
           }, null, 8, ["state"]),
-          $e(tN, {
+          $e(aN, {
             buttons: e.uiState.viewButtons || j.value.viewButtons || []
           }, null, 8, ["buttons"]),
-          $e(ZS, {
+          $e(nw, {
             buttons: e.uiState.floatingButtons || P.value,
             "fov-value": e.uiState.fovValue || "100°",
             preview: e.uiState.cameraPreview || {},
             "preview-toggle": e.uiState.outputPreviewToggle || {}
           }, null, 8, ["buttons", "fov-value", "preview", "preview-toggle"]),
-          $e(zw, {
+          $e(Hw, {
             model: e.uiState.selectionMenu || {}
           }, null, 8, ["model"]),
-          $e(Fk, {
+          $e($k, {
             model: e.uiState.tooltip || {}
           }, null, 8, ["model"]),
-          $e(uw, {
+          $e(hw, {
             model: e.uiState.confirmDialog || {}
           }, null, 8, ["model"])
         ]),
-        e.hideSidebar ? zt("", !0) : (ke(), Ii(Ok, {
+        e.hideSidebar ? zt("", !0) : (ke(), Ii(zk, {
           key: 0,
           "node-title": e.nodeTitle,
           model: e.uiState.sidePanel || {}
         }, null, 8, ["node-title", "model"]))
-      ], 8, nN)
+      ], 8, oN)
     ])) : zt("", !0);
   }
 }, pr = "loading", wa = "ready", br = "failed";
-function ng(e, t = "") {
+function og(e, t = "") {
   return e && (e.__panoLoadState = pr, e.__panoLoadSource = String(t || e.currentSrc || e.src || ""), e);
 }
-function rg(e, t = "") {
+function sg(e, t = "") {
   return e && (e.__panoLoadState = wa, e.__panoLoadSource = String(t || e.currentSrc || e.src || ""), e);
 }
-function ig(e, t = "") {
+function lg(e, t = "") {
   return e && (e.__panoLoadState = br, e.__panoLoadSource = String(t || e.currentSrc || e.src || ""), e);
 }
-function Qu(e, t) {
+function ec(e, t) {
   return e ? e.__panoLoadState === br ? br : typeof t == "function" && t(e) ? wa : pr : wa;
 }
-function ec(e) {
-  return Qu(e) === br;
+function tc(e) {
+  return ec(e) === br;
 }
-function oN({ presented: e, background: t = wa, stickers: n = [] } = {}) {
+function cN({ presented: e, background: t = wa, stickers: n = [] } = {}) {
   if (!e) return { status: pr, detail: "boot" };
   const r = Array.isArray(n) ? n : [], a = t === pr, o = r.includes(pr);
   if (a && o) return { status: pr, detail: "mixed" };
@@ -12956,16 +12963,16 @@ function ra(e, t) {
   const a = `/view?${r.toString()}`;
   return typeof (e == null ? void 0 : e.apiURL) == "function" ? e.apiURL(a) : a;
 }
-function zh(e, t) {
+function Hh(e, t) {
   if (!e || t == null) return null;
   const n = e.links;
   return n ? n instanceof Map ? n.get(t) || n.get(Number(t)) || n.get(String(t)) || null : n[t] || n[String(t)] || null : null;
 }
-function sN(e, t) {
+function fN(e, t) {
   var n, r;
   return !e || t == null ? null : typeof e.getNodeById == "function" ? e.getNodeById(t) : ((n = e._nodes_by_id) == null ? void 0 : n[t]) || ((r = e._nodes_by_id) == null ? void 0 : r[String(t)]) || null;
 }
-function $h(e) {
+function Uh(e) {
   return e ? typeof e == "object" && !Array.isArray(e) ? {
     originId: e.origin_id ?? null,
     originSlot: Number(e.origin_slot ?? 0)
@@ -12974,7 +12981,7 @@ function $h(e) {
     originSlot: Number(e[2] ?? 0)
   } : { originId: null, originSlot: 0 } : { originId: null, originSlot: 0 };
 }
-function lN(e, t, n = null) {
+function dN(e, t, n = null) {
   var a, o;
   let r = null;
   try {
@@ -12988,26 +12995,26 @@ function lN(e, t, n = null) {
       f != null && f.outputNode && (r = f.outputNode);
     } catch {
     }
-  return !r && n != null && (r = sN(e == null ? void 0 : e.graph, n)), r;
+  return !r && n != null && (r = fN(e == null ? void 0 : e.graph, n)), r;
 }
-function uN(e) {
+function hN(e) {
   const t = String(e || "").trim();
   return !!t && (/^https?:\/\//i.test(t) || t.startsWith("/") || t.startsWith("blob:") || t.startsWith("data:"));
 }
-function cN(e) {
+function pN(e) {
   const n = String(e || "").trim().replaceAll("\\", "/").replace(/^\.\/+/, "").replace(/^\/+/, "");
   if (!n) return { filename: "", subfolder: "" };
   const r = n.split("/").filter(Boolean);
   return r.length ? { filename: String(r.pop() || "").trim(), subfolder: r.join("/") } : { filename: "", subfolder: "" };
 }
-function fN(e) {
+function mN(e) {
   const t = String(e || "");
   let n = 2166136261;
   for (const r of t)
     n ^= r.codePointAt(0) || 0, n = Math.imul(n, 16777619);
   return String(n >>> 0);
 }
-function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
+function gN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
   const a = (I) => {
     if (!I) return "";
     if (typeof I == "string") return String(I || "").trim();
@@ -13053,7 +13060,7 @@ function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
     return G != null && G.ui && Object.prototype.hasOwnProperty.call(G.ui, R) ? G.ui[R] : G && Object.prototype.hasOwnProperty.call(G, R) ? G[R] : null;
   }, g = (I, R) => {
     const G = h(I, "pano_sticker_input_state_hash"), H = Array.isArray(G) ? G[0] : G;
-    return String(H ?? "").trim() || fN(R);
+    return String(H ?? "").trim() || mN(R);
   }, v = (I) => {
     const R = [], G = /* @__PURE__ */ new Set();
     for (const H of I || []) {
@@ -13077,9 +13084,9 @@ function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
     if (se < 0) return { src: "", sourceType: "", inputName: G };
     const ie = H[se], T = ie == null ? void 0 : ie.link;
     if (T == null) return { src: "", sourceType: "", inputName: G };
-    const { originId: q, originSlot: re } = $h(zh(I == null ? void 0 : I.graph, T));
+    const { originId: q, originSlot: re } = Uh(Hh(I == null ? void 0 : I.graph, T));
     if (q == null) return { src: "", sourceType: "", inputName: G };
-    const J = lN(I, se, q);
+    const J = dN(I, se, q);
     if (!J) return { src: "", sourceType: "", inputName: G };
     const de = Number(re || 0);
     let ce = [];
@@ -13122,8 +13129,8 @@ function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
   }, b = (I) => {
     const R = String(I || "").trim();
     if (!R) return [];
-    if (uN(R)) return [R];
-    const { filename: G, subfolder: H } = cN(R);
+    if (hN(R)) return [R];
+    const { filename: G, subfolder: H } = pN(R);
     return G ? v([
       ra(t, { filename: G, subfolder: H, type: "temp" }),
       ra(t, { filename: G, subfolder: H, type: "output" }),
@@ -13152,7 +13159,7 @@ function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
       var ie, T, q, re;
       const G = String(R || ""), H = Array.isArray(I == null ? void 0 : I.inputs) ? I.inputs.find((J) => String((J == null ? void 0 : J.name) || "") === G) : null;
       if ((H == null ? void 0 : H.link) != null) {
-        const { originId: J, originSlot: de } = $h(zh(I == null ? void 0 : I.graph, H.link)), ce = c(J), we = [
+        const { originId: J, originSlot: de } = Uh(Hh(I == null ? void 0 : I.graph, H.link)), ce = c(J), we = [
           ce == null ? void 0 : ce.output,
           ce == null ? void 0 : ce.result,
           (ie = ce == null ? void 0 : ce.data) == null ? void 0 : ie.output,
@@ -13228,40 +13235,40 @@ function dN({ app: e, api: t, ImageCtor: n, imageState: r } = {}) {
     uiValue: h
   };
 }
-const hN = "state_json", as = "sticker_image_1", pN = "external_image", os = "pano_sticker_input_images", mN = !0, Ts = [
+const bN = "state_json", as = "sticker_image_1", yN = "external_image", os = "pano_sticker_input_images", vN = !0, Ts = [
   { id: "green", label: "Green", color: { r: 0, g: 1, b: 0, a: 1 } },
   { id: "red", label: "Red", color: { r: 1, g: 0, b: 0, a: 1 } },
   { id: "blue", label: "Blue", color: { r: 0, g: 0, b: 1, a: 1 } },
   { id: "black", label: "Black", color: { r: 0, g: 0, b: 0, a: 1 } },
   { id: "white", label: "White", color: { r: 1, g: 1, b: 1, a: 1 } }
-], pn = Math.PI / 180, zr = 180 / Math.PI, yu = 1, gN = "rgb(255, 221, 87)", bN = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M19 8a8 8 0 1 0 1 6M19 3v5h-5' fill='none' stroke='black' stroke-opacity='.7' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M19 8a8 8 0 1 0 1 6M19 3v5h-5' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 12 12, crosshair`, yN = 64, jh = 40, vu = 16, vN = 0.45, Vh = 180, _N = 160, Zs = 24, xN = 4, SN = 4, ss = /* @__PURE__ */ new Map(), Hh = /* @__PURE__ */ new Map(), ii = /* @__PURE__ */ new Map(), wN = 12, tr = dN({
+], pn = Math.PI / 180, zr = 180 / Math.PI, yu = 1, _N = "rgb(255, 221, 87)", xN = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M19 8a8 8 0 1 0 1 6M19 3v5h-5' fill='none' stroke='black' stroke-opacity='.7' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cpath d='M19 8a8 8 0 1 0 1 6M19 3v5h-5' fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E") 12 12, crosshair`, SN = 64, Bh = 40, vu = 16, wN = 0.45, Gh = 180, kN = 160, Zs = 24, NN = 4, MN = 4, ss = /* @__PURE__ */ new Map(), Kh = /* @__PURE__ */ new Map(), ii = /* @__PURE__ */ new Map(), PN = 12, tr = gN({
   app: nr,
   api: bn,
   ImageCtor: Image,
   imageState: {
-    isImageLoadFailed: ec,
-    markImageFailed: ig,
-    markImageLoading: ng,
-    markImageReady: rg
+    isImageLoadFailed: tc,
+    markImageFailed: lg,
+    markImageLoading: og,
+    markImageReady: sg
   }
-}), kN = tr.assetSource, NN = tr.source, _u = tr.uiImage, MN = tr.invalidateUiImage, PN = tr.resolvePreferredExactLinkedSource, xu = tr.loadPreferredExactLinkedImage;
+}), AN = tr.assetSource, CN = tr.source, _u = tr.uiImage, TN = tr.invalidateUiImage, IN = tr.resolvePreferredExactLinkedSource, xu = tr.loadPreferredExactLinkedImage;
 function ls(e) {
   return e < 0.5 ? 4 * e * e * e : 1 - Math.pow(-2 * e + 2, 3) / 2;
 }
-function AN(e) {
+function EN(e) {
   return 1 - Math.pow(1 - e, 3);
 }
-function CN(e, t, n) {
+function DN(e, t, n) {
   const r = W((Number(n || 0) - e) / Math.max(t - e, 1e-6), 0, 1);
   return r * r * (3 - 2 * r);
 }
-function TN(e) {
+function ON(e) {
   const t = String(e || "").trim();
   if (!t) return null;
   const n = ii.get(t);
   return !n || !Array.isArray(n.thumbnails) || !n.thumbnails.length ? null : (ii.delete(t), ii.set(t, n), n);
 }
-function IN(e, t) {
+function FN(e, t) {
   const n = String(e || "").trim();
   if (!n) return;
   const r = Array.isArray(t == null ? void 0 : t.thumbnails) ? t.thumbnails : [];
@@ -13271,13 +13278,13 @@ function IN(e, t) {
       thumbnailCount: Math.max(1, Number(t == null ? void 0 : t.thumbnailCount)),
       duration: Math.max(0, Number((t == null ? void 0 : t.duration) || 0)),
       fps: Math.max(1, Number((t == null ? void 0 : t.fps) || 24))
-    }); ii.size > wN; ) {
+    }); ii.size > PN; ) {
       const a = ii.keys().next().value;
       if (!a) break;
       ii.delete(a);
     }
 }
-function EN(e) {
+function RN(e) {
   return e * e * e;
 }
 function yr(e, t, n) {
@@ -13338,14 +13345,14 @@ function ur(e, t = null) {
   const n = t == null ? Number((e == null ? void 0 : e.a) ?? 1) : Number(t);
   return `rgba(${Math.round(W(Number((e == null ? void 0 : e.r) ?? 0), 0, 1) * 255)}, ${Math.round(W(Number((e == null ? void 0 : e.g) ?? 0), 0, 1) * 255)}, ${Math.round(W(Number((e == null ? void 0 : e.b) ?? 0), 0, 1) * 255)}, ${W(n, 0, 1)})`;
 }
-function DN(e) {
+function LN(e) {
   return `url("data:image/svg+xml,${encodeURIComponent(e)}")`;
 }
 let hs = { fillStyle: "", url: "" };
-function ON(e, t, n) {
+function zN(e, t, n) {
   if (hs.url && hs.fillStyle === String(e || ""))
     return hs.url;
-  const r = DN(`
+  const r = LN(`
 <svg xmlns="http://www.w3.org/2000/svg" width="${Zs}" height="${Zs}" viewBox="0 0 24 24" fill="none">
   <path d="M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z" fill="${e}" stroke="${t}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
   <path d="M4.037 4.688a.495.495 0 0 1 .651-.651l16 6.5a.5.5 0 0 1-.063.947l-6.124 1.58a2 2 0 0 0-1.438 1.435l-1.579 6.126a.5.5 0 0 1-.947.063z" fill="${e}" stroke="${n}" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
@@ -13366,7 +13373,7 @@ function $n(e) {
 function hn(e) {
   return e == null ? e : JSON.parse(JSON.stringify(e));
 }
-function FN(e) {
+function $N(e) {
   return Ts.some((t) => Is(e, t.color));
 }
 function wu(e, t, n) {
@@ -13399,7 +13406,7 @@ function aa(e) {
   const t = Number(e);
   return Number.isFinite(t) ? Number(t.toFixed(3)).toString() : "0";
 }
-const ag = "pano_suite.ui_settings.v1", og = "pano_suite.node_grid_visibility.v1";
+const ug = "pano_suite.ui_settings.v1", cg = "pano_suite.node_grid_visibility.v1";
 let ca = null, cr = null;
 function Es(e) {
   const t = e && typeof e == "object" ? e : {}, n = String(t.preview_quality || "balanced");
@@ -13409,10 +13416,10 @@ function Es(e) {
     preview_quality: n === "draft" || n === "balanced" || n === "high" ? n : "balanced"
   };
 }
-function RN() {
+function jN() {
   var e;
   try {
-    const t = String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem(ag)) || "").trim();
+    const t = String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem(ug)) || "").trim();
     if (!t) return ca ? Es(ca) : null;
     const n = JSON.parse(t), r = Es(n);
     return ca = r, r;
@@ -13420,22 +13427,22 @@ function RN() {
     return ca ? Es(ca) : null;
   }
 }
-function LN(e) {
+function VN(e) {
   var n;
   const t = Es(e);
   ca = t;
   try {
-    (n = window == null ? void 0 : window.localStorage) == null || n.setItem(ag, JSON.stringify(t));
+    (n = window == null ? void 0 : window.localStorage) == null || n.setItem(ug, JSON.stringify(t));
   } catch {
   }
   return t;
 }
-function sg() {
+function fg() {
   var e;
   if (cr && typeof cr == "object")
     return cr;
   try {
-    const t = String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem(og)) || "").trim();
+    const t = String(((e = window == null ? void 0 : window.localStorage) == null ? void 0 : e.getItem(cg)) || "").trim();
     if (!t)
       return cr = {}, cr;
     const n = JSON.parse(t);
@@ -13444,30 +13451,30 @@ function sg() {
     return cr = {}, cr;
   }
 }
-function zN(e, t = !0) {
+function HN(e, t = !0) {
   const n = String(e ?? "").trim();
   if (!n) return !!t;
-  const a = sg()[n];
+  const a = fg()[n];
   return typeof a == "boolean" ? a : !!t;
 }
-function $N(e, t) {
+function UN(e, t) {
   var a;
   const n = String(e ?? "").trim();
   if (!n) return;
-  const r = sg();
+  const r = fg();
   r[n] = !!t, cr = r;
   try {
-    (a = window == null ? void 0 : window.localStorage) == null || a.setItem(og, JSON.stringify(r));
+    (a = window == null ? void 0 : window.localStorage) == null || a.setItem(cg, JSON.stringify(r));
   } catch {
   }
 }
-function jN(e) {
+function BN(e) {
   var r, a;
   const t = Array.isArray((r = e == null ? void 0 : e.paint) == null ? void 0 : r.strokes) ? e.paint.strokes.length : 0, n = Array.isArray((a = e == null ? void 0 : e.mask) == null ? void 0 : a.strokes) ? e.mask.strokes.length : 0;
   return { paintCount: t, maskCount: n };
 }
-function Uh(e) {
-  const { paintCount: t, maskCount: n } = jN(e), r = Array.isArray(e == null ? void 0 : e.raster_objects) ? e.raster_objects : [];
+function Wh(e) {
+  const { paintCount: t, maskCount: n } = BN(e), r = Array.isArray(e == null ? void 0 : e.raster_objects) ? e.raster_objects : [];
   let a = 0, o = 0;
   return r.forEach((c) => {
     String((c == null ? void 0 : c.layerKind) || "paint") === "mask" ? o += 1 : a += 1;
@@ -13487,7 +13494,7 @@ function ps(e, t) {
   var n;
   return ((n = e.widgets) == null ? void 0 : n.find((r) => r.name === t)) || null;
 }
-function VN(e, t) {
+function GN(e, t) {
   const n = String((e == null ? void 0 : e.comfyClass) || (e == null ? void 0 : e.type) || (e == null ? void 0 : e.title) || "").trim(), r = {
     PanoramaStickers: "Panorama Stickers",
     "Panorama Stickers": "Panorama Stickers",
@@ -13501,27 +13508,27 @@ function VN(e, t) {
 function ms(e) {
   return `${e}_${Math.random().toString(16).slice(2, 10)}`;
 }
-function HN(e, t = 2048) {
+function KN(e, t = 2048) {
   if (typeof e == "number" && Number.isFinite(e)) return Math.round(e);
   const n = String(e ?? "").trim();
   if (!n) return t;
   const r = n.includes("x") ? n.split("x", 1)[0].trim() : n, a = Number(r);
   return Number.isFinite(a) ? Math.round(a) : t;
 }
-function UN(e) {
+function WN(e) {
   const t = String(e ?? "").trim().toLowerCase();
   return t === "auto" || t === "bg" || t === "background";
 }
-function BN(e) {
+function YN(e) {
   const t = Number((e == null ? void 0 : e.naturalWidth) || (e == null ? void 0 : e.videoWidth) || (e == null ? void 0 : e.width) || 0);
   return Number.isFinite(t) && t > 0 ? Math.round(t) : null;
 }
-async function GN(e, t, n = {}) {
-  var ad;
-  await Lm(e, { tolerateOperationFailure: !0 }), tr.clearFailedLinkedImages(e);
-  const r = (n == null ? void 0 : n.readOnly) === !0, a = (n == null ? void 0 : n.hideSidebar) ?? r, o = r, c = VN(e, t);
-  await Oc();
-  const f = ps(e, "output_preset"), h = ps(e, "coverage"), g = ps(e, "bg_color"), v = ps(e, hN), x = () => {
+async function qN(e, t, n = {}) {
+  var od;
+  await Vm(e, { tolerateOperationFailure: !0 }), tr.clearFailedLinkedImages(e);
+  const r = (n == null ? void 0 : n.readOnly) === !0, a = (n == null ? void 0 : n.hideSidebar) ?? r, o = r, c = GN(e, t);
+  await Fc();
+  const f = ps(e, "output_preset"), h = ps(e, "coverage"), g = ps(e, "bg_color"), v = ps(e, bN), x = () => {
     const i = t === "stickers" ? ["bg_erp", "erp_image"] : ["erp_image", "bg_erp"];
     return xu(
       e,
@@ -13531,22 +13538,22 @@ async function GN(e, t, n = {}) {
     );
   }, S = () => {
     const i = x();
-    return BN(i);
+    return YN(i);
   }, M = (i = 2048) => {
     const s = f == null ? void 0 : f.value;
-    return UN(s) ? S() || Math.max(1, Math.round(Number(i || 2048))) : HN(s, i);
-  }, b = Rm(String((v == null ? void 0 : v.value) || ""), {
+    return WN(s) ? S() || Math.max(1, Math.round(Number(i || 2048))) : KN(s, i);
+  }, b = jm(String((v == null ? void 0 : v.value) || ""), {
     outputPreset: M(2048),
     backgroundColor: String((g == null ? void 0 : g.value) || "#00ff00"),
     coverage: ln(h == null ? void 0 : h.value),
-    sharedUiSettings: RN()
+    sharedUiSettings: jN()
   });
   e.__panoLiveStateOverride = b, e.__panoLiveStateVersion = 0, t === "cutout" && (b.shots = Array.isArray(b.shots) ? b.shots.slice(0, 1) : [], b.shots.length || (b.active.selected_shot_id = null));
   const O = t === "cutout" ? (() => {
     var l;
     const i = Array.isArray(b.shots) ? b.shots : [], s = String(((l = b == null ? void 0 : b.active) == null ? void 0 : l.selected_shot_id) || "");
     return i.find((u) => String((u == null ? void 0 : u.id) || "") === s) || i[0] || null;
-  })() : null, j = O ? vf(O, !1) : { width: 220, height: 132 }, z = tg(t), P = /* @__PURE__ */ ka({
+  })() : null, j = O ? _f(O, !1) : { width: 220, height: 132 }, z = ag(t), P = /* @__PURE__ */ ka({
     stageStatus: pr,
     stageStatusDetail: "boot",
     stageWarningDetail: "",
@@ -13647,13 +13654,13 @@ async function GN(e, t, n = {}) {
   const I = ({ intent: i, file: s } = {}) => {
     if (Sr(s)) {
       if (i === "add") {
-        Af(s);
+        Cf(s);
         return;
       }
-      i === "replace" && Q0(s);
+      i === "replace" && rb(s);
     }
   }, R = ({ intent: i } = {}) => {
-  }, G = _c(aN, {
+  }, G = xc(uN, {
     open: !0,
     type: t,
     readOnly: r,
@@ -13682,10 +13689,10 @@ async function GN(e, t, n = {}) {
     }
     throw $.remove(), i;
   }
-  const se = $.querySelector(".pano-modal-overlay"), ie = $.querySelector(".pano-modal"), T = ie == null ? void 0 : ie.querySelector("[data-stage-overlay]"), q = ie == null ? void 0 : ie.querySelector("[data-stage-background]"), re = ie == null ? void 0 : ie.querySelector(".pano-stage-wrap"), J = ((ad = H == null ? void 0 : H.getPaintOverlayRefs) == null ? void 0 : ad.call(H)) || {}, de = J.cursor || null, ce = J.sizePreview || null, we = J.sizeSample || null;
+  const se = $.querySelector(".pano-modal-overlay"), ie = $.querySelector(".pano-modal"), T = ie == null ? void 0 : ie.querySelector("[data-stage-overlay]"), q = ie == null ? void 0 : ie.querySelector("[data-stage-background]"), re = ie == null ? void 0 : ie.querySelector(".pano-stage-wrap"), J = ((od = H == null ? void 0 : H.getPaintOverlayRefs) == null ? void 0 : od.call(H)) || {}, de = J.cursor || null, ce = J.sizePreview || null, we = J.sizeSample || null;
   if (!se || !ie || !T || !q || !re || !de || !ce || !we)
     throw G.unmount(), $.remove(), new Error("Failed to mount Panorama Vue modal shell");
-  const A = T.getContext("2d"), xe = ko(), Ae = t === "cutout" ? VS({ targetId: `cutout_modal_${String((e == null ? void 0 : e.id) ?? "0")}` }) : null, Ne = ie.querySelector("[data-side]"), U = ie.querySelector("[data-video-element]"), je = ie.querySelector(".pano-floating-right"), mt = ie.querySelector(".pano-floating-top"), nt = ie.querySelector("[data-tool-rail]"), Ye = ie.querySelector("[data-frame-rail]"), Ve = ie.querySelector("[data-frame-roll-knob]"), qt = ie.querySelector("[data-paint-dock]"), An = ie.querySelector(".pano-video-transport"), Sn = ie.querySelector("[data-selection-menu]"), nn = ie.querySelector("[data-tooltip]"), un = ie.querySelector("[data-camera-preview-host]"), L = ie.querySelector("[data-paint-color-row]"), V = ie.querySelector("[data-paint-color-pop]"), te = ie.querySelector("[data-paint-color-sv]"), ye = ie.querySelector("[data-paint-color-sv-cursor]"), he = ie.querySelector("[data-paint-hue-strip]"), D = ie.querySelector("[data-paint-hue-handle]");
+  const A = T.getContext("2d"), xe = ko(), Ae = t === "cutout" ? GS({ targetId: `cutout_modal_${String((e == null ? void 0 : e.id) ?? "0")}` }) : null, Ne = ie.querySelector("[data-side]"), U = ie.querySelector("[data-video-element]"), je = ie.querySelector(".pano-floating-right"), mt = ie.querySelector(".pano-floating-top"), nt = ie.querySelector("[data-tool-rail]"), Ye = ie.querySelector("[data-frame-rail]"), Ve = ie.querySelector("[data-frame-roll-knob]"), qt = ie.querySelector("[data-paint-dock]"), An = ie.querySelector(".pano-video-transport"), Sn = ie.querySelector("[data-selection-menu]"), nn = ie.querySelector("[data-tooltip]"), un = ie.querySelector("[data-camera-preview-host]"), L = ie.querySelector("[data-paint-color-row]"), V = ie.querySelector("[data-paint-color-pop]"), te = ie.querySelector("[data-paint-color-sv]"), ye = ie.querySelector("[data-paint-color-sv-cursor]"), he = ie.querySelector("[data-paint-hue-strip]"), D = ie.querySelector("[data-paint-hue-handle]");
   let Q = 0, ee = 0;
   re == null || re.removeAttribute("data-stage-ready"), re == null || re.setAttribute("data-stage-loading-kind", "boot"), T.style.opacity = "1", q.style.opacity = "0", a && (Ne == null || Ne.remove(), ie.classList.add("pano-modal-readonly"));
   const fe = () => {
@@ -13694,7 +13701,7 @@ async function GN(e, t, n = {}) {
       d.customPaintSessionStart = null;
       return;
     }
-    if (FN(d.customPaintColor)) {
+    if ($N(d.customPaintColor)) {
       d.customPaintSessionStart = null;
       return;
     }
@@ -13714,14 +13721,14 @@ async function GN(e, t, n = {}) {
       l.hidden = !0;
     }), ne(!0), t === "cutout" && d.cutoutAspectOpen && !i.target.closest(".pano-aspect-popover") && !i.target.closest("[data-action='aspect']") && (d.cutoutAspectOpen = !1, d.menuMode = "", d.menuSize.measured = !1, rt(), be()), (s = P.frameRail) != null && s.aspectOpen && !i.target.closest(".pano-frame-aspect-control") && (P.frameRail.aspectOpen = !1)));
   });
-  const ge = t === "stickers" ? b.active.selected_sticker_id : b.active.selected_shot_id, Ce = JSON.stringify(fh(b)), d = {
+  const ge = t === "stickers" ? b.active.selected_sticker_id : b.active.selected_shot_id, Ce = JSON.stringify(hh(b)), d = {
     mode: "pano",
     selectedId: ge,
     viewYaw: 0,
     viewPitch: 0,
     viewFov: 100,
     coverage: ln(b.coverage),
-    historyController: OS(80, { entries: [Ce], index: 0 }),
+    historyController: zS(80, { entries: [Ce], index: 0 }),
     primaryTool: "cursor",
     paintTool: "pen",
     maskTool: "pen",
@@ -13738,7 +13745,7 @@ async function GN(e, t, n = {}) {
     menuSize: { w: 220, h: 40, measured: !1 },
     menuMode: "",
     cutoutAspectOpen: !1,
-    showGrid: zN(e == null ? void 0 : e.id, !0),
+    showGrid: HN(e == null ? void 0 : e.id, !0),
     showPanorama: !0,
     showObjects: !0,
     showMask: !0,
@@ -13866,7 +13873,7 @@ async function GN(e, t, n = {}) {
       Tt();
       return;
     }
-    const p = TN(u);
+    const p = ON(u);
     if (p) {
       E.thumbnailSrc = u, P.videoTransport.thumbnails = p.thumbnails, P.videoTransport.thumbnailCount = p.thumbnailCount;
       return;
@@ -13912,7 +13919,7 @@ async function GN(e, t, n = {}) {
         label: Sl(le)
       });
     }
-    E.thumbnailJobId === m && (P.videoTransport.thumbnails = K, P.videoTransport.thumbnailCount = K.length || Ie, IN(u, {
+    E.thumbnailJobId === m && (P.videoTransport.thumbnails = K, P.videoTransport.thumbnailCount = K.length || Ie, FN(u, {
       thumbnails: K,
       thumbnailCount: K.length || Ie,
       duration: C,
@@ -14022,14 +14029,14 @@ async function GN(e, t, n = {}) {
     });
   }
   function cn(i) {
-    return Rc(i == null ? void 0 : i.dataTransfer);
+    return Lc(i == null ? void 0 : i.dataTransfer);
   }
   function rn(i) {
     const s = !!i;
     Pt.active !== s && (Pt.active = s, re.classList.toggle("drop-active", s));
   }
   function Di(i, s, l = d.viewFov, u = 140, p = 620) {
-    const m = z1(d.viewYaw, i), _ = s - d.viewPitch, y = l - d.viewFov, w = Math.hypot(m, _) + Math.abs(y) * 0.6, k = Math.round(W(u + w * 2.2, u, p));
+    const m = H1(d.viewYaw, i), _ = s - d.viewPitch, y = l - d.viewFov, w = Math.hypot(m, _) + Math.abs(y) * 0.6, k = Math.round(W(u + w * 2.2, u, p));
     d.viewTween = {
       active: !0,
       startTs: performance.now(),
@@ -14042,7 +14049,7 @@ async function GN(e, t, n = {}) {
       deltaYaw: m
     }, d.viewInertia.active = !1, d.viewInertia.vx = 0, d.viewInertia.vy = 0, be();
   }
-  Lg();
+  Vg();
   function Rn() {
     return t === "stickers" ? b.stickers : b.shots;
   }
@@ -14050,7 +14057,7 @@ async function GN(e, t, n = {}) {
     const i = b.painting || (b.painting = so(null));
     return Array.isArray(i.groups) || (i.groups = []), i.groups;
   }
-  function lg(i = "paint") {
+  function dg(i = "paint") {
     var p, m;
     const s = Array.isArray((m = (p = b.painting) == null ? void 0 : p[i]) == null ? void 0 : m.strokes) ? b.painting[i].strokes : [], l = [], u = /* @__PURE__ */ new Set();
     for (const _ of s) {
@@ -14059,8 +14066,8 @@ async function GN(e, t, n = {}) {
     }
     return l;
   }
-  function ug() {
-    return lg("paint");
+  function hg() {
+    return dg("paint");
   }
   function Pa(i, s) {
     const l = String(s || "").trim();
@@ -14093,7 +14100,7 @@ async function GN(e, t, n = {}) {
       String((l == null ? void 0 : l.layerKind) || "paint") === "paint" && (i = Math.max(i, Number((l == null ? void 0 : l.z_index) || 0)));
     return i + 1;
   }
-  function Vc(i, s = null) {
+  function Hc(i, s = null) {
     const l = String(i || "").trim();
     if (!l) return null;
     const u = Rt();
@@ -14107,7 +14114,7 @@ async function GN(e, t, n = {}) {
       frame: null
     }, u.push(p)), p;
   }
-  function cg(i) {
+  function pg(i) {
     if (!(i != null && i.centerUv)) return [];
     const s = Number(i.centerUv.u || 0), l = Number(i.centerUv.v || 0), u = Number(i.halfW || 0), p = Number(i.halfH || 0);
     return [
@@ -14129,8 +14136,8 @@ async function GN(e, t, n = {}) {
       }
     ];
   }
-  function fg() {
-    const i = new Set(ug()), l = Rt().filter((u) => i.has(String((u == null ? void 0 : u.actionGroupId) || "")));
+  function mg() {
+    const i = new Set(hg()), l = Rt().filter((u) => i.has(String((u == null ? void 0 : u.actionGroupId) || "")));
     return i.forEach((u) => {
       l.some((p) => String((p == null ? void 0 : p.actionGroupId) || "") === u) || l.push({
         id: u,
@@ -14142,7 +14149,7 @@ async function GN(e, t, n = {}) {
       });
     }), l.sort((u, p) => Number((u == null ? void 0 : u.z_index) || 0) - Number((p == null ? void 0 : p.z_index) || 0)), b.painting.groups = l, l;
   }
-  function dg(i, s, l) {
+  function gg(i, s, l) {
     var K;
     const u = (Y) => (Number(Y || 0) % 1 + 1) % 1, p = [];
     for (const Y of l) {
@@ -14182,7 +14189,7 @@ async function GN(e, t, n = {}) {
     const p = Rt().find((_) => String((_ == null ? void 0 : _.actionGroupId) || "") === u);
     if (!p) return null;
     const m = l || qn(u, s);
-    return p.frame = dg(u, s, m), p.frame;
+    return p.frame = gg(u, s, m), p.frame;
   }
   function Oi() {
     var u;
@@ -14191,7 +14198,7 @@ async function GN(e, t, n = {}) {
       id: String((p == null ? void 0 : p.id) || ""),
       z_index: Number((p == null ? void 0 : p.z_index) || 0),
       item: p
-    })), s = fg().map((p) => ({
+    })), s = mg().map((p) => ({
       type: "strokeGroup",
       id: String((p == null ? void 0 : p.id) || (p == null ? void 0 : p.actionGroupId) || ""),
       actionGroupId: String((p == null ? void 0 : p.actionGroupId) || ""),
@@ -14234,14 +14241,14 @@ async function GN(e, t, n = {}) {
       }
     ].sort((B, Z) => Number((B == null ? void 0 : B.z_index) || 0) - Number((Z == null ? void 0 : Z.z_index) || 0));
   }
-  function hg() {
+  function bg() {
     return Rt().slice().sort((i, s) => Number((i == null ? void 0 : i.z_index) || 0) - Number((s == null ? void 0 : s.z_index) || 0)).map((i) => Ri(Pa("paint", (i == null ? void 0 : i.actionGroupId) || (i == null ? void 0 : i.id) || ""))).filter(Boolean);
   }
-  function pg() {
+  function yg() {
     var i;
     return (Array.isArray((i = b.painting) == null ? void 0 : i.raster_objects) ? b.painting.raster_objects : []).filter((s) => String((s == null ? void 0 : s.layerKind) || "paint") === "paint").slice().sort((s, l) => Number((s == null ? void 0 : s.z_index) || 0) - Number((l == null ? void 0 : l.z_index) || 0)).map((s) => Fi(Aa((s == null ? void 0 : s.id) || ""))).filter(Boolean);
   }
-  function Hc(i = d.interaction) {
+  function Uc(i = d.interaction) {
     const s = String((i == null ? void 0 : i.kind) || "");
     if (s === "paint_stroke" || s === "paint_lasso_fill" || s === "move_stroke_group" || s === "scale_stroke_group" || s === "rotate_stroke_group" || s === "move_raster_object" || s === "scale_raster_object") return !0;
     if (s === "move_multi") {
@@ -14250,7 +14257,7 @@ async function GN(e, t, n = {}) {
     }
     return !1;
   }
-  function mg() {
+  function vg() {
     var s, l, u, p;
     let i = null;
     try {
@@ -14267,7 +14274,7 @@ async function GN(e, t, n = {}) {
   function Ao() {
     var p, m, _, y, w, k, C;
     const i = d.interaction, s = String((i == null ? void 0 : i.kind) || "");
-    if (!Hc(i)) return "";
+    if (!Uc(i)) return "";
     if (s === "paint_stroke" || s === "paint_lasso_fill") {
       const N = ((p = i == null ? void 0 : i.stroke) == null ? void 0 : p.geometry) || null, F = String(((m = i == null ? void 0 : i.stroke) == null ? void 0 : m.layerKind) || ""), B = ((_ = N == null ? void 0 : N.rawPoints) == null ? void 0 : _.length) ?? ((y = N == null ? void 0 : N.points) == null ? void 0 : y.length) ?? 0, Z = String((i == null ? void 0 : i._livePreviewToken) || "");
       return `_${F || "paint"}_${s}_live${Z}_${B}_${d.livePaintInteractionRevision}`;
@@ -14326,7 +14333,7 @@ async function GN(e, t, n = {}) {
     const l = Ca(i, s), u = String(l.actionGroupId || "").trim();
     return u ? Xi(l.layerKind).filter((p) => String((p == null ? void 0 : p.actionGroupId) || "").trim() === u) : [];
   }
-  function gg(i, s = "paint") {
+  function _g(i, s = "paint") {
     const l = String(i || "").trim(), p = `geomv5:${String(s || "paint").trim() || "paint"}:${l}:${d.mode}:${Oa()}`;
     if (d.mode === "frame") {
       const m = He(), _ = String((m == null ? void 0 : m.id) || ""), y = m ? Yt(m) : null;
@@ -14372,7 +14379,7 @@ async function GN(e, t, n = {}) {
       v: W(m + B, 0, 1)
     };
   }
-  function Uc(i, s, l, u = null, p = null, m = null) {
+  function Bc(i, s, l, u = null, p = null, m = null) {
     const _ = Ca(i, p), y = String(_.actionGroupId || "").trim();
     if (!y) return !1;
     const w = Xi(_.layerKind), k = Array.isArray(u) ? new Map(u.map((N) => [String((N == null ? void 0 : N.id) || ""), N])) : null;
@@ -14387,7 +14394,7 @@ async function GN(e, t, n = {}) {
     }
     return C;
   }
-  function Bc(i, s = 1, l = 0, u = null, p = null, m = null) {
+  function Gc(i, s = 1, l = 0, u = null, p = null, m = null) {
     const _ = Ca(i, p), y = String(_.actionGroupId || "").trim();
     if (!y) return !1;
     const w = Xi(_.layerKind), k = Array.isArray(u) ? u : qn(y, _.layerKind), C = Array.isArray(k) ? new Map(k.map((B) => [String((B == null ? void 0 : B.id) || ""), B])) : null, N = (m == null ? void 0 : m.centerUv) ?? yl(y, _.layerKind, k);
@@ -14402,7 +14409,7 @@ async function GN(e, t, n = {}) {
     }
     return F;
   }
-  function Gc(i, s, l, u = null) {
+  function Kc(i, s, l, u = null) {
     const p = Jt(i);
     if (!p) return !1;
     const m = Cn().find((C) => String((C == null ? void 0 : C.id) || "").trim() === p);
@@ -14410,7 +14417,7 @@ async function GN(e, t, n = {}) {
     const _ = u && typeof u == "object" ? u : m, y = (_ == null ? void 0 : _.transform) || {}, w = Number(y.du || 0) + Number(s || 0), k = W(Number(y.dv || 0) + Number(l || 0), -1, 1);
     return m.transform || (m.transform = { du: 0, dv: 0, rot_deg: 0, scale: 1 }), m.transform.du = w, m.transform.dv = k, !0;
   }
-  function bg(i, s = 1, l = null) {
+  function xg(i, s = 1, l = null) {
     const u = Jt(i);
     if (!u) return !1;
     const p = Cn().find((k) => String((k == null ? void 0 : k.id) || "").trim() === u);
@@ -14462,7 +14469,7 @@ async function GN(e, t, n = {}) {
       rotateHandle: { x: (m + _) * 0.5, y: y - 30 }
     };
   }
-  function Kc(i) {
+  function Wc(i) {
     const s = String((i == null ? void 0 : i.id) || "").trim();
     return !!s && Array.isArray(d.selectedIds) && d.selectedIds.includes(s);
   }
@@ -14486,7 +14493,7 @@ async function GN(e, t, n = {}) {
     const s = Array.isArray(i) ? i : Xn();
     return s.length > 0 && s.every((l) => wn(l));
   }
-  function yg(i, s) {
+  function Sg(i, s) {
     const l = s === !0;
     if (!i || typeof i != "object") return !1;
     if (Wt(i)) {
@@ -14499,20 +14506,20 @@ async function GN(e, t, n = {}) {
     }
     return i.locked === l ? !1 : (i.locked = l, !0);
   }
-  function vg() {
+  function wg() {
     if (r) return;
     const i = Xn();
     if (!i.length) return;
     const s = !_l(i);
     let l = !1;
     i.forEach((u) => {
-      yg(u, s) && (l = !0);
+      Sg(u, s) && (l = !0);
     }), l && (st(), ut(), rt(), We(), be());
   }
   function Li(i) {
     d.selectedId = (i == null ? void 0 : i.id) || null, d.selectedIds = i != null && i.id ? [i.id] : [], i && vt(i) ? b.active.selected_sticker_id = i.id || null : b.active.selected_sticker_id = null, i && Ln(i) ? b.active.selected_shot_id = i.id || null : i ? Ln(i) || (b.active.selected_shot_id = b.active.selected_shot_id) : b.active.selected_shot_id = null;
   }
-  function _g(i, s = null) {
+  function kg(i, s = null) {
     const l = [], u = /* @__PURE__ */ new Set();
     (Array.isArray(i) ? i : []).forEach((_) => {
       const y = String((_ == null ? void 0 : _.id) || "").trim();
@@ -14523,7 +14530,7 @@ async function GN(e, t, n = {}) {
     const m = It();
     b.active.selected_sticker_id = m && vt(m) && m.id || null, m && Ln(m) ? b.active.selected_shot_id = m.id || null : l.length || (b.active.selected_shot_id = null);
   }
-  function Wc() {
+  function Yc() {
     const i = (Array.isArray(b.shots) ? b.shots : []).map((l, u) => ({
       kind: "frame",
       item: l,
@@ -14539,7 +14546,7 @@ async function GN(e, t, n = {}) {
     });
     return [...i, ...s];
   }
-  function xg(i) {
+  function Ng(i) {
     return i === "frame" ? Te.camera : i === "stroke" ? Te.paintbrush_vertical_tool : Te.image;
   }
   function xl(i) {
@@ -14548,33 +14555,33 @@ async function GN(e, t, n = {}) {
       icon: null
     } : {
       label: String(i.label || ""),
-      icon: xg(i.kind)
+      icon: Ng(i.kind)
     };
   }
-  function Yc() {
+  function qc() {
     return pl();
   }
   function Zt(i) {
-    return !i || typeof i != "object" ? !1 : String(i.id || "") === as || String(i.source_kind || "") === pN;
+    return !i || typeof i != "object" ? !1 : String(i.id || "") === as || String(i.source_kind || "") === yN;
   }
   function zi(i) {
     return !!(i && typeof i == "object" && i.visible === !1);
   }
-  function Sg(i) {
-    return Zt(i) && zi(i) ? rm : 1;
+  function Mg(i) {
+    return Zt(i) && zi(i) ? sm : 1;
   }
-  function wg() {
+  function Pg() {
     return d.primaryTool === "mask" ? d.maskTool : d.paintTool;
   }
-  function kg() {
-    return String(wg() || "") === "lasso_fill";
+  function Ag() {
+    return String(Pg() || "") === "lasso_fill";
   }
-  function Ng() {
+  function Cg() {
     if (r) return;
     const i = It();
     !i || !Zt(i) || (i.visible = zi(i), an(), st(), ut(), We(), rt(), be());
   }
-  function Mg() {
+  function Tg() {
     if (r || t !== "stickers") return;
     const i = It();
     if (!i || !Zt(i)) return;
@@ -14590,7 +14597,7 @@ async function GN(e, t, n = {}) {
       Number(l.naturalHeight || l.height || 1)
     ) : i.vFOV_deg = Number(s.vFOV_deg ?? i.vFOV_deg ?? 30), i.rot_deg = Number(s.rot_deg ?? i.rot_deg ?? 0), st(), ut(), We(), rt(), be();
   }
-  function Pg(i) {
+  function Ig(i) {
     if (!i || !Zt(i)) return null;
     const s = i.initial_pose;
     if (!s || typeof s != "object") return null;
@@ -14609,26 +14616,26 @@ async function GN(e, t, n = {}) {
       Number(u.naturalHeight || u.height || 1)
     )), l;
   }
-  function Ag() {
+  function Eg() {
     const i = It();
     if (!i || !Zt(i)) return !1;
-    const s = Pg(i);
+    const s = Ig(i);
     if (!s) return !1;
     const l = (u, p) => Math.abs(Number(u || 0) - Number(p || 0)) <= 1e-4;
     return !(l(i.yaw_deg, s.yaw_deg) && l(i.pitch_deg, s.pitch_deg) && l(i.hFOV_deg, s.hFOV_deg) && l(i.vFOV_deg, s.vFOV_deg) && l(i.rot_deg, s.rot_deg));
   }
-  function qc(i) {
+  function Xc(i) {
     return tr.uiList(e, i);
   }
-  function Xc(i) {
+  function Jc(i) {
     return tr.uiValue(e, i);
   }
-  function Jc() {
+  function Zc() {
     const i = String((e == null ? void 0 : e.comfyClass) || (e == null ? void 0 : e.type) || (e == null ? void 0 : e.title) || "");
     return Hs(i) ? { videoKey: "pano_videos", metaKey: "pano_video_meta" } : t === "stickers" || t === "cutout" ? { videoKey: "pano_input_videos", metaKey: "pano_input_video_meta" } : { videoKey: "pano_videos", metaKey: "pano_video_meta" };
   }
-  function Cg() {
-    const { metaKey: i } = Jc(), s = Xc(i);
+  function Dg() {
+    const { metaKey: i } = Zc(), s = Jc(i);
     return Array.isArray(s) && s.length > 0 && s[0] && typeof s[0] == "object" ? s[0] : s && typeof s == "object" ? s : null;
   }
   function $i(i) {
@@ -14681,7 +14688,7 @@ async function GN(e, t, n = {}) {
   function Ar() {
     return !!(U instanceof HTMLVideoElement && U.getAttribute("src") && d.primaryTool !== "paint" && d.primaryTool !== "mask");
   }
-  function Tg() {
+  function Og() {
     ar({
       visible: Ar()
     });
@@ -14693,7 +14700,7 @@ async function GN(e, t, n = {}) {
     const l = at.getContext("2d");
     return l ? (l.clearRect(0, 0, i, s), l.drawImage(U, 0, 0, i, s), at.__panoFrameIdx = Number(at.__panoFrameIdx || 0) + 1, E.presentedTime = Number(E.editorTime || U.currentTime || 0), !0) : !1;
   }
-  function Zc() {
+  function Qc() {
     return E.mode === "scrub" && Number(at.width || 0) > 0 && Number(at.height || 0) > 0 && Number(at.__panoFrameIdx || 0) > 0 ? at : U instanceof HTMLVideoElement && Number(U.videoWidth || 0) > 0 && Number(U.videoHeight || 0) > 0 && Number(U.readyState || 0) >= 2 ? U : null;
   }
   function wl(i) {
@@ -14710,7 +14717,7 @@ async function GN(e, t, n = {}) {
   }
   function Vi() {
     if (!(U instanceof HTMLVideoElement)) return null;
-    const { videoKey: i } = Jc(), s = qc(i)[0] || null, l = NN(s), u = Cg(), p = Math.max(0, Number((u == null ? void 0 : u.frames) || 0)), m = Math.max(1, Number((u == null ? void 0 : u.fps) || 24)), _ = Number((u == null ? void 0 : u.duration) || (p > 0 ? p / m : 0)), y = !!(u != null && u.has_audio) || Kt(U);
+    const { videoKey: i } = Zc(), s = Xc(i)[0] || null, l = CN(s), u = Dg(), p = Math.max(0, Number((u == null ? void 0 : u.frames) || 0)), m = Math.max(1, Number((u == null ? void 0 : u.fps) || 24)), _ = Number((u == null ? void 0 : u.duration) || (p > 0 ? p / m : 0)), y = !!(u != null && u.has_audio) || Kt(U);
     return l && U.dataset.panoSrc !== l ? (U.pause(), U.dataset.panoSrc = l, U.dataset.panoFrameIdx = "0", U.loop = !!P.videoTransport.loop, U.muted = !!P.videoTransport.muted, U.volume = Math.max(0, Math.min(1, Number(P.videoTransport.volume ?? 1))), U.src = l, U.load(), li(l, _, m)) : !l && U.getAttribute("src") && (U.pause(), U.removeAttribute("src"), U.load(), Tt()), U.loop !== !!P.videoTransport.loop && (U.loop = !!P.videoTransport.loop), l && (!Array.isArray(P.videoTransport.thumbnails) || P.videoTransport.thumbnails.length === 0) && li(l, _, m), l || Tt(), ar({
       ready: !!l,
       playing: !U.paused && !U.ended,
@@ -14727,7 +14734,7 @@ async function GN(e, t, n = {}) {
       thumbnailCount: P.videoTransport.thumbnailCount
     }), l || null;
   }
-  function Ig(i, s = null) {
+  function Fg(i, s = null) {
     var l;
     if (i && typeof i == "object" && !Array.isArray(i)) return i;
     if (Array.isArray(i) && i.length > 0) {
@@ -14749,14 +14756,14 @@ async function GN(e, t, n = {}) {
   function kl(i, s = null) {
     return _u(e, i, Re, s || (() => be()));
   }
-  function Qc(i = null) {
+  function ef(i = null) {
     return kl(os, i);
   }
   function Hi(i, s, l) {
     const u = Math.max(1, Number(s || 1)), p = Math.max(1, Number(l || 1)), m = W(Number(i || 30), 0.1, 179) * pn, _ = 2 * Math.atan(Math.tan(m * 0.5) * (p / u));
     return W(_ * zr, 0.1, 179);
   }
-  function Eg(i) {
+  function Rg(i) {
     const s = String(i || "").trim();
     if (!s) return null;
     try {
@@ -14782,7 +14789,7 @@ async function GN(e, t, n = {}) {
       return null;
     }
   }
-  function ef(i) {
+  function tf(i) {
     const s = Number(i == null ? void 0 : i.yaw_deg), l = Number(i == null ? void 0 : i.pitch_deg), u = Number((i == null ? void 0 : i.roll_deg) ?? (i == null ? void 0 : i.rot_deg)), p = Number(i == null ? void 0 : i.hFOV_deg), m = Pi(i);
     return {
       kind: "pano_sticker_state",
@@ -14796,9 +14803,9 @@ async function GN(e, t, n = {}) {
       source_aspect: m
     };
   }
-  function Dg(i) {
+  function Lg(i) {
     var y;
-    if (!i || typeof i != "object") return ef(null);
+    if (!i || typeof i != "object") return tf(null);
     const s = Number(i == null ? void 0 : i.yaw_deg), l = Number(i == null ? void 0 : i.pitch_deg), u = Number((i == null ? void 0 : i.roll_deg) ?? (i == null ? void 0 : i.rot_deg)), p = Number(i == null ? void 0 : i.hFOV_deg), m = Number(i == null ? void 0 : i.vFOV_deg);
     let _ = 1;
     if (Number.isFinite(p) && Number.isFinite(m)) {
@@ -14824,16 +14831,16 @@ async function GN(e, t, n = {}) {
       source_aspect: _
     };
   }
-  function Og(i) {
+  function zg(i) {
     return tr.linkedValue(e, i);
   }
-  function Fg(i, s, l) {
+  function $g(i, s, l) {
     const u = i && typeof i == "object" ? {
       yaw_deg: Number(i.yaw_deg || 0),
       pitch_deg: Number(i.pitch_deg || 0),
       roll_deg: Number(i.rot_deg ?? i.roll_deg ?? 0),
       hFOV_deg: Number(i.hFOV_deg || 30)
-    } : Eg(s);
+    } : Rg(s);
     if (u) {
       const _ = Number((l == null ? void 0 : l.naturalWidth) || (l == null ? void 0 : l.width) || u.source_aspect || 1), y = Number((l == null ? void 0 : l.naturalHeight) || (l == null ? void 0 : l.height) || 1);
       return {
@@ -14853,11 +14860,11 @@ async function GN(e, t, n = {}) {
       rot_deg: 0
     };
   }
-  function tf(i = "sync") {
+  function nf(i = "sync") {
     if (t !== "stickers" || r) return;
-    const s = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs.find((k) => String((k == null ? void 0 : k.name) || "") === "sticker_image") : null, l = (s == null ? void 0 : s.link) ?? null, u = Qc(() => {
+    const s = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs.find((k) => String((k == null ? void 0 : k.name) || "") === "sticker_image") : null, l = (s == null ? void 0 : s.link) ?? null, u = ef(() => {
       Qa(e, "image-loaded");
-    }), p = Ig(Xc("pano_sticker_input_pose"), null), m = Og("sticker_state"), _ = tr.externalStateHash(e, m), y = l == null ? null : Fg(p, m, u), w = Cm(b, {
+    }), p = Fg(Jc("pano_sticker_input_pose"), null), m = zg("sticker_state"), _ = tr.externalStateHash(e, m), y = l == null ? null : $g(p, m, u), w = Dm(b, {
       connected: l != null,
       linkId: l,
       stateHash: _,
@@ -14879,7 +14886,7 @@ async function GN(e, t, n = {}) {
       aspect_id: Lr(l)
     }), d.selectedId = null, d.selectedIds = [], d.cutoutAspectOpen = !1, b.active.selected_sticker_id = null, b.active.selected_shot_id = null;
   }
-  function Rg() {
+  function jg() {
     if (t !== "cutout") return;
     const i = He();
     i && (d.selectedId = String(i.id || "") || null, d.selectedIds = d.selectedId ? [d.selectedId] : []);
@@ -14895,7 +14902,7 @@ async function GN(e, t, n = {}) {
       icon: i ? Te.camera : Te.plus_circle
     });
   }
-  function nf() {
+  function rf() {
     const i = t === "cutout" && d.mode === "frame", s = !i && !!d.showGrid;
     na(P.floatingButtons, "action", "reset-view", {
       disabled: r || i
@@ -14919,10 +14926,10 @@ async function GN(e, t, n = {}) {
       value: u,
       label: u,
       active: !!s && String(Lr(s)) === u
-    })), s || (P.frameRail.aspectOpen = !1), P.outputPreviewToggle.visible = t === "cutout" && d.mode !== "frame" && !!He(), t === "cutout" && P.cameraPreview && (P.cameraPreview.visible = d.mode !== "frame", P.cameraPreview.expanded = !!d.outputPreviewExpanded, P.cameraPreview.settled = P.cameraPreview.settled === !0 && oe.pendingStableLayoutFrames <= 0 && oe.hasPresentedFrame), nf(), Rf() ? _t(d.pointerPos) : Nt(d.mode === "pano" ? "grab" : "default");
+    })), s || (P.frameRail.aspectOpen = !1), P.outputPreviewToggle.visible = t === "cutout" && d.mode !== "frame" && !!He(), t === "cutout" && P.cameraPreview && (P.cameraPreview.visible = d.mode !== "frame", P.cameraPreview.expanded = !!d.outputPreviewExpanded, P.cameraPreview.settled = P.cameraPreview.settled === !0 && oe.pendingStableLayoutFrames <= 0 && oe.hasPresentedFrame), rf(), Lf() ? _t(d.pointerPos) : Nt(d.mode === "pano" ? "grab" : "default");
   }
-  function Lg() {
-    const s = cf({
+  function Vg() {
+    const s = ff({
       yaw_deg: 0,
       pitch_deg: 0,
       hFOV_deg: 20,
@@ -14961,26 +14968,26 @@ async function GN(e, t, n = {}) {
     const p = i, m = p / l;
     return { x: 0, y: (s - m) * 0.5, w: p, h: m };
   }
-  function rf(i) {
+  function af(i) {
     var _;
     if (i && typeof i == "object" && (Zt(i) || i.external === !0))
-      return Qc(() => {
+      return ef(() => {
         Qa(e, "image-loaded");
       });
     const s = String(i && typeof i == "object" ? i.asset_id || i.assetId || "" : i || "");
     if (!s) return null;
     const l = Re.get(s);
     if (l) return l;
-    const u = (_ = b.assets) == null ? void 0 : _[s], p = kN(u);
+    const u = (_ = b.assets) == null ? void 0 : _[s], p = AN(u);
     if (!p) return null;
     const m = new Image();
-    return ng(m, p), m.onload = () => {
-      rg(m, p), be();
+    return og(m, p), m.onload = () => {
+      sg(m, p), be();
     }, m.onerror = () => {
-      ig(m, p), be();
+      lg(m, p), be();
     }, m.src = p, Re.set(s, m), m;
   }
-  function af(i, s = null) {
+  function of(i, s = null) {
     const l = String((i == null ? void 0 : i.rasterDataUrl) || "").trim();
     if (!l) return null;
     const u = Ue.get(l);
@@ -14991,12 +14998,12 @@ async function GN(e, t, n = {}) {
       typeof s == "function" && s();
     }, p.src = l, Ue.set(l, p), p;
   }
-  function zg(i) {
+  function Hg(i) {
     const s = String((i == null ? void 0 : i.rasterDataUrl) || "").trim();
     if (!s) return null;
     const l = et.get(s);
     if (l) return l.ready ? l : null;
-    const u = af(i, () => {
+    const u = of(i, () => {
       const C = et.get(s);
       C && (C.ready = !1), be({ localOnly: !0 });
     });
@@ -15011,7 +15018,7 @@ async function GN(e, t, n = {}) {
     const w = y.getImageData(0, 0, p, m).data, k = { canvas: _, width: p, height: m, alpha: w, ready: !0 };
     return et.set(s, k), k;
   }
-  function $g(i, s, l = 1, u = 0) {
+  function Ug(i, s, l = 1, u = 0) {
     if (!i || typeof i != "object") return i;
     const p = Number((s == null ? void 0 : s.u) || 0), m = Number((s == null ? void 0 : s.v) || 0), _ = Un(Number(i.u || 0), p), y = Number(i.v || 0) - m, w = Math.max(0.02, Number(l || 1)), k = Number(u || 0) * pn, C = Math.cos(k), N = Math.sin(k), F = _ / w, B = y / w, Z = F * C + B * N, K = -F * N + B * C;
     return {
@@ -15020,7 +15027,7 @@ async function GN(e, t, n = {}) {
       v: m + K
     };
   }
-  function jg(i, s) {
+  function Bg(i, s) {
     if (!i || !s) return null;
     const l = (i == null ? void 0 : i.bbox) || null;
     if (!l) return null;
@@ -15030,7 +15037,7 @@ async function GN(e, t, n = {}) {
     }, m = {
       u: ((Number(s.u || 0) - Number(u.du || 0)) % 1 + 1) % 1,
       v: Number(s.v || 0) - Number(u.dv || 0)
-    }, _ = $g(
+    }, _ = Ug(
       m,
       p,
       Number(u.scale || 1),
@@ -15039,22 +15046,22 @@ async function GN(e, t, n = {}) {
     if (!(y > 1e-6) || !(w > 1e-6)) return null;
     const k = Un(Number(_.u || 0), Number(l.u0 || 0)) / y, C = (Number(_.v || 0) - Number(l.v0 || 0)) / w;
     if (k < 0 || k > 1 || C < 0 || C > 1) return 0;
-    const N = zg(i);
+    const N = Hg(i);
     if (!N) return null;
     const F = W(Math.floor(k * N.width), 0, N.width - 1), B = W(Math.floor(C * N.height), 0, N.height - 1);
     return Number(N.alpha[(B * N.width + F) * 4 + 3] || 0);
   }
-  function of(i, s, l, u = null) {
+  function sf(i, s, l, u = null) {
     if (!(s != null && s.visible) || !Or(l, s.corners)) return !1;
-    const p = u || Zn(l, performance.now()), m = jg(i, p);
+    const p = u || Zn(l, performance.now()), m = Bg(i, p);
     return m === null ? !0 : m > 8;
   }
-  function Vg() {
+  function Gg() {
     var u, p, m, _, y, w, k, C;
     const i = ((p = (u = d.paintEngine) == null ? void 0 : u.getErpTarget) == null ? void 0 : p.call(u, ml(!1))) || null, s = Math.max(1, Number(((m = i == null ? void 0 : i.descriptor) == null ? void 0 : m.width) || ((y = (_ = i == null ? void 0 : i.displayPaint) == null ? void 0 : _.canvas) == null ? void 0 : y.width) || 2048)), l = Math.max(1, Number(((w = i == null ? void 0 : i.descriptor) == null ? void 0 : w.height) || ((C = (k = i == null ? void 0 : i.displayPaint) == null ? void 0 : k.canvas) == null ? void 0 : C.height) || 1024));
     return { width: s, height: l };
   }
-  function Hg() {
+  function Kg() {
     var B, Z, K;
     const i = d.interaction;
     if ((i == null ? void 0 : i.kind) !== "paint_stroke") return null;
@@ -15069,7 +15076,7 @@ async function GN(e, t, n = {}) {
       m.processedPoints = Ol(Y, p.targetSpace, !0);
     }
     const _ = Da(l.width, l.height, { readback: !0 });
-    if (!wf(_, p, { w: l.width, h: l.height })) return null;
+    if (!kf(_, p, { w: l.width, h: l.height })) return null;
     const y = ((K = (Z = _.ctx) == null ? void 0 : Z.getImageData(0, 0, l.width, l.height)) == null ? void 0 : K.data) || null;
     if (!y) return null;
     let w = l.width, k = l.height, C = -1, N = -1;
@@ -15088,7 +15095,7 @@ async function GN(e, t, n = {}) {
   function Ui() {
     d._activePaintEraserPreviewInfo = null, d._liveEraserPreviewCanvasCache = null;
   }
-  function Ug(i, s, l) {
+  function Wg(i, s, l) {
     var u, p;
     if (!i) return null;
     if (i.type === "rasterObject" && ((u = i.item) != null && u.bbox)) {
@@ -15115,7 +15122,7 @@ async function GN(e, t, n = {}) {
     }
     return null;
   }
-  function Bg(i, s, l) {
+  function Yg(i, s, l) {
     if (!i || !s) return !1;
     const u = (_) => _.wraps ? [
       { minX: 0, maxX: _.maxX, minY: _.minY, maxY: _.maxY, wraps: !1 },
@@ -15123,13 +15130,13 @@ async function GN(e, t, n = {}) {
     ] : [_], p = u(i), m = u(s);
     return p.some((_) => m.some((y) => !(_.maxX < y.minX || y.maxX < _.minX || _.maxY < y.minY || y.maxY < _.minY)));
   }
-  function Gg(i, s, l) {
+  function qg(i, s, l) {
     var _e, ze, Be, it, ve, ae, me;
     if (!i || !s || !((_e = l == null ? void 0 : l.surface) != null && _e.canvas) || s.type !== "rasterObject") return i;
     const u = Number(i.width || l.surface.canvas.width || 0), p = Number(i.height || l.surface.canvas.height || 0);
     if (u < 1 || p < 1) return i;
-    const m = Ug(s, u, p);
-    if (m && !Bg(m, l.bounds, u)) return i;
+    const m = Wg(s, u, p);
+    if (m && !Yg(m, l.bounds, u)) return i;
     const _ = String(((ze = s.item) == null ? void 0 : ze.id) || s.id || ""), y = ((Be = s.item) == null ? void 0 : Be.transform) || {}, w = `${l.key}:${_}:${u}:${p}:${Number(y.du || 0).toFixed(6)}:${Number(y.dv || 0).toFixed(6)}:${Number(y.rot_deg || 0).toFixed(3)}:${Number(y.scale || 1).toFixed(4)}`, k = d._liveEraserPreviewCanvasCache instanceof Map ? d._liveEraserPreviewCanvasCache : d._liveEraserPreviewCanvasCache = /* @__PURE__ */ new Map();
     if (k.has(w)) return k.get(w);
     const C = W(Math.floor(Number(((it = l.bounds) == null ? void 0 : it.minX) || 0)), 0, Math.max(0, u - 1)), N = W(Math.floor(Number(((ve = l.bounds) == null ? void 0 : ve.minY) || 0)), 0, Math.max(0, p - 1)), F = W(Math.ceil(Number(((ae = l.bounds) == null ? void 0 : ae.maxX) || 0)), C, Math.max(0, u - 1)), B = W(Math.ceil(Number(((me = l.bounds) == null ? void 0 : me.maxY) || 0)), N, Math.max(0, p - 1)), Z = Math.max(1, F - C + 1), K = Math.max(1, B - N + 1), Y = Da(u, p, { readback: !0 });
@@ -15147,12 +15154,12 @@ async function GN(e, t, n = {}) {
     }
     return le ? (k.size > 64 && k.clear(), k.set(w, Y.canvas), Y.canvas) : (k.set(w, i), i);
   }
-  function sf(i, s = null) {
+  function lf(i, s = null) {
     const l = Jt((i == null ? void 0 : i.rasterObjectId) || (i == null ? void 0 : i.id) || ""), u = (i == null ? void 0 : i.bbox) || null;
     if (!l || !u) return null;
-    const p = af(i, s);
+    const p = of(i, s);
     if (!p || !(p.complete || p.width || p.naturalWidth)) return null;
-    const { width: m, height: _ } = Vg(), y = (i == null ? void 0 : i.transform) || {}, w = [
+    const { width: m, height: _ } = Gg(), y = (i == null ? void 0 : i.transform) || {}, w = [
       l,
       m,
       _,
@@ -15177,26 +15184,26 @@ async function GN(e, t, n = {}) {
       N.save(), N.translate(Y + _e, ue), N.rotate(pe), N.scale(le, le), N.drawImage(p, -Z * 0.5, -K * 0.5, Z, K), N.restore();
     return gt.set(w, C), C;
   }
-  function Kg() {
+  function Xg() {
     return fl(b, {
       selectedId: d.selectedId || null,
       hoveredId: null,
       includeHidden: !0
     });
   }
-  function Wg(i) {
-    return im(
+  function Jg(i) {
+    return lm(
       b,
-      (s, l, u) => rf(u || s),
+      (s, l, u) => af(u || s),
       { scene: i }
     );
   }
-  function lf(i, s, l, u, p = "modal_object_view") {
+  function uf(i, s, l, u, p = "modal_object_view") {
     if (!i || !s || !l) return !1;
     String((l == null ? void 0 : l.mode) || "");
     const m = ui(u);
-    if (pf(s, l))
-      return n0(
+    if (mf(s, l))
+      return o0(
         s,
         l,
         m && d.showPanorama ? u : null,
@@ -15245,18 +15252,18 @@ async function GN(e, t, n = {}) {
     };
   }
   let Eo = null, Do = !1;
-  function Yg() {
-    const i = Uh(b.painting);
+  function Zg() {
+    const i = Wh(b.painting);
     if (i.totalPaintCount <= 0 && i.totalMaskCount <= 0) return !1;
     const s = b.painting_layer, l = Wi();
     return !s || typeof s != "object" || String(s.revision || "") !== l || i.totalPaintCount > 0 && !s.paint || i.totalMaskCount > 0 && !s.mask;
   }
-  function uf() {
+  function cf() {
     const i = String(e.id ?? "0"), s = ss.get(i);
     if (Do && s) return s;
     const l = (async () => {
       var m, _, y, w, k, C, N, F, B, Z, K, Y;
-      const u = Wi(), p = Uh(b.painting);
+      const u = Wi(), p = Wh(b.painting);
       if (p.totalPaintCount <= 0 && p.totalMaskCount <= 0) {
         b.painting_layer !== null && (b.painting_layer = null, Eo = u, In());
         return;
@@ -15305,7 +15312,7 @@ async function GN(e, t, n = {}) {
   }
   function Bi() {
     if (t === "cutout") {
-      const y = Zc();
+      const y = Qc();
       if (y) return y;
       const w = xu(
         e,
@@ -15313,12 +15320,12 @@ async function GN(e, t, n = {}) {
         () => be(),
         "background:cutout:erp_image|bg_erp"
       );
-      return w && !ec(w) ? w : _u(e, "pano_input_images", Re, () => be()) || w || null;
+      return w && !tc(w) ? w : _u(e, "pano_input_images", Re, () => be()) || w || null;
     }
-    const i = Zc();
+    const i = Qc();
     if (i) return i;
     const s = _u(e, "pano_input_images", Re, () => be());
-    if (s && !ec(s)) return s;
+    if (s && !tc(s)) return s;
     const l = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs.map((y) => String((y == null ? void 0 : y.name) || "")) : [], u = l.includes("erp_image"), p = l.includes("bg_erp");
     let m = [];
     return r && (u || p) ? m = u ? ["erp_image", "bg_erp"] : ["bg_erp", "erp_image"] : m = t === "stickers" ? ["bg_erp", "erp_image"] : ["erp_image", "bg_erp"], xu(e, m, () => be(), `background:${m.join("|")}`) || s || null;
@@ -15326,22 +15333,22 @@ async function GN(e, t, n = {}) {
   function ui(i) {
     return i ? i instanceof HTMLImageElement ? !!i.complete && Number(i.naturalWidth || i.width || 0) > 0 && Number(i.naturalHeight || i.height || 0) > 0 : i instanceof HTMLVideoElement ? Number(i.videoWidth || 0) > 0 && Number(i.videoHeight || 0) > 0 && Number(i.readyState || 0) >= 2 : Number(i.width || i.naturalWidth || 0) > 0 && Number(i.height || i.naturalHeight || 0) > 0 : !1;
   }
-  function qg() {
+  function Qg() {
     let i = wa;
     const s = [];
     if (d.showPanorama) {
       const l = Bi();
-      i = Qu(l, ui);
+      i = ec(l, ui);
     }
     if (d.showObjects) {
       const l = Array.isArray(b.stickers) ? b.stickers : [];
       for (const u of l) {
         if ((u == null ? void 0 : u.visible) === !1) continue;
-        const p = rf(u);
-        s.push(Qu(p, ui));
+        const p = af(u);
+        s.push(ec(p, ui));
       }
     }
-    return oN({
+    return cN({
       presented: oe.hasPresentedFrame,
       background: i,
       stickers: s
@@ -15390,7 +15397,7 @@ async function GN(e, t, n = {}) {
     const u = s * i.cr - l * i.sr, p = s * i.sr + l * i.cr;
     return ia(us(us(i.centerDir, cs(i.right, u)), cs(i.up, p)));
   }
-  function cf(i) {
+  function ff(i) {
     const s = Oo(i);
     return [
       { u: -1, v: 1 },
@@ -15399,18 +15406,18 @@ async function GN(e, t, n = {}) {
       { u: -1, v: -1 }
     ].map(({ u, v: p }) => Zr(s, u * s.tanX, p * s.tanY));
   }
-  function ff(i, s, l) {
+  function df(i, s, l) {
     const u = Oo(i), p = (s * 2 - 1) * u.tanX, m = (1 - l * 2) * u.tanY;
     return Zr(u, p, m);
   }
-  function df(i) {
+  function hf(i) {
     const s = (i == null ? void 0 : i.bbox) || null, l = (i == null ? void 0 : i.transform) || {};
     return s ? {
       u: (((Number(s.u0 || 0) + Number(s.u1 || 0)) * 0.5 + Number(l.du || 0)) % 1 + 1) % 1,
       v: W((Number(s.v0 || 0) + Number(s.v1 || 0)) * 0.5 + Number(l.dv || 0), 0, 1)
     } : { u: 0.5, v: 0.5 };
   }
-  function Xg(i) {
+  function e0(i) {
     var w, k, C, N;
     const s = (i == null ? void 0 : i.bbox) || null;
     if (!s) return [];
@@ -15425,7 +15432,7 @@ async function GN(e, t, n = {}) {
       { u: Number(s.u0 || 0), v: Number(s.v1 || 0) }
     ].map((F) => Co(To(F, l, u, p), m, _));
   }
-  function Jg(i) {
+  function t0(i) {
     const s = Jt((i == null ? void 0 : i.rasterObjectId) || (i == null ? void 0 : i.id) || ""), l = (i == null ? void 0 : i.transform) || {}, u = (i == null ? void 0 : i.bbox) || {}, p = `${s}:${d.mode}:${Oa()}:${u.u0}:${u.v0}:${u.u1}:${u.v1}:${l.du}:${l.dv}:${l.rot_deg}:${l.scale}`;
     if (d.mode === "frame") {
       const m = He(), _ = m ? Yt(m) : null;
@@ -15433,7 +15440,7 @@ async function GN(e, t, n = {}) {
     }
     return `${p}:view:${Math.round(Number(d.viewYaw || 0) * 100)}:${Math.round(Number(d.viewPitch || 0) * 100)}:${Math.round(Number(d.viewFov || 0) * 100)}:${Math.round(Number((T == null ? void 0 : T.width) || 0))}:${Math.round(Number((T == null ? void 0 : T.height) || 0))}`;
   }
-  function Zg(i) {
+  function n0(i) {
     const s = String((i == null ? void 0 : i.id) || ""), u = [
       Ln(i) ? "frame" : vt(i) ? "sticker" : "item",
       s,
@@ -15452,36 +15459,36 @@ async function GN(e, t, n = {}) {
     }
     return `${u}:view:${Math.round(Number(d.viewYaw || 0) * 100)}:${Math.round(Number(d.viewPitch || 0) * 100)}:${Math.round(Number(d.viewFov || 0) * 100)}:${Math.round(Number((T == null ? void 0 : T.width) || 0))}:${Math.round(Number((T == null ? void 0 : T.height) || 0))}`;
   }
-  function Qg() {
+  function r0() {
     var s;
     const i = String(((s = b.ui_settings) == null ? void 0 : s.preview_quality) || "balanced");
     return i === "draft" ? d.hqFrames && d.hqFrames > 0 ? [28, 20] : d.interaction ? [12, 9] : [20, 14] : i === "high" ? d.hqFrames && d.hqFrames > 0 ? [48, 36] : d.interaction ? [20, 14] : [36, 26] : d.hqFrames && d.hqFrames > 0 ? [40, 30] : d.interaction ? [16, 12] : [28, 20];
   }
-  function hf() {
+  function pf() {
     var i;
     return !!q && !!((i = xe == null ? void 0 : xe.isSupported) != null && i.call(xe));
   }
-  function pf(i, s) {
-    return !hf() || t !== "stickers" && t !== "cutout" || String((s == null ? void 0 : s.mode) || "") !== "panorama" ? !1 : Number((i == null ? void 0 : i.x) || 0) === 0 && Number((i == null ? void 0 : i.y) || 0) === 0 && Math.round(Number((i == null ? void 0 : i.w) || 0)) === Math.round(Number((T == null ? void 0 : T.width) || 0)) && Math.round(Number((i == null ? void 0 : i.h) || 0)) === Math.round(Number((T == null ? void 0 : T.height) || 0));
+  function mf(i, s) {
+    return !pf() || t !== "stickers" && t !== "cutout" || String((s == null ? void 0 : s.mode) || "") !== "panorama" ? !1 : Number((i == null ? void 0 : i.x) || 0) === 0 && Number((i == null ? void 0 : i.y) || 0) === 0 && Math.round(Number((i == null ? void 0 : i.w) || 0)) === Math.round(Number((T == null ? void 0 : T.width) || 0)) && Math.round(Number((i == null ? void 0 : i.h) || 0)) === Math.round(Number((T == null ? void 0 : T.height) || 0));
   }
   function Fo() {
-    return d.showObjects ? Kg() : { stickers: [], selectedId: null, hoveredId: null };
+    return d.showObjects ? Xg() : { stickers: [], selectedId: null, hoveredId: null };
   }
   function Ro(i) {
-    return !d.showObjects || !Array.isArray(i == null ? void 0 : i.stickers) || i.stickers.length === 0 ? [] : Wg(i);
+    return !d.showObjects || !Array.isArray(i == null ? void 0 : i.stickers) || i.stickers.length === 0 ? [] : Jg(i);
   }
-  function mf() {
+  function gf() {
     var i, s;
     return ((s = (i = d.paintEngine) == null ? void 0 : i.getMaskDisplayCanvas) == null ? void 0 : s.call(i)) || null;
   }
-  function e0() {
-    return mf() ? `${Fl()}:mask_display` : "";
+  function i0() {
+    return gf() ? `${Fl()}:mask_display` : "";
   }
   function Ea(i) {
     if (!d.showMask) return i;
-    const s = mf();
+    const s = gf();
     if (!s) return i;
-    const l = e0(), u = i.reduce((_, y) => Math.max(_, Number((y == null ? void 0 : y.zIndex) || 0)), -1), p = (Array.isArray(b.stickers) ? b.stickers : []).reduce((_, y) => Math.max(_, Number((y == null ? void 0 : y.z_index) || 0)), -1), m = Math.max(u, p);
+    const l = i0(), u = i.reduce((_, y) => Math.max(_, Number((y == null ? void 0 : y.zIndex) || 0)), -1), p = (Array.isArray(b.stickers) ? b.stickers : []).reduce((_, y) => Math.max(_, Number((y == null ? void 0 : y.z_index) || 0)), -1), m = Math.max(u, p);
     return i.push({
       id: "mask_display",
       source: s,
@@ -15493,7 +15500,7 @@ async function GN(e, t, n = {}) {
   }
   function Lo() {
     var u, p;
-    const i = gl(!0), s = Hg(), l = [];
+    const i = gl(!0), s = Kg(), l = [];
     for (const m of i) {
       if ((m == null ? void 0 : m.type) === "strokeGroup") {
         const _ = String(m.actionGroupId || m.id || "");
@@ -15513,9 +15520,9 @@ async function GN(e, t, n = {}) {
       if ((m == null ? void 0 : m.type) === "rasterObject") {
         const _ = m.item || null, y = Jt((_ == null ? void 0 : _.id) || m.id || "");
         if (!y) continue;
-        const w = sf(_, () => be());
+        const w = lf(_, () => be());
         if (!w) continue;
-        const k = Gg(w, m, s), C = (_ == null ? void 0 : _.transform) || {};
+        const k = qg(w, m, s), C = (_ == null ? void 0 : _.transform) || {};
         l.push({
           id: `raster:${y}`,
           source: k,
@@ -15536,7 +15543,7 @@ async function GN(e, t, n = {}) {
     }
     return Ea(l);
   }
-  function t0(i, s = "modal_bg_gl") {
+  function a0(i, s = "modal_bg_gl") {
     const l = Fo(), u = Ro(l), p = ui(i), m = p ? $i(i) : "none", _ = d.showObjects ? Lo() : Ea([]), y = null, w = [
       s,
       m,
@@ -15575,11 +15582,11 @@ async function GN(e, t, n = {}) {
     }
     oe.backgroundWasVisible = !1, oe.backgroundDirty = !1;
   }
-  function n0(i, s, l, u = "modal_bg_gl") {
+  function o0(i, s, l, u = "modal_bg_gl") {
     var k;
-    if (!pf(i, s)) return !1;
+    if (!mf(i, s)) return !1;
     if (!oe.backgroundDirty && oe.backgroundWasVisible) return !0;
-    const { descriptor: p, hasContent: m } = t0(l, u);
+    const { descriptor: p, hasContent: m } = a0(l, u);
     if (!m || !xe.syncState(p))
       return Il(), !1;
     const y = xe.renderToTarget("modal_pano", s, {
@@ -15591,9 +15598,9 @@ async function GN(e, t, n = {}) {
     }), w = (k = q == null ? void 0 : q.getContext) == null ? void 0 : k.call(q, "2d");
     return !y || !w ? (Il(), !1) : (w.clearRect(0, 0, q.width, q.height), w.drawImage(y, 0, 0, q.width, q.height), oe.backgroundWasVisible = !0, oe.backgroundDirty = !1, !0);
   }
-  function r0(i = !1) {
+  function s0(i = !1) {
     const s = T.width, l = T.height, u = Jr();
-    if (A.globalAlpha = 1, A.lineWidth = 1, i || (A.fillStyle = "#070707", A.fillRect(0, 0, s, l), A.fillStyle = "#070707", A.fillRect(u.x, u.y, u.w, u.h)), Vo(), lf(
+    if (A.globalAlpha = 1, A.lineWidth = 1, i || (A.fillStyle = "#070707", A.fillRect(0, 0, s, l), A.fillStyle = "#070707", A.fillRect(u.x, u.y, u.w, u.h)), Vo(), uf(
       A,
       { x: u.x, y: u.y, w: u.w, h: u.h },
       { mode: "unwrap" },
@@ -15614,7 +15621,7 @@ async function GN(e, t, n = {}) {
       A.fillText("Left", u.x + u.w * 0.25, p), A.fillText("Front", u.x + u.w * 0.5, p), A.fillText("Right", u.x + u.w * 0.75, p), A.fillText("Back", u.x + 38, p), A.fillText("Back", u.x + u.w - 38, p);
     }
   }
-  function gf(i, s, l = 1) {
+  function bf(i, s, l = 1) {
     let u = !1;
     A.strokeStyle = s, A.lineWidth = l, A.beginPath();
     for (const p of i) {
@@ -15627,9 +15634,9 @@ async function GN(e, t, n = {}) {
     }
     A.stroke();
   }
-  function i0(i = !1) {
+  function l0(i = !1) {
     const s = T.width, l = T.height;
-    if (i || (hf() ? A.clearRect(0, 0, s, l) : (A.fillStyle = "#070707", A.fillRect(0, 0, s, l))), Vo(), lf(
+    if (i || (pf() ? A.clearRect(0, 0, s, l) : (A.fillStyle = "#070707", A.fillRect(0, 0, s, l))), Vo(), uf(
       A,
       { x: 0, y: 0, w: s, h: l },
       {
@@ -15645,12 +15652,12 @@ async function GN(e, t, n = {}) {
       for (let p = -180; p <= 180; p += 15) {
         const m = [];
         for (let _ = -89; _ <= 89; _ += 4) m.push(lr(p, _));
-        gf(m, "#3f3f46", p % 90 === 0 ? 1.3 : 1);
+        bf(m, "#3f3f46", p % 90 === 0 ? 1.3 : 1);
       }
       for (let p = -75; p <= 75; p += 15) {
         const m = [];
         for (let _ = -180; _ <= 180; _ += 4) m.push(lr(_, p));
-        gf(m, p === 0 ? "rgba(250, 250, 250, 0.86)" : "#3f3f46", p === 0 ? 1.5 : 1);
+        bf(m, p === 0 ? "rgba(250, 250, 250, 0.86)" : "#3f3f46", p === 0 ? 1.5 : 1);
       }
       const u = [
         { name: "Left", dir: lr(-90, 0) },
@@ -15664,28 +15671,28 @@ async function GN(e, t, n = {}) {
       });
     }
   }
-  function a0(i, s = null, l = null, u = null) {
+  function u0(i, s = null, l = null, u = null) {
     if (d.mode === "frame") {
       const p = s || He();
       if (!p) return [];
       const m = l || Yt(p);
-      return j0(i, p, m);
+      return B0(i, p, m);
     }
-    return kf(i, u);
+    return Nf(i, u);
   }
   function zo(i, s = null, l = null, u = null, p = null) {
     if (!i) return null;
     if (d.mode === "unwrap") {
-      const _ = kf([i], p);
+      const _ = Nf([i], p);
       return _[0] ? { x: _[0].x, y: _[0].y, z: 1 } : null;
     }
     const m = Ki(i);
     return m ? Tr(m, s, l, u) : null;
   }
-  function o0(i, s) {
+  function c0(i, s) {
     const l = String(i.actionGroupId || i.id || "").trim(), u = qn(l, i.layerKind), p = Xr(l, i.layerKind, u), m = (p == null ? void 0 : p.centerUv) || yl(l, i.layerKind, u), _ = d.mode === "unwrap" ? Number((m == null ? void 0 : m.u) || 0) : null, y = [], w = d.mode === "frame" ? He() : null, k = w ? Yt(w) : null;
     for (const le of u) {
-      const _e = (le == null ? void 0 : le.geometry) || null, ze = (_e == null ? void 0 : _e.geometryKind) === "lasso_fill" ? _e == null ? void 0 : _e.points : (_e == null ? void 0 : _e.processedPoints) || (_e == null ? void 0 : _e.rawPoints) || (_e == null ? void 0 : _e.points) || [], Be = a0(ze, w, k, _).filter((ae) => Number.isFinite(ae == null ? void 0 : ae.x) && Number.isFinite(ae == null ? void 0 : ae.y));
+      const _e = (le == null ? void 0 : le.geometry) || null, ze = (_e == null ? void 0 : _e.geometryKind) === "lasso_fill" ? _e == null ? void 0 : _e.points : (_e == null ? void 0 : _e.processedPoints) || (_e == null ? void 0 : _e.rawPoints) || (_e == null ? void 0 : _e.points) || [], Be = u0(ze, w, k, _).filter((ae) => Number.isFinite(ae == null ? void 0 : ae.x) && Number.isFinite(ae == null ? void 0 : ae.y));
       if (!Be.length) continue;
       const it = Qr(String((le == null ? void 0 : le.toolKind) || "pen")), ve = En[it] || En[Dr];
       y.push({
@@ -15700,7 +15707,7 @@ async function GN(e, t, n = {}) {
       const le = { visible: !1, kind: "strokeGroup" };
       return d._strokeGeomCache.set(s, le), le;
     }
-    const F = cg(p).map((le) => zo(le, C.x, w, k, _)).filter((le) => Number.isFinite(le == null ? void 0 : le.x) && Number.isFinite(le == null ? void 0 : le.y)).map((le) => ({ x: Number(le.x || 0), y: Number(le.y || 0) }));
+    const F = pg(p).map((le) => zo(le, C.x, w, k, _)).filter((le) => Number.isFinite(le == null ? void 0 : le.x) && Number.isFinite(le == null ? void 0 : le.y)).map((le) => ({ x: Number(le.x || 0), y: Number(le.y || 0) }));
     if (F.length < 4) {
       const le = { visible: !1, kind: "strokeGroup" };
       return d._strokeGeomCache.set(s, le), le;
@@ -15727,8 +15734,8 @@ async function GN(e, t, n = {}) {
     };
     return d._strokeGeomCache.set(s, pe), pe;
   }
-  function s0(i, s) {
-    const l = d.mode === "frame" ? He() : null, u = l ? Yt(l) : null, p = df(i), m = d.mode === "unwrap" ? Number((p == null ? void 0 : p.u) || 0) : null, _ = zo(p, null, l, u, m), w = Xg(i).map((F) => zo(F, (_ == null ? void 0 : _.x) ?? null, l, u, m)).filter((F) => Number.isFinite(F == null ? void 0 : F.x) && Number.isFinite(F == null ? void 0 : F.y));
+  function f0(i, s) {
+    const l = d.mode === "frame" ? He() : null, u = l ? Yt(l) : null, p = hf(i), m = d.mode === "unwrap" ? Number((p == null ? void 0 : p.u) || 0) : null, _ = zo(p, null, l, u, m), w = e0(i).map((F) => zo(F, (_ == null ? void 0 : _.x) ?? null, l, u, m)).filter((F) => Number.isFinite(F == null ? void 0 : F.x) && Number.isFinite(F == null ? void 0 : F.y));
     if (!Array.isArray(w) || w.length < 4) {
       const F = { visible: !1, kind: "rasterObject" };
       return d._strokeGeomCache.set(s, F), F;
@@ -15767,15 +15774,15 @@ async function GN(e, t, n = {}) {
       clipped: C <= N
     };
   }
-  function l0(i, s = []) {
+  function d0(i, s = []) {
     if (d.mode !== "pano" || vt(i)) return 1;
     const l = s.map((u) => Number((u == null ? void 0 : u.rawZ) ?? (u == null ? void 0 : u.z))).filter((u) => Number.isFinite(u));
-    return l.length ? CN(0.035, 0.2, Math.min(...l)) : 1;
+    return l.length ? DN(0.035, 0.2, Math.min(...l)) : 1;
   }
-  function u0(i) {
+  function h0(i) {
     const s = lr(Number(i.yaw_deg || 0), Number(i.pitch_deg || 0)), l = d.mode === "frame" ? He() : null, u = l ? Yt(l) : null, p = d.mode === "pano" && (vt(i) || Ln(i)), m = p ? { clipBehind: !0 } : null, _ = Tr(s, null, l, u, m);
     if (!_) return { visible: !1 };
-    const y = Oo(i), k = cf(i).map((ae) => Tr(ae, _.x, l, u, m)).filter((ae) => Number.isFinite(ae == null ? void 0 : ae.x) && Number.isFinite(ae == null ? void 0 : ae.y));
+    const y = Oo(i), k = ff(i).map((ae) => Tr(ae, _.x, l, u, m)).filter((ae) => Number.isFinite(ae == null ? void 0 : ae.x) && Number.isFinite(ae == null ? void 0 : ae.y));
     if (k.length < 4) return { visible: !1 };
     const C = Zr(y, 0, y.tanY), N = Zr(y, 0, y.tanY + Math.max(y.tanY * 0.43, 0.053)), F = Tr(C, _.x, l, u, m);
     if (!F) return { visible: !1 };
@@ -15795,7 +15802,7 @@ async function GN(e, t, n = {}) {
       ze
     ];
     if (p && !Be.some((ae) => Number((ae == null ? void 0 : ae.rawZ) ?? (ae == null ? void 0 : ae.z)) > 1e-4)) return { visible: !1 };
-    const it = l0(i, Be), ve = [
+    const it = d0(i, Be), ve = [
       {
         edge: "top",
         x: pe.x,
@@ -15838,17 +15845,17 @@ async function GN(e, t, n = {}) {
   }
   function Qt(i) {
     if (Wt(i)) {
-      const p = String(i.actionGroupId || i.id || "").trim(), m = gg(p, i.layerKind), _ = d._strokeGeomCache.get(m);
-      return _ || (d._strokeGeomCache.size > 256 && d._strokeGeomCache.clear(), o0(i, m));
+      const p = String(i.actionGroupId || i.id || "").trim(), m = _g(p, i.layerKind), _ = d._strokeGeomCache.get(m);
+      return _ || (d._strokeGeomCache.size > 256 && d._strokeGeomCache.clear(), c0(i, m));
     }
     if (fn(i)) {
-      const p = Jg(i), m = d._strokeGeomCache.get(p);
-      return m || (d._strokeGeomCache.size > 256 && d._strokeGeomCache.clear(), s0(i, p));
+      const p = t0(i), m = d._strokeGeomCache.get(p);
+      return m || (d._strokeGeomCache.size > 256 && d._strokeGeomCache.clear(), f0(i, p));
     }
-    const s = Zg(i), l = d._strokeGeomCache.get(s);
+    const s = n0(i), l = d._strokeGeomCache.get(s);
     if (l) return l;
     d._strokeGeomCache.size > 256 && d._strokeGeomCache.clear();
-    const u = u0(i);
+    const u = h0(i);
     return d._strokeGeomCache.set(s, u), u;
   }
   function $o(i, s, l, u = null) {
@@ -15857,21 +15864,21 @@ async function GN(e, t, n = {}) {
       const _ = m / l;
       let y = 0, w = 0;
       s === 0 ? (y = _, w = 0) : s === 1 ? (y = 1, w = _) : s === 2 ? (y = 1 - _, w = 1) : (y = 0, w = 1 - _);
-      const k = ff(i, y, w), C = d.mode === "unwrap" ? Tl(k, u) : Ia(k);
+      const k = df(i, y, w), C = d.mode === "unwrap" ? Tl(k, u) : Ia(k);
       C && p.push(C);
     }
     return p;
   }
-  function c0(i, s) {
+  function p0(i, s) {
     const l = lr(Number(i.yaw_deg || 0), Number(i.pitch_deg || 0)), u = d.mode === "unwrap" ? Tl(l) : null, p = u ? u.x : null, m = d.mode === "pano" ? 28 : 20, _ = [
       $o(i, 0, m, p),
       $o(i, 1, m, p),
       $o(i, 2, m, p),
       $o(i, 3, m, p)
     ];
-    Im(A, _, { selected: s });
+    Fm(A, _, { selected: s });
   }
-  function f0() {
+  function m0() {
     const i = [...Array.isArray(b.shots) ? b.shots : []], s = [...Array.isArray(b.stickers) ? b.stickers : []].sort((l, u) => Number(l.z_index || 0) - Number(u.z_index || 0));
     return [...i, ...s];
   }
@@ -15886,7 +15893,7 @@ async function GN(e, t, n = {}) {
       i.closePath();
     }
   }
-  function bf(i, s, l) {
+  function yf(i, s, l) {
     const u = Array.isArray(i == null ? void 0 : i.corners) ? i.corners : [];
     if (u.length < 4) return;
     const p = W(Number((i == null ? void 0 : i.visibilityAlpha) ?? 1), 0, 1);
@@ -15909,24 +15916,24 @@ async function GN(e, t, n = {}) {
       A.beginPath(), A.moveTo(F.x, F.y), A.lineTo(F.x + K / ue * N, F.y + Y / ue * N), A.stroke();
     }), A.restore(), A.globalAlpha = m;
   }
-  function d0(i, s, l, u) {
+  function g0(i, s, l, u) {
     const p = W(Number((s == null ? void 0 : s.visibilityAlpha) ?? 1), 0, 1);
     if (p <= 0.01) return;
     if (Ln(i)) {
-      bf(s, l, u);
+      yf(s, l, u);
       return;
     }
     if (vt(i)) {
       const _ = A.globalAlpha;
-      A.globalAlpha = _ * Sg(i) * p, d.mode === "frame" ? (A.strokeStyle = l ? "rgba(250, 250, 250, 0.9)" : u ? "rgba(255, 89, 89, 0.72)" : "#71717a", A.lineWidth = l ? 2 : 1, jo(A, s.corners), A.stroke()) : c0(i, l), A.globalAlpha = _;
+      A.globalAlpha = _ * Mg(i) * p, d.mode === "frame" ? (A.strokeStyle = l ? "rgba(250, 250, 250, 0.9)" : u ? "rgba(255, 89, 89, 0.72)" : "#71717a", A.lineWidth = l ? 2 : 1, jo(A, s.corners), A.stroke()) : p0(i, l), A.globalAlpha = _;
       return;
     }
     const m = A.globalAlpha;
     A.globalAlpha = m * p, A.fillStyle = l ? "rgba(0, 112, 243, 0.24)" : u ? "rgba(255, 89, 89, 0.12)" : "rgba(255, 255, 255, 0.12)", jo(A, s.corners), A.fill(), A.strokeStyle = l ? "rgba(255, 255, 255, 1)" : u ? "rgba(255, 116, 116, 0.88)" : "rgba(255, 255, 255, 0.82)", A.lineWidth = l ? 2.8 : 1.9, jo(A, s.corners), A.stroke(), A.globalAlpha = m;
   }
-  function yf(i, s, l) {
+  function vf(i, s, l) {
     if (vt(i)) {
-      Em(A, s, { accent: l });
+      Rm(A, s, { accent: l });
       return;
     }
     A.fillStyle = l, s.corners.forEach((u) => {
@@ -15937,9 +15944,9 @@ async function GN(e, t, n = {}) {
       A.beginPath(), A.moveTo(u.x - y * k, u.y - w * k), A.lineTo(u.x + y * k, u.y + w * k), A.stroke();
     }), A.lineCap = "butt"), Wt(i) || (A.strokeStyle = "rgba(250, 250, 250, 0.9)", A.lineWidth = 1.8, A.beginPath(), A.moveTo(s.rotateStemBase.x, s.rotateStemBase.y), A.lineTo(s.rotateHandle.x, s.rotateHandle.y), A.stroke(), A.fillStyle = l, A.beginPath(), A.arc(s.rotateHandle.x, s.rotateHandle.y, 10, 0, Math.PI * 2), A.fill());
   }
-  function h0() {
+  function b0() {
     var y;
-    const [i, s] = Qg(), l = d.mode === "frame" ? [] : Xn(), u = l.length > 1, p = t === "cutout" ? f0() : Rn(), m = p.map((w) => `${String((w == null ? void 0 : w.id) || "")}:${Ln(w) ? "frame" : Number((w == null ? void 0 : w.z_index) || 0)}`).join("|");
+    const [i, s] = r0(), l = d.mode === "frame" ? [] : Xn(), u = l.length > 1, p = t === "cutout" ? m0() : Rn(), m = p.map((w) => `${String((w == null ? void 0 : w.id) || "")}:${Ln(w) ? "frame" : Number((w == null ? void 0 : w.z_index) || 0)}`).join("|");
     (!d._sortedItemsCache || d._sortedItemsCache.src !== p || d._sortedItemsCache.orderKey !== m) && (d._sortedItemsCache = {
       src: p,
       orderKey: m,
@@ -15947,7 +15954,7 @@ async function GN(e, t, n = {}) {
     });
     const _ = d._sortedItemsCache.sorted;
     for (const w of _) {
-      const k = d.mode !== "frame" && !u && Kc(w);
+      const k = d.mode !== "frame" && !u && Wc(w);
       if (d.mode === "frame" && !k || !d.showObjects && !Ln(w)) continue;
       const C = vt(w), N = Ln(w), F = wn(w);
       if (!C && !N)
@@ -15958,15 +15965,15 @@ async function GN(e, t, n = {}) {
       const Z = W(Number((B == null ? void 0 : B.visibilityAlpha) ?? 1), 0, 1);
       if (Z <= 0.01) continue;
       const K = N && t === "cutout" && d.mode === "pano" ? W(Number(d.cutoutPanoFrameAlpha || 0), 0, 1) : 1;
-      if (A.save(), A.globalAlpha *= K, d0(w, B, k, F), k && B.visible) {
+      if (A.save(), A.globalAlpha *= K, g0(w, B, k, F), k && B.visible) {
         const Y = F ? "#ff4d4f" : C && Zt(w) ? "#f59e0b" : "#0070f3", ue = A.globalAlpha;
-        A.globalAlpha = ue * Z, yf(w, B, Y), A.globalAlpha = ue;
+        A.globalAlpha = ue * Z, vf(w, B, Y), A.globalAlpha = ue;
       }
       A.restore();
     }
     if (t === "cutout" && d.mode === "pano" && !He() && d.cutoutPanoFrameVisual && d.cutoutPanoFrameAlpha > 1e-4) {
       const w = d.cutoutPanoFrameVisual, k = W(Number(d.cutoutPanoFrameAlpha || 0), 0, 1);
-      A.save(), A.globalAlpha *= k, bf(w.geom, w.selected, w.locked), w.selected && yf(
+      A.save(), A.globalAlpha *= k, yf(w.geom, w.selected, w.locked), w.selected && vf(
         w.item,
         w.geom,
         w.locked ? "#ff4d4f" : "#0070f3"
@@ -15995,36 +16002,36 @@ async function GN(e, t, n = {}) {
         }), A.restore();
       });
     if (((y = d.interaction) == null ? void 0 : y.kind) === "marquee_select") {
-      const w = Vf(d.interaction.start, d.interaction.current);
+      const w = Hf(d.interaction.start, d.interaction.current);
       A.save(), A.strokeStyle = "rgba(255, 255, 255, 0.9)", A.fillStyle = "rgba(255, 255, 255, 0.08)", A.lineWidth = 1, A.setLineDash([5, 4]), A.beginPath(), A.rect(w.x0, w.y0, w.x1 - w.x0, w.y1 - w.y0), A.fill(), A.stroke(), A.restore();
     }
     d.hqFrames && i >= 40 && s >= 30 && (d.hqFrames -= 1, d.hqFrames > 0 && be());
   }
-  function p0(i) {
+  function y0(i) {
     const s = vr(i), l = W(Number((s == null ? void 0 : s.aspect) || 1), 0.05, 20), u = 320;
     return l >= 1 ? { width: u, height: Math.max(1, Math.round(u / l)) } : { width: Math.max(1, Math.round(u * l)), height: u };
   }
-  function vf(i, s = !1) {
+  function _f(i, s = !1) {
     const l = W(Pi(i), 0.05, 20), u = s ? 320 : 220;
     return l >= 1 ? { width: u, height: Math.max(1, Math.round(u / l)) } : { width: Math.max(1, Math.round(u * l)), height: u };
   }
-  function m0(i) {
+  function v0(i) {
     if (!un || !i) return !1;
     const s = un.closest(".pano-camera-preview");
     if (!s) return !1;
     const l = Math.round(Number(s.clientWidth || un.clientWidth || 0)), u = Math.round(Number(s.clientHeight || un.clientHeight || 0));
     return Math.abs(l - Number(i.width || 0)) <= 1 && Math.abs(u - Number(i.height || 0)) <= 1;
   }
-  function g0() {
+  function _0() {
     return `obj:${Number(d.objectVisualRevision || 0)}`;
   }
-  function b0(i, s = {}) {
+  function x0(i, s = {}) {
     if (!i) return "";
-    const l = Bi(), u = l && ui(l) ? $i(l) : "no_bg", p = p0(i);
+    const l = Bi(), u = l && ui(l) ? $i(l) : "no_bg", p = y0(i);
     return [
       String((i == null ? void 0 : i.id) || ""),
       Fl(),
-      g0(),
+      _0(),
       Ao(),
       u,
       d.showPanorama ? "panorama:1" : "panorama:0",
@@ -16034,7 +16041,7 @@ async function GN(e, t, n = {}) {
       String(s.quality || "balanced")
     ].join("|");
   }
-  function y0() {
+  function S0() {
     var F, B, Z, K;
     if (d.outputPreviewRect = null, P.outputPreviewToggle.visible = d.mode !== "frame" && !!He(), t !== "cutout" || !P.cameraPreview) return;
     if (d.mode === "frame") {
@@ -16052,7 +16059,7 @@ async function GN(e, t, n = {}) {
       P.cameraPreview.ready = !1, P.cameraPreview.label = i ? "Preview unavailable" : "Add Frame to preview", P.cameraPreview.expanded = !!d.outputPreviewExpanded, P.cameraPreview.settled = !1, P.cameraPreview.width = 220, P.cameraPreview.height = 132, (Z = Ae == null ? void 0 : Ae.clearScene) == null || Z.call(Ae), (K = De == null ? void 0 : De.requestRender) == null || K.call(De);
       return;
     }
-    const l = vf(i, !!d.outputPreviewExpanded);
+    const l = _f(i, !!d.outputPreviewExpanded);
     P.cameraPreview.width = l.width, P.cameraPreview.height = l.height, P.cameraPreview.expanded = !!d.outputPreviewExpanded;
     const u = Fo(), p = Ro(u), m = ui(s), _ = m ? $i(s) : "none", y = d.showObjects ? Lo() : Ea([]), w = Xa({
       stateRevision: [
@@ -16084,14 +16091,14 @@ async function GN(e, t, n = {}) {
       return;
     }
     Ae.syncScene(w), De.setView(vr(i));
-    const C = m0(l), N = C ? De.present() : !1;
+    const C = v0(l), N = C ? De.present() : !1;
     C || De.requestRender(), P.cameraPreview.ready = !0, P.cameraPreview.label = C && N ? "" : "Loading preview", P.cameraPreview.settled = C && N && oe.pendingStableLayoutFrames <= 0 && oe.hasPresentedFrame;
   }
-  function v0(i, s, l, u = {}) {
+  function w0(i, s, l, u = {}) {
     if (!Ae || !l) return !1;
     const p = Bi(), m = Fo(), _ = Ro(m), y = ui(p), w = d.showObjects ? Lo() : Ea([]);
     return y || _.length > 0 || w.length > 0 ? (Ae.syncScene(Xa({
-      stateRevision: b0(l, u),
+      stateRevision: x0(l, u),
       backgroundSource: y && d.showPanorama ? p : null,
       backgroundRevision: y ? `cutout_frame:${$i(p)}` : "",
       coverageDeg: ln(b.coverage),
@@ -16105,17 +16112,17 @@ async function GN(e, t, n = {}) {
   function Dl(i, s) {
     if (!i || !s) return null;
     const l = Number(s.x || 0), u = Number(s.y || 0);
-    return ff(i, l, u);
+    return df(i, l, u);
   }
   function Ki(i) {
     if (!i) return null;
     const s = (Number(i.u || 0) - 0.5) * (2 * Math.PI), l = (0.5 - Number(i.v || 0)) * Math.PI, u = Math.cos(l);
     return yr(u * Math.sin(s), Math.sin(l), u * Math.cos(s));
   }
-  function _0(i) {
+  function k0(i) {
     return !i || typeof i != "object" ? { x: 0, y: 0 } : { x: Number((i == null ? void 0 : i.u) || 0), y: Number((i == null ? void 0 : i.v) || 0) };
   }
-  function x0(i, s, l, u = {}) {
+  function N0(i, s, l, u = {}) {
     return { ...{
       ...i,
       t: Number((i == null ? void 0 : i.t) || 0),
@@ -16123,7 +16130,7 @@ async function GN(e, t, n = {}) {
       pressureLike: dn(i, "pressureLike", 1)
     }, ...u, u: s, v: l };
   }
-  function S0(i, s = !1) {
+  function M0(i, s = !1) {
     return s ? 12e-4 : 18e-4;
   }
   function Ol(i, s, l = !1) {
@@ -16136,8 +16143,8 @@ async function GN(e, t, n = {}) {
         p.set(Y, { x: _e, y: pe }), K = _e;
       });
     }
-    const m = (K) => !K || typeof K != "object" ? { x: 0, y: 0 } : p.get(K) || _0(K), _ = (K, Y, ue, pe = {}) => {
-      const le = u ? (Number(Y) % 1 + 1) % 1 : Number(Y), _e = x0(K, le, ue, pe);
+    const m = (K) => !K || typeof K != "object" ? { x: 0, y: 0 } : p.get(K) || k0(K), _ = (K, Y, ue, pe = {}) => {
+      const le = u ? (Number(Y) % 1 + 1) % 1 : Number(Y), _e = N0(K, le, ue, pe);
       return p.set(_e, { x: Number(Y), y: Number(ue) }), _e;
     }, y = (K, Y, ue) => {
       const pe = m(K), le = m(Y);
@@ -16151,7 +16158,7 @@ async function GN(e, t, n = {}) {
       const K = m(i[0]);
       return [_(i[0], K.x, K.y)];
     }
-    const w = S0(s, l), k = (K, Y) => {
+    const w = M0(s, l), k = (K, Y) => {
       const ue = [0];
       for (let ae = 1; ae < K.length; ae += 1) {
         const me = m(K[ae - 1]), Oe = m(K[ae]);
@@ -16209,7 +16216,7 @@ async function GN(e, t, n = {}) {
     const u = Number(i == null ? void 0 : i[s]);
     return Number.isFinite(u) ? Math.max(0, u) : l;
   }
-  function w0(i) {
+  function P0(i) {
     const s = Number(i == null ? void 0 : i.radiusValue);
     if (Number.isFinite(s) && s > 0) {
       const l = String((i == null ? void 0 : i.radiusModel) || "").trim() || "erp_uv_norm";
@@ -16244,30 +16251,30 @@ async function GN(e, t, n = {}) {
     const i = Ao(), s = Wi();
     return i ? `${s}:${i}` : s;
   }
-  function k0() {
+  function A0() {
     d.paintStrokeRevision += 1, d.paintCompositeRevision += 1;
   }
-  function N0() {
+  function C0() {
     d.paintCompositeRevision += 1;
   }
-  function M0() {
+  function T0() {
     d._sortedItemsCache = null, d._strokeGeomCache.clear();
   }
-  function _f() {
+  function xf() {
     var i, s;
     d.paintEngineRevisionKey = null, (s = (i = d.paintEngine) == null ? void 0 : i.rebuildCommitted) == null || s.call(i, b), d.paintEngineRevisionKey = Oa();
   }
-  function xf() {
+  function Sf() {
     b.painting_layer !== null && (b.painting_layer = null), Eo = "";
   }
   function an() {
-    d.objectVisualRevision = Number(d.objectVisualRevision || 0) + 1, M0(), oe.backgroundDirty = !0, oe.dirty = !0;
+    d.objectVisualRevision = Number(d.objectVisualRevision || 0) + 1, T0(), oe.backgroundDirty = !0, oe.dirty = !0;
   }
   function Jn({ rebuildPaintEngine: i = !1 } = {}) {
-    xf(), k0(), an(), i && _f();
+    Sf(), A0(), an(), i && xf();
   }
   function Yi() {
-    xf(), N0(), an();
+    Sf(), C0(), an();
   }
   function Vo() {
     var u;
@@ -16287,11 +16294,11 @@ async function GN(e, t, n = {}) {
   function zn() {
     return Ho();
   }
-  function P0(i, s, l, u, p = null) {
-    const m = w0(i), _ = dn(s, "widthScale", 1) * dn(s, "pressureLike", 1);
+  function I0(i, s, l, u, p = null) {
+    const m = P0(i), _ = dn(s, "widthScale", 1) * dn(s, "pressureLike", 1);
     return m.model === "erp_uv_norm" ? Math.max(0.5, m.value * l * _) : m.model === "world_angle" ? p ? Math.max(0.5, m.value / Math.max(1e-6, Number(p.hFOV_deg || 90) * pn) * l * _) : Math.max(0.5, m.value / (2 * Math.PI) * l * _) : Math.max(0.5, Number((i == null ? void 0 : i.size) || 10) * 0.5 * _);
   }
-  function A0(i, s, l = {}) {
+  function E0(i, s, l = {}) {
     const u = String((s == null ? void 0 : s.layerKind) || "paint"), p = String((s == null ? void 0 : s.toolKind) || "pen"), m = l.preview === !0, _ = m ? 0.78 : 1;
     if (i.globalAlpha = p === "marker" ? 0.7 * _ : 1, u === "mask") {
       i.fillStyle = m ? "rgba(34, 197, 94, 0.75)" : "rgba(255,255,255,1)";
@@ -16304,15 +16311,15 @@ async function GN(e, t, n = {}) {
     const y = String((s == null ? void 0 : s.layerKind) || "") === "mask" ? { r: 0, g: 0, b: 0, a: 1 } : (s == null ? void 0 : s.color) || { r: 1, g: 0.25, b: 0.25, a: 1 }, w = m ? Math.max(0.28, Number(y.a ?? 1) * 0.88) : Math.max(0.12, Number(y.a ?? 1));
     i.fillStyle = `rgba(${Math.round(Number(y.r || 0) * 255)}, ${Math.round(Number(y.g || 0) * 255)}, ${Math.round(Number(y.b || 0) * 255)}, ${w})`;
   }
-  function C0(i, s, l) {
+  function D0(i, s, l) {
     const u = Math.max(0.5, Math.min(l, Number((s == null ? void 0 : s.radiusPx) || 0.5)));
     !Number.isFinite(s == null ? void 0 : s.x) || !Number.isFinite(s == null ? void 0 : s.y) || !Number.isFinite(u) || (i.beginPath(), i.arc(Number(s.x || 0), Number(s.y || 0), u, 0, Math.PI * 2), i.fill());
   }
-  function T0(i, s, l, u, p = {}) {
+  function O0(i, s, l, u, p = {}) {
     if (!i || !Array.isArray(s) || !s.length) return;
     const m = Math.max(u.w, u.h) * 0.25;
-    i.save(), A0(i, l, p);
-    const _ = (y) => C0(i, y, m);
+    i.save(), E0(i, l, p);
+    const _ = (y) => D0(i, y, m);
     if (s.length === 1) {
       _(s[0]), i.restore();
       return;
@@ -16340,10 +16347,10 @@ async function GN(e, t, n = {}) {
     }
     _(s[s.length - 1]), i.restore();
   }
-  function I0(i, s, l, u) {
-    T0(i, s, l, u, { preview: !1 });
+  function F0(i, s, l, u) {
+    O0(i, s, l, u, { preview: !1 });
   }
-  function E0(i, s, l, u, p) {
+  function R0(i, s, l, u, p) {
     var y, w, k, C;
     if (!i || !Array.isArray(s) || s.length < 3) return;
     const m = "u", _ = "v";
@@ -16360,19 +16367,19 @@ async function GN(e, t, n = {}) {
       i.lineTo(Number(((k = s[N]) == null ? void 0 : k[m]) || 0) * u.w, Number(((C = s[N]) == null ? void 0 : C[_]) || 0) * u.h);
     i.closePath(), i.fill(), i.restore();
   }
-  function Sf(i) {
+  function wf(i) {
     const s = (i == null ? void 0 : i.geometry) || null;
     return s ? String(s.geometryKind || "") === "lasso_fill" ? Array.isArray(s.points) ? s.points : [] : Array.isArray(s.processedPoints) && s.processedPoints.length ? s.processedPoints : Array.isArray(s.rawPoints) && s.rawPoints.length ? s.rawPoints : Array.isArray(s.points) ? s.points : [] : [];
   }
-  function D0(i, s) {
-    const l = Sf(i);
+  function L0(i, s) {
+    const l = wf(i);
     return !Array.isArray(l) || !l.length ? [] : l.map((u) => ({
       x: Number((u == null ? void 0 : u.u) || 0) * Number((s == null ? void 0 : s.w) || 1),
       y: Number((u == null ? void 0 : u.v) || 0) * Number((s == null ? void 0 : s.h) || 1),
-      radiusPx: P0(i, u, Number((s == null ? void 0 : s.w) || 1), Number((s == null ? void 0 : s.h) || 1))
+      radiusPx: I0(i, u, Number((s == null ? void 0 : s.w) || 1), Number((s == null ? void 0 : s.h) || 1))
     }));
   }
-  function wf(i, s, l = null) {
+  function kf(i, s, l = null) {
     var y, w, k, C;
     if (!(i != null && i.ctx) || !s) return !1;
     const u = l || { w: Number(((y = i.canvas) == null ? void 0 : y.width) || 0), h: Number(((w = i.canvas) == null ? void 0 : w.height) || 0) }, p = String((s == null ? void 0 : s.toolKind) || "") === "eraser" ? {
@@ -16381,11 +16388,11 @@ async function GN(e, t, n = {}) {
       toolKind: String(((k = s == null ? void 0 : s.geometry) == null ? void 0 : k.geometryKind) || "") === "lasso_fill" ? "lasso_fill" : "pen"
     } : s;
     if (String(((C = s == null ? void 0 : s.geometry) == null ? void 0 : C.geometryKind) || "") === "lasso_fill")
-      return E0(i.ctx, Sf(p), p, u), !0;
-    const _ = D0(p, u);
-    return _.length ? (I0(i.ctx, _, p, u), !0) : !1;
+      return R0(i.ctx, wf(p), p, u), !0;
+    const _ = L0(p, u);
+    return _.length ? (F0(i.ctx, _, p, u), !0) : !1;
   }
-  function O0(i, s, l, u = 8) {
+  function z0(i, s, l, u = 8) {
     const p = new Uint8Array(s * l), m = [], _ = new Int32Array(s * l), y = new Int32Array(s * l);
     for (let w = 0; w < l; w += 1)
       for (let k = 0; k < s; k += 1) {
@@ -16414,7 +16421,7 @@ async function GN(e, t, n = {}) {
       }
     return m;
   }
-  function F0(i, s) {
+  function $0(i, s) {
     const l = [...new Set((Array.isArray(i == null ? void 0 : i.pixels) ? i.pixels : []).map((w) => Number((w == null ? void 0 : w.x) || 0)).filter((w) => Number.isFinite(w)))].sort((w, k) => w - k);
     if (!l.length) return null;
     if (l.length === 1)
@@ -16435,14 +16442,14 @@ async function GN(e, t, n = {}) {
       widthPx: Math.max(1, y - _ + 1)
     };
   }
-  function R0(i, s, l = {}) {
+  function j0(i, s, l = {}) {
     var k;
     const u = Number((i == null ? void 0 : i.width) || 0), p = Number((i == null ? void 0 : i.height) || 0), m = (k = i == null ? void 0 : i.getContext) == null ? void 0 : k.call(i, "2d");
     if (!m || u < 1 || p < 1) return [];
     const _ = m.getImageData(0, 0, u, p), y = new Uint8Array(u * p);
     for (let C = 0; C < y.length; C += 1) y[C] = _.data[C * 4 + 3];
-    return O0(y, u, p, 8).map((C, N) => {
-      const F = F0(C, u);
+    return z0(y, u, p, 8).map((C, N) => {
+      const F = $0(C, u);
       if (!F) return null;
       const B = Number(F.widthPx || 0), Z = C.maxY - C.minY + 1, K = Number(F.startX || 0), Y = document.createElement("canvas");
       Y.width = B, Y.height = Z;
@@ -16484,7 +16491,7 @@ async function GN(e, t, n = {}) {
       y: (1 - y / Math.max(1e-6, l.tanY)) * 0.5
     };
   }
-  function L0(i) {
+  function V0(i) {
     if (!Array.isArray(i) || i.length < 3) return [];
     if (d.mode === "unwrap") {
       const l = Jr();
@@ -16496,7 +16503,7 @@ async function GN(e, t, n = {}) {
     const s = i.map((l) => Ia(Ki(l))).filter(Boolean);
     return s.every((l) => Number(l.z || 0) > 0) ? s.map((l) => ({ x: Number(l.x || 0), y: Number(l.y || 0) })) : [];
   }
-  function kf(i, s = null) {
+  function Nf(i, s = null) {
     if (!Array.isArray(i) || i.length < 1) return [];
     if (d.mode === "unwrap") {
       const u = Jr();
@@ -16511,7 +16518,7 @@ async function GN(e, t, n = {}) {
     const l = i.map((u) => Ia(Ki(u))).filter(Boolean);
     return l.every((u) => Number(u.z || 0) > 0) ? l.map((u) => ({ x: Number(u.x || 0), y: Number(u.y || 0) })) : [];
   }
-  function z0(i, s = 160) {
+  function H0(i, s = 160) {
     if (!Array.isArray(i) || i.length < 3) return !1;
     for (let l = 0; l < i.length; l += 1) {
       const u = i[l], p = i[(l + 1) % i.length];
@@ -16519,7 +16526,7 @@ async function GN(e, t, n = {}) {
     }
     return !0;
   }
-  function $0(i, s, l) {
+  function U0(i, s, l) {
     if (!Array.isArray(i) || i.length < 3 || !s || !l) return [];
     const u = [];
     for (const p of i) {
@@ -16530,9 +16537,9 @@ async function GN(e, t, n = {}) {
         y: Number(l.y || 0) + Number(_.y || 0) * Number(l.h || 0)
       });
     }
-    return z0(u, Math.max(80, Math.max(l.w, l.h) * 0.75)) ? u : [];
+    return H0(u, Math.max(80, Math.max(l.w, l.h) * 0.75)) ? u : [];
   }
-  function j0(i, s, l) {
+  function B0(i, s, l) {
     if (!Array.isArray(i) || i.length < 1 || !s || !l) return [];
     const u = [];
     for (const p of i) {
@@ -16544,7 +16551,7 @@ async function GN(e, t, n = {}) {
     }
     return u;
   }
-  function V0() {
+  function G0() {
     var B;
     const i = He(), s = $l(i);
     if (!i || !s) return !1;
@@ -16555,12 +16562,12 @@ async function GN(e, t, n = {}) {
       ...i,
       hFOV_deg: 2 * Math.atan(_ / u) * zr,
       vFOV_deg: 2 * Math.atan(y / u) * zr
-    }, C = H0(l);
+    }, C = K0(l);
     A.save(), A.fillStyle = "#0a0a0a", A.fillRect(0, 0, T.width, T.height);
     const N = d.interaction ? "draft" : String(((B = b.ui_settings) == null ? void 0 : B.preview_quality) || "balanced");
-    return v0(A, w, k, { quality: N }) === !0 || (A.fillStyle = "rgba(255, 255, 255, 0.03)", A.fillRect(w.x, w.y, w.w, w.h)), A.restore(), A.save(), A.fillStyle = "rgba(0, 0, 0, 0.58)", A.beginPath(), A.rect(0, 0, T.width, T.height), A.roundRect(l.x, l.y, l.w, l.h, C), A.fill("evenodd"), A.restore(), A.save(), A.strokeStyle = gN, A.globalAlpha = 0.62, A.lineWidth = 2, A.beginPath(), A.roundRect(l.x + 1, l.y + 1, l.w - 2, l.h - 2, Math.max(0, C - 1)), A.stroke(), A.restore(), !0;
+    return w0(A, w, k, { quality: N }) === !0 || (A.fillStyle = "rgba(255, 255, 255, 0.03)", A.fillRect(w.x, w.y, w.w, w.h)), A.restore(), A.save(), A.fillStyle = "rgba(0, 0, 0, 0.58)", A.beginPath(), A.rect(0, 0, T.width, T.height), A.roundRect(l.x, l.y, l.w, l.h, C), A.fill("evenodd"), A.restore(), A.save(), A.strokeStyle = _N, A.globalAlpha = 0.62, A.lineWidth = 2, A.beginPath(), A.roundRect(l.x + 1, l.y + 1, l.w - 2, l.h - 2, Math.max(0, C - 1)), A.stroke(), A.restore(), !0;
   }
-  function H0(i) {
+  function K0(i) {
     const s = Math.max(1e-6, Number(oe.frameCanvasScale || 1));
     return Math.min(Xt * s, Number((i == null ? void 0 : i.w) || 0) * 0.5, Number((i == null ? void 0 : i.h) || 0) * 0.5);
   }
@@ -16569,23 +16576,23 @@ async function GN(e, t, n = {}) {
     const i = d.mode === "frame" ? He() : null;
     P.frameRollKnob.visible = !!i && !r && i.locked !== !0, P.frameRollKnob.rollDeg = Number((i == null ? void 0 : i.roll_deg) ?? (i == null ? void 0 : i.rot_deg) ?? 0), P.frameRollKnob.displayValue = aa(P.frameRollKnob.rollDeg), P.frameRollKnob.dragging = ((s = d.interaction) == null ? void 0 : s.kind) === "roll_frame", P.frameRollKnob.armed = !!i && d.altModifier === !0;
   }
-  function U0() {
+  function W0() {
     var w, k;
     if (((w = d.interaction) == null ? void 0 : w.kind) !== "paint_lasso_fill") return;
     const i = d.interaction.stroke, s = (k = i == null ? void 0 : i.geometry) == null ? void 0 : k.points;
     let l;
     if (d.mode === "frame") {
       const C = He(), N = Yt(C);
-      l = $0(s, C, N);
+      l = U0(s, C, N);
     } else
-      l = L0(s);
+      l = V0(s);
     if (!Array.isArray(l) || l.length < 3) return;
     const u = String((i == null ? void 0 : i.layerKind) || "") === "mask", p = (i == null ? void 0 : i.color) || { r: 1, g: 0.25, b: 0.25 }, m = Math.round(Number(p.r || 0) * 255), _ = Math.round(Number(p.g || 0) * 255), y = Math.round(Number(p.b || 0) * 255);
     A.save(), A.beginPath(), A.moveTo(Number(l[0].x || 0), Number(l[0].y || 0));
     for (let C = 1; C < l.length; C++) A.lineTo(Number(l[C].x || 0), Number(l[C].y || 0));
     A.closePath(), u ? (A.lineWidth = 2, A.setLineDash([6, 6]), A.lineDashOffset = 0, A.strokeStyle = "rgba(0,0,0,0.96)", A.stroke(), A.lineDashOffset = -6, A.strokeStyle = "rgba(255,255,255,0.96)", A.stroke(), A.setLineDash([]), A.lineDashOffset = 0) : (A.lineWidth = 1.5, A.setLineDash([6, 4]), A.strokeStyle = `rgba(${m},${_},${y},1)`, A.stroke(), A.setLineDash([])), A.restore();
   }
-  function B0() {
+  function Y0() {
     const i = d.frameRollOverlayVisual, s = W(Number(d.frameRollOverlayAlpha || 0), 0, 1);
     if (d.mode !== "frame" || !(i != null && i.shot) || s <= 1e-4) return;
     const l = Yt(i.shot);
@@ -16600,17 +16607,17 @@ async function GN(e, t, n = {}) {
       A.moveTo(-m, k), A.lineTo(m, k);
     A.lineWidth = 1, A.strokeStyle = "rgba(255, 255, 255, 0.22)", A.stroke(), A.setTransform(1, 0, 0, 1, 0, 0), A.beginPath(), A.moveTo(u.x - _, u.y - y), A.lineTo(u.x + _, u.y + y), A.lineWidth = 1.5, A.setLineDash([8, 6]), A.strokeStyle = "rgba(255, 255, 255, 0.92)", A.shadowColor = "rgba(0, 0, 0, 0.8)", A.shadowBlur = 3, A.stroke(), A.setLineDash([]), A.restore();
   }
-  function G0() {
-    return t !== "cutout" || !He() ? 0 : vN;
+  function q0() {
+    return t !== "cutout" || !He() ? 0 : wN;
   }
-  function K0() {
+  function X0() {
     const i = W(Number(d.cutoutPanoDimAlpha || 0), 0, 1);
     if (i <= 1e-4 || t !== "cutout" || d.mode !== "pano") return;
     const s = He(), l = s ? Qt(s) : null, u = Array.isArray(l == null ? void 0 : l.corners) && l.corners.length >= 4 ? l.corners.map((_) => ({ x: Number(_.x || 0), y: Number(_.y || 0) })) : null;
     l != null && l.visible && u && (d.cutoutPanoDimCorners = u), s && (l != null && l.visible) && u && (d.cutoutPanoFrameVisual = {
       item: s,
       geom: l,
-      selected: Kc(s),
+      selected: Wc(s),
       locked: wn(s)
     });
     const p = Number(d.cutoutPanoDimTarget || 0) <= 1e-6, m = l != null && l.visible ? u : p ? d.cutoutPanoDimCorners || [] : [];
@@ -16621,29 +16628,29 @@ async function GN(e, t, n = {}) {
     }
     A.fill("evenodd"), A.restore();
   }
-  function W0() {
-    d.mode === "frame" ? (oe.frameSafeRect = pb(), V0()) : d.mode === "unwrap" ? r0(!1) : i0(!1), K0(), t === "cutout" && y0(), h0(), Ir(), U0(), B0(), P.fovValue = `${Math.round(d.viewFov)}°`, Math.abs(Number(d.outputPreviewAnim || 0) - Number(d.outputPreviewAnimTo || 0)) < 1e-6 && rt(), oe.hasPresentedFrame || (oe.hasPresentedFrame = !0, q.style.opacity = "1"), t === "cutout" && P.cameraPreview && (P.cameraPreview.settled = oe.pendingStableLayoutFrames <= 0 && oe.hasPresentedFrame && d.mode !== "frame");
-    const i = qg();
+  function J0() {
+    d.mode === "frame" ? (oe.frameSafeRect = yb(), G0()) : d.mode === "unwrap" ? s0(!1) : l0(!1), X0(), t === "cutout" && S0(), b0(), Ir(), W0(), Y0(), P.fovValue = `${Math.round(d.viewFov)}°`, Math.abs(Number(d.outputPreviewAnim || 0) - Number(d.outputPreviewAnimTo || 0)) < 1e-6 && rt(), oe.hasPresentedFrame || (oe.hasPresentedFrame = !0, q.style.opacity = "1"), t === "cutout" && P.cameraPreview && (P.cameraPreview.settled = oe.pendingStableLayoutFrames <= 0 && oe.hasPresentedFrame && d.mode !== "frame");
+    const i = Qg();
     P.stageStatus = i.status, P.stageStatusDetail = i.detail, i.status === pr ? (re == null || re.removeAttribute("data-stage-ready"), re == null || re.setAttribute("data-stage-loading-kind", i.detail)) : (re == null || re.setAttribute("data-stage-ready", ""), re == null || re.removeAttribute("data-stage-loading-kind"));
   }
-  function Y0(i = d.interaction) {
+  function Z0(i = d.interaction) {
     if (t !== "stickers" || d.mode !== "pano") return !1;
     const s = String((i == null ? void 0 : i.kind) || "");
     return s === "move" || s === "scale" || s === "scale_x" || s === "scale_y" || s === "rotate" ? !0 : s === "move_multi" ? Array.isArray(i == null ? void 0 : i.stickerSnapshots) && i.stickerSnapshots.length > 0 : !1;
   }
-  function q0() {
-    e.__panoLiveStateOverride = b, e.__panoLiveStateVersion = Number(e.__panoLiveStateVersion || 0) + 1, e.__panoLivePaintSurface = mg();
+  function Q0() {
+    e.__panoLiveStateOverride = b, e.__panoLiveStateVersion = Number(e.__panoLiveStateVersion || 0) + 1, e.__panoLivePaintSurface = vg();
   }
   function be(i = {}) {
     var y, w, k, C, N, F, B, Z, K, Y;
     const s = !!i.localOnly, l = i.externalSync === !0, u = String(i.cause || ""), p = String(((y = d.interaction) == null ? void 0 : y.kind) || "");
-    (!s || p === "view" || p === "pan_frame" || Y0() || !!((w = d.viewTween) != null && w.active) || u === "mode" || u === "frame_view" || u === "cutout_frame") && (oe.backgroundDirty = !0), s && Hc() && (d.livePaintInteractionRevision += 1, oe.backgroundDirty = !0), (!s || u === "selection" || u === "mode" || u === "cutout_frame") && (Nl(), Cr()), q0(), l && ((C = (k = e.__panoDomPreview) == null ? void 0 : k.requestDraw) == null || C.call(k), (N = e.setDirtyCanvas) == null || N.call(e, !0, !1)), l && !s && ((B = (F = e.graph) == null ? void 0 : F.setDirtyCanvas) == null || B.call(F, !0, !0), (Y = (K = (Z = nr) == null ? void 0 : Z.canvas) == null ? void 0 : K.setDirty) == null || Y.call(K, !0, !0)), oe.dirty = !0;
+    (!s || p === "view" || p === "pan_frame" || Z0() || !!((w = d.viewTween) != null && w.active) || u === "mode" || u === "frame_view" || u === "cutout_frame") && (oe.backgroundDirty = !0), s && Uc() && (d.livePaintInteractionRevision += 1, oe.backgroundDirty = !0), (!s || u === "selection" || u === "mode" || u === "cutout_frame") && (Nl(), Cr()), Q0(), l && ((C = (k = e.__panoDomPreview) == null ? void 0 : k.requestDraw) == null || C.call(k), (N = e.setDirtyCanvas) == null || N.call(e, !0, !1)), l && !s && ((B = (F = e.graph) == null ? void 0 : F.setDirtyCanvas) == null || B.call(F, !0, !0), (Y = (K = (Z = nr) == null ? void 0 : Z.canvas) == null ? void 0 : K.setDirty) == null || Y.call(K, !0, !0)), oe.dirty = !0;
   }
-  function Nf() {
+  function Mf() {
     const i = T.getBoundingClientRect(), s = Math.max(2, Math.round(i.width)), l = Math.max(2, Math.round(i.height));
     return T.width !== s || T.height !== l || q.width !== s || q.height !== l ? (T.width = s, T.height = l, q.width = s, q.height = l, oe.backgroundDirty = !0, oe.dirty = !0, t === "cutout" && (oe.pendingStableLayoutFrames = Math.max(Number(oe.pendingStableLayoutFrames || 0), 1)), !0) : !1;
   }
-  function X0(i = performance.now()) {
+  function eb(i = performance.now()) {
     var m, _;
     oe.lastTickTs = i;
     const s = d.mode === "frame" && ((m = d.interaction) == null ? void 0 : m.kind) === "roll_frame" ? d.interaction : null;
@@ -16651,7 +16658,7 @@ async function GN(e, t, n = {}) {
     const l = s ? 1 : 0;
     if (Math.abs(l - Number(d.frameRollOverlayTarget || 0)) > 1e-6 && (d.frameRollOverlayFrom = Number(d.frameRollOverlayAlpha || 0), d.frameRollOverlayTarget = l, d.frameRollOverlayStartTs = i), Math.abs(Number(d.frameRollOverlayAlpha || 0) - l) > 1e-6) {
       const y = W(
-        (i - Number(d.frameRollOverlayStartTs || i)) / _N,
+        (i - Number(d.frameRollOverlayStartTs || i)) / kN,
         0,
         1
       );
@@ -16661,10 +16668,10 @@ async function GN(e, t, n = {}) {
         ls(y)
       ), y >= 1 && (d.frameRollOverlayAlpha = l, l === 0 && (d.frameRollOverlayVisual = null)), oe.dirty = !0;
     }
-    const u = G0();
+    const u = q0();
     if (Math.abs(u - Number(d.cutoutPanoDimTarget || 0)) > 1e-6 && (d.cutoutPanoDimFrom = Number(d.cutoutPanoDimAlpha || 0), d.cutoutPanoDimTarget = u, d.cutoutPanoDimStartTs = i), Math.abs(Number(d.cutoutPanoDimAlpha || 0) - u) > 1e-6) {
       const y = W(
-        (i - Number(d.cutoutPanoDimStartTs || i)) / Vh,
+        (i - Number(d.cutoutPanoDimStartTs || i)) / Gh,
         0,
         1
       );
@@ -16677,7 +16684,7 @@ async function GN(e, t, n = {}) {
     const p = t === "cutout" && He() ? 1 : 0;
     if (Math.abs(p - Number(d.cutoutPanoFrameTarget || 0)) > 1e-6 && (d.cutoutPanoFrameFrom = Number(d.cutoutPanoFrameAlpha || 0), d.cutoutPanoFrameTarget = p, d.cutoutPanoFrameStartTs = i), Math.abs(Number(d.cutoutPanoFrameAlpha || 0) - p) > 1e-6) {
       const y = W(
-        (i - Number(d.cutoutPanoFrameStartTs || i)) / Vh,
+        (i - Number(d.cutoutPanoFrameStartTs || i)) / Gh,
         0,
         1
       );
@@ -16688,35 +16695,35 @@ async function GN(e, t, n = {}) {
       ), y >= 1 && (d.cutoutPanoFrameAlpha = p, p === 0 && (d.cutoutPanoFrameVisual = null)), oe.dirty = !0;
     }
     if (d.outputPreviewAnim !== d.outputPreviewAnimTo) {
-      const y = Math.max(1, Number(d.outputPreviewAnimDurationMs)), w = W((i - Number(d.outputPreviewAnimStartTs || 0)) / y, 0, 1), C = d.outputPreviewAnimTo > d.outputPreviewAnimFrom ? AN(w) : EN(w);
+      const y = Math.max(1, Number(d.outputPreviewAnimDurationMs)), w = W((i - Number(d.outputPreviewAnimStartTs || 0)) / y, 0, 1), C = d.outputPreviewAnimTo > d.outputPreviewAnimFrom ? EN(w) : RN(w);
       d.outputPreviewAnim = Gn(d.outputPreviewAnimFrom, d.outputPreviewAnimTo, C), oe.dirty = !0, w >= 1 && (d.outputPreviewAnim = d.outputPreviewAnimTo);
     }
     if ((_ = d.viewTween) != null && _.active) {
       const y = d.viewTween, w = W((i - y.startTs) / y.durationMs, 0, 1), k = ls(w);
       d.viewYaw = Ut(y.startYaw + y.deltaYaw * k), d.viewPitch = y.startPitch + (y.targetPitch - y.startPitch) * k, d.viewFov = y.startFov + (y.targetFov - y.startFov) * k, oe.backgroundDirty = !0, oe.dirty = !0, w >= 1 && (d.viewTween = null);
     }
-    if (d.viewInertia.vx = Number(on.state.inertia.vx || 0), d.viewInertia.vy = Number(on.state.inertia.vy || 0), d.viewInertia.active = !!on.state.inertia.active, on.stepInertia(i) && (d.viewInertia.vx = Number(on.state.inertia.vx || 0), d.viewInertia.vy = Number(on.state.inertia.vy || 0), d.viewInertia.active = !!on.state.inertia.active, oe.backgroundDirty = !0, oe.dirty = !0), (oe.dirty || i - oe.lastSizeCheckTs >= 220) && (Nf(), oe.lastSizeCheckTs = i), oe.pendingStableLayoutFrames > 0 && (oe.pendingStableLayoutFrames -= 1, oe.dirty = !0), oe.dirty) {
+    if (d.viewInertia.vx = Number(on.state.inertia.vx || 0), d.viewInertia.vy = Number(on.state.inertia.vy || 0), d.viewInertia.active = !!on.state.inertia.active, on.stepInertia(i) && (d.viewInertia.vx = Number(on.state.inertia.vx || 0), d.viewInertia.vy = Number(on.state.inertia.vy || 0), d.viewInertia.active = !!on.state.inertia.active, oe.backgroundDirty = !0, oe.dirty = !0), (oe.dirty || i - oe.lastSizeCheckTs >= 220) && (Mf(), oe.lastSizeCheckTs = i), oe.pendingStableLayoutFrames > 0 && (oe.pendingStableLayoutFrames -= 1, oe.dirty = !0), oe.dirty) {
       if (oe.pendingStableLayoutFrames > 0)
         return;
-      oe.dirty = !1, W0();
+      oe.dirty = !1, J0();
     }
   }
-  function Mf(i = performance.now()) {
+  function Pf(i = performance.now()) {
     if (oe.running)
       try {
-        X0(i);
+        eb(i);
       } catch (s) {
         const l = String((s == null ? void 0 : s.stack) || (s == null ? void 0 : s.message) || s || "unknown editor frame error");
         oe.tickErrorSignature !== l && (oe.tickErrorSignature = l, console.error("[PanoramaStickers] editor frame failed", s)), P.stageStatus = br, P.stageStatusDetail = "frame", re == null || re.setAttribute("data-stage-ready", ""), re == null || re.removeAttribute("data-stage-loading-kind");
       } finally {
-        oe.running && (oe.rafId = requestAnimationFrame(Mf));
+        oe.running && (oe.rafId = requestAnimationFrame(Pf));
       }
   }
-  function J0() {
+  function tb() {
     oe.running = !1, oe.rafId && cancelAnimationFrame(oe.rafId), oe.rafId = 0;
   }
   function st() {
-    r || (d.historyController.commitActionGroup(JSON.stringify(fh(b))), Bl());
+    r || (d.historyController.commitActionGroup(JSON.stringify(hh(b))), Bl());
   }
   function Rl(i) {
     if (r) return;
@@ -16725,7 +16732,7 @@ async function GN(e, t, n = {}) {
     const l = JSON.parse(s);
     Object.keys(b).forEach((u) => delete b[u]), Object.assign(b, l), d.selectedId = t === "stickers" || t === "cutout" ? b.active.selected_sticker_id : b.active.selected_shot_id, d.selectedIds = d.selectedId ? [d.selectedId] : [], Jn(), Tn(), We(), In(), be({ cause: "cutout_frame" });
   }
-  function Pf() {
+  function Af() {
     var l, u;
     const i = Array.isArray((l = d.historyController) == null ? void 0 : l.entries) ? d.historyController.entries : [], s = Number((u = d.historyController) == null ? void 0 : u.index);
     return {
@@ -16735,7 +16742,7 @@ async function GN(e, t, n = {}) {
   }
   function Tn() {
     Po();
-    const i = US({
+    const i = WS({
       editor: d,
       swatches: Ts,
       paintColorPopOpen: V ? !V.hidden : !1,
@@ -16744,9 +16751,9 @@ async function GN(e, t, n = {}) {
       rgb01ToHsv: ku,
       hsv01ToRgb: wu,
       getBrushPresetIdForTool: Qr,
-      isActiveLassoTool: kg
+      isActiveLassoTool: Ag
     });
-    if (Object.assign(P.paintDock, i), Tg(), !i.visible) {
+    if (Object.assign(P.paintDock, i), Og(), !i.visible) {
       V && (V.hidden = !0);
       return;
     }
@@ -16770,9 +16777,9 @@ async function GN(e, t, n = {}) {
     var Be, it, ve, ae;
     if (a) return;
     b.ui_settings = b.ui_settings || {};
-    const i = HS(b.ui_settings);
+    const i = KS(b.ui_settings);
     if (o) {
-      P.sidePanel = BS({
+      P.sidePanel = YS({
         coverage: b.coverage,
         uiSettings: i,
         normalizeCoverageValue: ln
@@ -16819,7 +16826,7 @@ async function GN(e, t, n = {}) {
         if (!Ee) return;
         const lt = Zt(Ee) ? String(Ee.id || as) : String(((At = (sn = b.assets) == null ? void 0 : sn[Ee.asset_id]) == null ? void 0 : At.name) || Ee.asset_id || Ee.id), tt = `${qe + 1}. ${lt}${Zt(Ee) && zi(Ee) ? " (hidden)" : ""}`, xt = xl({ item: Ee, label: tt, kind: "image" });
         me.push({ id: Ee.id, label: xt.label, icon: xt.icon, item: Ee, kind: "image" });
-      }) : Wc().forEach((Ee) => {
+      }) : Yc().forEach((Ee) => {
         if (!(Ee != null && Ee.item)) return;
         const qe = xl(Ee);
         me.push({ id: Ee.item.id, label: qe.label, icon: qe.icon, item: Ee.item, kind: Ee.kind });
@@ -16854,10 +16861,10 @@ async function GN(e, t, n = {}) {
       });
     }, B = [];
     p.length > 1 ? (B.push(`Selected objects: ${p.length}`), B.push("Multi-selection supports z-order and delete.")) : (F("yaw_deg", "Yaw", -180, 180, 0.1), F("pitch_deg", "Pitch", -90, 90, 0.1), F("hFOV_deg", "H FOV", 1, 179, 0.1), F("vFOV_deg", "V FOV", 1, 179, 0.1), t === "stickers" || m === "image" ? F("rot_deg", "Rotation", -180, 180, 0.1) : F("roll_deg", "Roll", -180, 180, 0.1));
-    const Z = Array.isArray((it = (Be = b == null ? void 0 : b.painting) == null ? void 0 : Be.paint) == null ? void 0 : it.strokes) ? b.painting.paint.strokes.length : 0, K = Array.isArray((ae = (ve = b == null ? void 0 : b.painting) == null ? void 0 : ve.mask) == null ? void 0 : ae.strokes) ? b.painting.mask.strokes.length : 0, Y = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs.map((me) => String((me == null ? void 0 : me.name) || "")) : [], ue = PN(
+    const Z = Array.isArray((it = (Be = b == null ? void 0 : b.painting) == null ? void 0 : Be.paint) == null ? void 0 : it.strokes) ? b.painting.paint.strokes.length : 0, K = Array.isArray((ae = (ve = b == null ? void 0 : b.painting) == null ? void 0 : ve.mask) == null ? void 0 : ae.strokes) ? b.painting.mask.strokes.length : 0, Y = Array.isArray(e == null ? void 0 : e.inputs) ? e.inputs.map((me) => String((me == null ? void 0 : me.name) || "")) : [], ue = IN(
       e,
       Y.includes("erp_image") ? ["erp_image", "bg_erp"] : ["bg_erp", "erp_image"]
-    ), pe = !!String((ue == null ? void 0 : ue.src) || "").trim() || qc("pano_input_images").length > 0, le = Array.isArray(Rn()) && Rn().length > 0 || Z > 0, _e = K > 0, ze = [
+    ), pe = !!String((ue == null ? void 0 : ue.src) || "").trim() || Xc("pano_input_images").length > 0, le = Array.isArray(Rn()) && Rn().length > 0 || Z > 0, _e = K > 0, ze = [
       { key: "mask", label: "Mask", icon: Te.circle_dashed_tool, visible: !!d.showMask, enabled: _e },
       { key: "objects", label: "Paint / Images", icon: Te.image, visible: !!d.showObjects, enabled: le },
       { key: "panorama", label: "Panorama", icon: Te.globe, visible: !!d.showPanorama, enabled: pe }
@@ -16866,7 +16873,7 @@ async function GN(e, t, n = {}) {
       ariaLabel: `Toggle ${me.label.toLowerCase()}`,
       tip: me.visible ? "Hide" : "Show"
     }));
-    P.sidePanel = GS({
+    P.sidePanel = qS({
       coverage: b.coverage,
       readOnly: r,
       selectionPicker: C,
@@ -16880,7 +16887,7 @@ async function GN(e, t, n = {}) {
       normalizeCoverageValue: ln
     });
   }
-  async function Af(i) {
+  async function Cf(i) {
     if (r || t !== "stickers" && t !== "cutout" || !Sr(i)) return;
     const s = ms("asset"), l = Uu(e, `add:${s}`, async () => {
       try {
@@ -16895,7 +16902,7 @@ async function GN(e, t, n = {}) {
           hFOV_deg: 30,
           vFOV_deg: Hi(30, Number(u.naturalWidth || u.width || 1), Number(u.naturalHeight || u.height || 1)),
           rot_deg: 0,
-          z_index: Yc()
+          z_index: qc()
         }), Li(b.stickers[b.stickers.length - 1]), zl(), We(), rt(), be();
         const m = await As(i, {
           fetchApi: (w, k) => bn.fetchApi(w, k)
@@ -16913,11 +16920,11 @@ async function GN(e, t, n = {}) {
     } catch {
     }
   }
-  function Z0() {
+  function nb() {
     var i;
     r || t !== "stickers" && t !== "cutout" || (i = H == null ? void 0 : H.openImagePicker) == null || i.call(H, "add");
   }
-  async function Q0(i) {
+  async function rb(i) {
     if (r || t !== "stickers" && t !== "cutout") return;
     const s = It();
     if (!s || !vt(s) || Zt(s) || !Sr(i)) return;
@@ -16949,13 +16956,13 @@ async function GN(e, t, n = {}) {
     } catch {
     }
   }
-  function eb() {
+  function ib() {
     var s;
     if (r) return;
     const i = It();
     !i || !vt(i) || Zt(i) || (s = H == null ? void 0 : H.openImagePicker) == null || s.call(H, "replace");
   }
-  async function tb() {
+  async function ab() {
     if (r || t !== "stickers") return;
     const i = b.assets && typeof b.assets == "object" ? b.assets : {}, s = Object.entries(i).filter(([, u]) => {
       const p = String((u == null ? void 0 : u.type) || "").toLowerCase(), m = String((u == null ? void 0 : u.value) || "");
@@ -16979,7 +16986,7 @@ async function GN(e, t, n = {}) {
       }
     l && (ut(), be());
   }
-  function nb() {
+  function ob() {
     if (r || t !== "cutout") return;
     const i = He();
     if (i) {
@@ -16990,7 +16997,7 @@ async function GN(e, t, n = {}) {
       ), We(), rt(), be({ cause: "cutout_frame" });
       return;
     }
-    const s = cm({
+    const s = pm({
       id: `frame_${Date.now().toString(36)}`,
       yawDeg: Ut(Number(d.viewYaw || 0)),
       pitchDeg: Number(d.viewPitch || 0),
@@ -16998,16 +17005,16 @@ async function GN(e, t, n = {}) {
     });
     b.shots = [s], Li(s), zl(), d.mode = "pano", st(), ut(), We(), rt(), be({ cause: "cutout_frame" });
   }
-  function rb() {
+  function sb() {
     r || t !== "cutout" || (b.shots = [], d.selectedId = null, d.selectedIds = [], d.mode === "frame" && (d.mode = "pano"), d.cutoutAspectOpen = !1, b.active.selected_shot_id = null, st(), ut(), We(), rt(), be());
   }
-  function ib() {
+  function lb() {
     const i = Array.isArray(b.stickers) ? b.stickers : [], s = [];
     for (const l of i)
       Zt(l) && (l.visible = !1, s.push(l));
     return s;
   }
-  function Cf(i, s, l = "Clear") {
+  function Tf(i, s, l = "Clear") {
     return new Promise((u) => {
       P.confirmDialog = {
         visible: !0,
@@ -17018,28 +17025,28 @@ async function GN(e, t, n = {}) {
       };
     });
   }
-  async function ab() {
+  async function ub() {
     var l, u;
-    if (r || !await Cf(
+    if (r || !await Tf(
       "Clear All Paint Data",
       t === "stickers" ? "This will remove all paint, mask, and sticker images in the current node." : "This will remove all paint, mask, and images in the current node. The cutout frame will be preserved.",
       "Clear All"
     )) return;
     b.painting = so(null), Jn();
-    const s = ib();
+    const s = lb();
     if (t === "stickers")
       b.stickers = s, b.assets = {}, d.selectedId = ((l = s[0]) == null ? void 0 : l.id) || null, d.selectedIds = d.selectedId ? [d.selectedId] : [], b.active.selected_sticker_id = ((u = s[0]) == null ? void 0 : u.id) || null, Gi();
     else {
-      const p = cx(b.shots, b.active.selected_shot_id);
+      const p = px(b.shots, b.active.selected_shot_id);
       b.stickers = s, b.assets = {}, b.shots = p.shots, d.selectedId = p.selectedShotId, d.selectedIds = d.selectedId ? [d.selectedId] : [], b.active.selected_sticker_id = null, b.active.selected_shot_id = p.selectedShotId, !p.selectedShotId && d.mode === "frame" && (d.mode = "pano"), d.cutoutAspectOpen = !1, Gi();
     }
     st(), ut(), We(), rt(), be();
   }
-  async function ob(i) {
+  async function cb(i) {
     var m, _, y, w;
     if (r) return;
     const s = i === "mask" ? "mask" : "paint", l = s === "mask" ? "Mask" : "Paint", u = Xi(s);
-    if (!(!u.length && !(((m = d.interaction) == null ? void 0 : m.kind) === "draw" && ((_ = d.interaction) == null ? void 0 : _.layerKind) === s) || !await Cf(
+    if (!(!u.length && !(((m = d.interaction) == null ? void 0 : m.kind) === "draw" && ((_ = d.interaction) == null ? void 0 : _.layerKind) === s) || !await Tf(
       `Clear ${l}`,
       `This will remove all ${s} strokes in the current node.`,
       `Clear ${l}`
@@ -17051,14 +17058,14 @@ async function GN(e, t, n = {}) {
       u.length = 0, b.painting.raster_objects = Cn().filter((k) => String((k == null ? void 0 : k.layerKind) || "paint") !== s), s === "paint" && (Rt().length = 0), Jn(), st(), ut(), We(), rt(), Tn(), be();
     }
   }
-  function sb() {
+  function fb() {
     if (r) return;
     const i = It();
     if (!i || !vt(i) || Zt(i)) return;
     const s = JSON.parse(JSON.stringify(i));
-    s.id = ms("st"), s.yaw_deg = Ut((s.yaw_deg || 0) + 8), s.z_index = Yc(), b.stickers.push(s), b.active.selected_sticker_id = s.id, d.selectedId = s.id, d.selectedIds = [s.id], an(), st(), ut(), rt(), We(), be();
+    s.id = ms("st"), s.yaw_deg = Ut((s.yaw_deg || 0) + 8), s.z_index = qc(), b.stickers.push(s), b.active.selected_sticker_id = s.id, d.selectedId = s.id, d.selectedIds = [s.id], an(), st(), ut(), rt(), We(), be();
   }
-  function Tf() {
+  function If() {
     var l, u, p, m, _, y;
     if (r) return;
     const i = Xn(), s = It();
@@ -17087,16 +17094,16 @@ async function GN(e, t, n = {}) {
         b.stickers = b.stickers.filter((w) => w.id !== s.id), Gi(), an(), d.selectedId = ((_ = b.stickers[0]) == null ? void 0 : _.id) || null, d.selectedIds = d.selectedId ? [d.selectedId] : [], b.active.selected_sticker_id = ((y = b.stickers[0]) == null ? void 0 : y.id) || null, st(), ut(), We(), rt(), be();
         return;
       }
-      rb();
+      sb();
     }
   }
   function Ll(i, s) {
     const l = oe.frameSafeRect;
     if (!i || !l || d.mode !== "frame") return !1;
-    const u = yu * Mi(l, i), p = Cc(Ac(l, s), u);
+    const u = yu * Mi(l, i), p = Tc(Cc(l, s), u);
     return i.hFOV_deg = p.hFOV_deg, i.vFOV_deg = p.vFOV_deg, !0;
   }
-  function If(i, s) {
+  function Ef(i, s) {
     if (!i || i.locked === !0) return;
     const l = {
       "1:1": [1, 1],
@@ -17121,7 +17128,7 @@ async function GN(e, t, n = {}) {
     }
     i.aspect_id = `${p}:${m}`;
   }
-  function lb(i, s, l) {
+  function db(i, s, l) {
     if (!i || i.locked === !0) return !1;
     const u = go(s, l);
     if (!u) return !1;
@@ -17132,7 +17139,7 @@ async function GN(e, t, n = {}) {
     }
     return i.aspect_id = u.label, !0;
   }
-  function Ef(i) {
+  function Df(i) {
     if (!i || i.locked === !0) return;
     const s = String(i.aspect_id || "").trim(), l = Na(i), u = l.tanHalfX / Math.max(1e-12, l.tanHalfY), p = 1 / Math.max(1e-12, u);
     if (!Ll(i, p)) {
@@ -17145,16 +17152,16 @@ async function GN(e, t, n = {}) {
     } else
       i.aspect_id = vi(i);
   }
-  function Df() {
+  function Of() {
     Oi().forEach((s, l) => {
       s.type === "sticker" && s.item && (s.item.z_index = l), s.type === "strokeGroup" && s.item && (s.item.z_index = l), s.type === "rasterObject" && s.item && (s.item.z_index = l);
     });
   }
-  function ub() {
+  function hb() {
     if (r) return;
     const i = Xn();
     if (!It() || i.length === 0 || i.some((y) => wn(y))) return;
-    Df();
+    Of();
     const l = Oi(), u = new Set(i.map((y) => vt(y) ? `sticker:${String(y.id || "")}` : fn(y) ? `rasterObject:${Jt(y.rasterObjectId || y.id || "")}` : `strokeGroup:${String(y.actionGroupId || y.id || "")}`)), p = [], m = [];
     if (l.forEach((y) => {
       var k, C;
@@ -17165,11 +17172,11 @@ async function GN(e, t, n = {}) {
       y.type === "sticker" && y.item && (y.item.z_index = w), y.type === "strokeGroup" && y.item && (y.item.z_index = w), y.type === "rasterObject" && y.item && (y.item.z_index = w);
     }), an(), st(), ut(), rt(), be();
   }
-  function cb() {
+  function pb() {
     if (r) return;
     const i = Xn();
     if (!It() || i.length === 0 || i.some((y) => wn(y))) return;
-    Df();
+    Of();
     const l = Oi(), u = new Set(i.map((y) => vt(y) ? `sticker:${String(y.id || "")}` : fn(y) ? `rasterObject:${Jt(y.rasterObjectId || y.id || "")}` : `strokeGroup:${String(y.actionGroupId || y.id || "")}`)), p = [], m = [];
     if (l.forEach((y) => {
       var k, C;
@@ -17180,7 +17187,7 @@ async function GN(e, t, n = {}) {
       y.type === "sticker" && y.item && (y.item.z_index = w), y.type === "strokeGroup" && y.item && (y.item.z_index = w), y.type === "rasterObject" && y.item && (y.item.z_index = w);
     }), an(), st(), ut(), rt(), be();
   }
-  function fb() {
+  function mb() {
     r || (b.projection_model = "pinhole_rectilinear", b.alpha_mode = "straight", f && (b.output_preset = M(Number(b.output_preset || 2048))), h && (b.coverage = ln(h.value)), g && (b.bg_color = String(g.value || b.bg_color || "#00ff00")), In(), e.setDirtyCanvas(!0, !0));
   }
   function In() {
@@ -17190,21 +17197,21 @@ async function GN(e, t, n = {}) {
     const i = JSON.stringify(b);
     v && (v.value = i, (s = v.callback) == null || s.call(v, i));
   }
-  const Of = () => In();
-  r || (e.__panoFlushStateBeforeQueue = Of);
+  const Ff = () => In();
+  r || (e.__panoFlushStateBeforeQueue = Ff);
   function Uo() {
-    b.ui_settings = LN(b.ui_settings), r || In();
+    b.ui_settings = VN(b.ui_settings), r || In();
   }
   function ut() {
     var i;
     r || (In(), (i = e.setDirtyCanvas) == null || i.call(e, !0, !0));
   }
-  function db() {
-    r || Yg() && uf().catch((i) => {
+  function gb() {
+    r || Zg() && cf().catch((i) => {
       console.error("[PanoramaPaintingLayerSync] background close sync failed", i);
     });
   }
-  function hb(i = {}) {
+  function bb(i = {}) {
     var u, p, m, _, y, w, k, C, N, F;
     const s = i.syncPreview !== !1, l = i.syncGraph !== !1;
     s && ((p = (u = e.__panoPreviewNodeRuntime) == null ? void 0 : u.requestDraw) == null || p.call(u), (_ = (m = e.__panoDomPreview) == null ? void 0 : m.requestDraw) == null || _.call(m), (y = e.setDirtyCanvas) == null || y.call(e, !0, !1)), l && ((k = (w = e.graph) == null ? void 0 : w.setDirtyCanvas) == null || k.call(w, !0, !0), (F = (N = (C = nr) == null ? void 0 : C.canvas) == null ? void 0 : N.setDirty) == null || F.call(N, !0, !0));
@@ -17226,7 +17233,7 @@ async function GN(e, t, n = {}) {
       y: Number(i.clientY) - Number(s.top || 0)
     };
   }
-  function Ff() {
+  function Rf() {
     return d.mode === "pano" || d.mode === "unwrap";
   }
   function He() {
@@ -17236,7 +17243,7 @@ async function GN(e, t, n = {}) {
     const s = String(b.active.selected_shot_id || "");
     return i.find((l) => String((l == null ? void 0 : l.id) || "") === s) || i[0] || null;
   }
-  function pb() {
+  function yb() {
     var B, Z, K, Y, ue;
     if (!T) return null;
     const i = (B = T.getBoundingClientRect) == null ? void 0 : B.call(T), s = Number((i == null ? void 0 : i.width) || 0) > 0 ? T.width / i.width : 1, l = Number((i == null ? void 0 : i.height) || 0) > 0 ? T.height / i.height : 1;
@@ -17246,7 +17253,7 @@ async function GN(e, t, n = {}) {
     let _ = Math.max(p + 1, T.height - 24);
     const y = (Z = nt == null ? void 0 : nt.getBoundingClientRect) == null ? void 0 : Z.call(nt), w = (K = Ye == null ? void 0 : Ye.getBoundingClientRect) == null ? void 0 : K.call(Ye);
     let k = 24;
-    y && i && y.width > 0 && y.height > 0 && (k = Math.max(k, (y.right - i.left) * s + jh)), w && i && w.width > 0 && w.height > 0 && ((Y = P.frameRail) == null ? void 0 : Y.visible) === !0 && (k = Math.max(k, (i.right - w.left) * s + jh)), u = Math.max(u, k);
+    y && i && y.width > 0 && y.height > 0 && (k = Math.max(k, (y.right - i.left) * s + Bh)), w && i && w.width > 0 && w.height > 0 && ((Y = P.frameRail) == null ? void 0 : Y.visible) === !0 && (k = Math.max(k, (i.right - w.left) * s + Bh)), u = Math.max(u, k);
     const C = Math.min(m, T.width - k);
     let N = 24;
     const F = (ue = mt == null ? void 0 : mt.getBoundingClientRect) == null ? void 0 : ue.call(mt);
@@ -17259,7 +17266,7 @@ async function GN(e, t, n = {}) {
       !_e || _e.width <= 0 || _e.height <= 0 || (N = Math.max(N, (i.bottom - _e.top) * l + vu));
     }), je && i) {
       const pe = getComputedStyle(je);
-      pe.display !== "none" && pe.visibility !== "hidden" && Number(pe.opacity) > 0 && (N = Math.max(N, (yN + vu) * l));
+      pe.display !== "none" && pe.visibility !== "hidden" && Number(pe.opacity) > 0 && (N = Math.max(N, (SN + vu) * l));
     }
     return p = Math.max(p, N), _ = Math.max(p + 1, Math.min(_, T.height - N)), {
       x: u,
@@ -17276,7 +17283,7 @@ async function GN(e, t, n = {}) {
       w: Math.max(1, T.width - 48),
       h: Math.max(1, T.height - 48)
     };
-    return Y1(s, i, yu * Mi(s, i));
+    return Z1(s, i, yu * Mi(s, i));
   }
   function Yt(i = He()) {
     const s = $l(i);
@@ -17321,10 +17328,10 @@ async function GN(e, t, n = {}) {
       t: Number(l || 0)
     };
   }
-  function mb(i, s) {
+  function vb(i, s) {
     const l = He();
     if (!l || l.locked === !0) return !1;
-    const u = Number(s) > 0, p = dm(l, s);
+    const u = Number(s) > 0, p = gm(l, s);
     if (!p) return !1;
     if (u) {
       const m = yu * Mi(
@@ -17337,7 +17344,7 @@ async function GN(e, t, n = {}) {
       d.frameWheelCommitTimer = 0, d.frameWheelChanged && (d.frameWheelChanged = !1, st(), ut(), We());
     }, 180), We(), !0;
   }
-  function gb() {
+  function _b() {
     return d.frameWheelCommitTimer && (window.clearTimeout(d.frameWheelCommitTimer), d.frameWheelCommitTimer = 0), d.frameWheelChanged ? (d.frameWheelChanged = !1, st(), ut(), We(), !0) : !1;
   }
   function Ra() {
@@ -17346,7 +17353,7 @@ async function GN(e, t, n = {}) {
     const s = i.kind === "roll_frame";
     return i.kind === "pan_frame" ? (i.shot.yaw_deg = i.start.yaw_deg, i.shot.pitch_deg = i.start.pitch_deg) : i.shot.roll_deg = i.start.roll_deg, s && fi(), d.interaction = null, Ui(), Cr(), We(), _t(d.pointerPos), be({ localOnly: !0 }), !0;
   }
-  function bb(i, s) {
+  function xb(i, s) {
     const l = Number(s || 0) * 0.5;
     return {
       radiusModel: "erp_uv_norm",
@@ -17357,20 +17364,20 @@ async function GN(e, t, n = {}) {
     const s = String(i || "").trim();
     return s === "eraser" ? Dr : En[s] ? s : d.activeBrushPresetId || Dr;
   }
-  function Rf() {
-    return (d.primaryTool === "paint" || d.primaryTool === "mask") && (Ff() || jl());
-  }
   function Lf() {
+    return (d.primaryTool === "paint" || d.primaryTool === "mask") && (Rf() || jl());
+  }
+  function zf() {
     var i;
-    return Rf() && ((i = d.pointerPos) == null ? void 0 : i.inside) === !0;
+    return Lf() && ((i = d.pointerPos) == null ? void 0 : i.inside) === !0;
   }
   function Go(i, s = !0) {
     const l = Number((i == null ? void 0 : i.x) || 0), u = Number((i == null ? void 0 : i.y) || 0), p = s !== !1, m = d.pointerPos || { x: 0, y: 0, inside: !1 }, _ = m.inside !== p || Math.abs(m.x - l) > 0.01 || Math.abs(m.y - u) > 0.01;
     return d.pointerPos = { x: l, y: u, inside: p }, _;
   }
-  function yb() {
+  function Sb() {
     var C, N;
-    if (!Lf()) return null;
+    if (!zf()) return null;
     const i = d.primaryTool === "mask" ? "mask" : "paint", s = i === "mask" ? d.maskTool : d.paintTool, l = Qr(s), u = En[l] || En[Dr], p = Number(d.brushSizes[l] ?? 10), m = Math.max(1, p) * Math.max(0.1, Number(u.sizeScale ?? 1)), _ = Math.max(3, m * 0.5), y = i === "mask" ? s === "lasso_fill" ? { r: 0, g: 0, b: 0, a: 1 } : { r: 34 / 255, g: 197 / 255, b: 94 / 255, a: 0.8 } : s === "eraser" ? { r: 1, g: 1, b: 1, a: 0.2 } : $n(d.paintColor), w = i === "mask" ? s === "lasso_fill" ? 0.18 : 0.2 : s === "eraser" ? 0.06 : W(Math.max(0.16, Number(y.a ?? 1) * 0.3), 0.16, 0.52), k = i === "mask" ? 0.95 : s === "eraser" ? 0.75 : W(Math.max(0.46, Number(y.a ?? 1) * 0.92), 0.46, 1);
     return {
       layerKind: i,
@@ -17385,9 +17392,9 @@ async function GN(e, t, n = {}) {
       hotspotY: _
     };
   }
-  function vb() {
+  function wb() {
     var F, B, Z;
-    const i = yb();
+    const i = Sb();
     if (!de) return;
     if (!i) {
       de.style.display = "none";
@@ -17397,7 +17404,7 @@ async function GN(e, t, n = {}) {
     const w = "rgba(222, 222, 222, 0.72)", k = "rgba(52, 52, 52, 0.72)";
     let C = Number(i.hotspotX ?? s * 0.5), N = Number(i.hotspotY ?? l * 0.5);
     if (i.toolKind === "lasso_fill")
-      s = Zs, l = Zs, u = "0", _ = "0", y = "none", C = xN, N = SN, m = ON(i.fillStyle, k, w);
+      s = Zs, l = Zs, u = "0", _ = "0", y = "none", C = NN, N = MN, m = zN(i.fillStyle, k, w);
     else if (i.layerKind === "mask")
       m = "repeating-linear-gradient(135deg, rgba(18,18,18,0.72) 0px, rgba(18,18,18,0.72) 4px, rgba(18,18,18,0.16) 4px, rgba(18,18,18,0.16) 8px)";
     else if (i.toolKind === "marker") {
@@ -17406,7 +17413,7 @@ async function GN(e, t, n = {}) {
     } else i.toolKind === "brush" ? m = `radial-gradient(circle at 50% 50%, ${i.strokeStyle} 0%, ${i.fillStyle} 45%, rgba(0,0,0,0) 100%)` : i.toolKind === "eraser" && (m = "rgba(255,255,255,0.14)");
     de.style.display = "block", de.style.width = `${Math.round(s)}px`, de.style.height = `${Math.round(l)}px`, de.style.borderRadius = u, de.style.border = _, de.style.boxShadow = y, de.style.background = m, de.style.backgroundRepeat = "no-repeat", de.style.backgroundPosition = "center", de.style.backgroundSize = "contain", de.style.transform = `translate(${Math.round(i.x - C)}px, ${Math.round(i.y - N)}px) rotate(${p}deg)`;
   }
-  function _b() {
+  function kb() {
     var pe;
     if (!ce || !we) return;
     const i = d.primaryTool === "mask" ? "mask" : "paint", s = i === "mask" ? d.maskTool : d.paintTool;
@@ -17427,8 +17434,8 @@ async function GN(e, t, n = {}) {
       ce.classList.remove("show", "fade-out"), Q = 0;
     }, 180));
   }
-  function zf(i, s, l, u) {
-    const p = Qr(s), m = En[p] || En[Dr], _ = d.brushSizes[p] ?? 10, y = Math.max(1, _) * Math.max(0.1, m.sizeScale ?? 1), w = bb(u, y), k = l.map((N) => ({
+  function $f(i, s, l, u) {
+    const p = Qr(s), m = En[p] || En[Dr], _ = d.brushSizes[p] ?? 10, y = Math.max(1, _) * Math.max(0.1, m.sizeScale ?? 1), w = xb(u, y), k = l.map((N) => ({
       ...N,
       t: Number((N == null ? void 0 : N.t) || 0),
       widthScale: Number.isFinite(Number(N == null ? void 0 : N.widthScale)) ? Math.max(0, Number(N.widthScale)) : 1,
@@ -17450,9 +17457,9 @@ async function GN(e, t, n = {}) {
         points: k.map((N) => ({ ...N }))
       }
     };
-    return Fh(C, m), Number(m.aspect ?? 1), Number(C.aspect ?? 1), String(C.stampKind || ""), Number(C.size || 0), String(C.radiusModel || ""), Number(C.radiusValue || 0), { ...C.targetSpace }, C;
+    return $h(C, m), Number(m.aspect ?? 1), Number(C.aspect ?? 1), String(C.stampKind || ""), Number(C.size || 0), String(C.radiusModel || ""), Number(C.radiusValue || 0), { ...C.targetSpace }, C;
   }
-  function $f(i, s, l, u) {
+  function jf(i, s, l, u) {
     const p = l.map((w) => ({
       ...w,
       t: Number((w == null ? void 0 : w.t) || 0),
@@ -17474,13 +17481,13 @@ async function GN(e, t, n = {}) {
         points: p.map((w) => ({ ...w }))
       }
     };
-    return Fh(y, _), Number(_.aspect ?? 1), Number(y.aspect ?? 1), String(y.stampKind || ""), { ...y.targetSpace }, y;
+    return $h(y, _), Number(_.aspect ?? 1), Number(y.aspect ?? 1), String(y.stampKind || ""), { ...y.targetSpace }, y;
   }
   function Xi(i) {
     const s = b.painting || (b.painting = so(null)), l = s[i] || (s[i] = { strokes: [] });
     return Array.isArray(l.strokes) || (l.strokes = []), l.strokes;
   }
-  function xb(i, s, l = performance.now()) {
+  function Nb(i, s, l = performance.now()) {
     let u;
     if (d.mode === "frame") {
       const k = He();
@@ -17507,7 +17514,7 @@ async function GN(e, t, n = {}) {
     }
     return !0;
   }
-  function Sb(i, s, l = performance.now()) {
+  function Mb(i, s, l = performance.now()) {
     var _, y;
     let u;
     if (d.mode === "frame") {
@@ -17530,13 +17537,13 @@ async function GN(e, t, n = {}) {
       pressureLike: 1
     }), !0;
   }
-  function wb(i) {
+  function Pb(i) {
     var le, _e, ze, Be, it;
     const s = (i == null ? void 0 : i.stroke) || null;
     if (!s || (i == null ? void 0 : i.layerKind) !== "paint" || String((s == null ? void 0 : s.toolKind) || "") !== "eraser") return !1;
     Vo();
     const l = zn(), u = Da(l.width, l.height);
-    if (!wf(u, s, { w: l.width, h: l.height })) return !1;
+    if (!kf(u, s, { w: l.width, h: l.height })) return !1;
     const p = ((_e = (le = u.ctx) == null ? void 0 : le.getImageData(0, 0, l.width, l.height)) == null ? void 0 : _e.data) || null;
     if (!p) return !1;
     const m = new Map(Rt().map((ve) => [String((ve == null ? void 0 : ve.actionGroupId) || (ve == null ? void 0 : ve.id) || "").trim(), ve ? { ...ve } : null])), _ = [], y = [], w = [...Cn().filter((ve) => String((ve == null ? void 0 : ve.layerKind) || "paint") !== "paint")];
@@ -17596,7 +17603,7 @@ async function GN(e, t, n = {}) {
       return { touched: !1, canvas: null };
     }
     function pe(ve, ae, me) {
-      const Oe = Number(me == null ? void 0 : me.z_index), Fe = R0(ve, ae, me).map((Ee, qe) => ({
+      const Oe = Number(me == null ? void 0 : me.z_index), Fe = j0(ve, ae, me).map((Ee, qe) => ({
         ...Ee,
         z_index: Number.isFinite(Oe) ? Oe + qe * 1e-3 : C + qe * 1e-3
       }));
@@ -17629,7 +17636,7 @@ async function GN(e, t, n = {}) {
         w.push(ve);
         continue;
       }
-      const ae = sf(ve, null);
+      const ae = lf(ve, null);
       if (!ae) {
         w.push(ve);
         continue;
@@ -17645,26 +17652,26 @@ async function GN(e, t, n = {}) {
     }
     return k ? (b.painting.paint.strokes = _, b.painting.groups = y.sort((ve, ae) => Number((ve == null ? void 0 : ve.z_index) || 0) - Number((ae == null ? void 0 : ae.z_index) || 0)), b.painting.raster_objects = w.sort((ve, ae) => Number((ve == null ? void 0 : ve.z_index) || 0) - Number((ae == null ? void 0 : ae.z_index) || 0)), Ta({ preservePanelValues: !1 }), !0) : !1;
   }
-  function kb(i) {
+  function Ab(i) {
     var _, y, w, k, C;
     if ((((y = (_ = i.stroke) == null ? void 0 : _.geometry) == null ? void 0 : y.rawPoints) || ((k = (w = i.stroke) == null ? void 0 : w.geometry) == null ? void 0 : k.points) || []).length >= 1) {
       Vl(i);
       const N = zn();
       N && (String(((C = i.stroke) == null ? void 0 : C.toolKind) || "") === "eraser" ? d.paintEngine.cancelActiveStroke(N) : d.paintEngine.commitActiveStroke(i.stroke, N)), i._hasCommittedSegments = !0;
     }
-    const l = i.stroke, u = { kind: "ERP_GLOBAL", viewMode: String(d.mode || "frame") }, p = zf(i.layerKind, l.toolKind, [], u);
+    const l = i.stroke, u = { kind: "ERP_GLOBAL", viewMode: String(d.mode || "frame") }, p = $f(i.layerKind, l.toolKind, [], u);
     p.actionGroupId = l.actionGroupId, i.stroke = p;
     const m = zn();
     m && d.paintEngine.beginStroke(p, m);
   }
-  function Nb(i) {
+  function Cb(i) {
     var _, y;
     if ((((y = (_ = i.stroke) == null ? void 0 : _.geometry) == null ? void 0 : y.points) || []).length >= 3) {
       Vl(i);
       const w = zn();
       w && d.paintEngine.commitActiveStroke(i.stroke, w), i._hasCommittedSegments = !0;
     }
-    const l = i.stroke, u = { kind: "ERP_GLOBAL", viewMode: String(d.mode || "frame") }, p = $f(i.layerKind, l.toolKind, [], u);
+    const l = i.stroke, u = { kind: "ERP_GLOBAL", viewMode: String(d.mode || "frame") }, p = jf(i.layerKind, l.toolKind, [], u);
     p.actionGroupId = l.actionGroupId, i.stroke = p;
     const m = zn();
     m && d.paintEngine.beginStroke(p, m);
@@ -17675,14 +17682,14 @@ async function GN(e, t, n = {}) {
     if (!s) return !1;
     const l = String(((_ = i == null ? void 0 : i.stroke) == null ? void 0 : _.toolKind) || "pen");
     if (i.layerKind === "paint" && l === "eraser")
-      return s.geometryKind !== "lasso_fill" && (s.processedPoints = Ol(s.rawPoints || s.points || [], i.stroke.targetSpace, !0)), wb(i);
+      return s.geometryKind !== "lasso_fill" && (s.processedPoints = Ol(s.rawPoints || s.points || [], i.stroke.targetSpace, !0)), Pb(i);
     const u = i.layerKind === "paint" && l !== "eraser";
     if (s.geometryKind === "lasso_fill")
-      return (Array.isArray(s.points) ? s.points : []).length < 3 ? !1 : (u && Vc((y = i.stroke) == null ? void 0 : y.actionGroupId), Xi(i.layerKind).push(i.stroke), !0);
+      return (Array.isArray(s.points) ? s.points : []).length < 3 ? !1 : (u && Hc((y = i.stroke) == null ? void 0 : y.actionGroupId), Xi(i.layerKind).push(i.stroke), !0);
     const p = s.rawPoints || s.points || [];
-    return p.length < 1 ? !1 : (s.processedPoints = Ol(p, i.stroke.targetSpace, !0), u && Vc((w = i.stroke) == null ? void 0 : w.actionGroupId), Xi(i.layerKind).push(i.stroke), !0);
+    return p.length < 1 ? !1 : (s.processedPoints = Ol(p, i.stroke.targetSpace, !0), u && Hc((w = i.stroke) == null ? void 0 : w.actionGroupId), Xi(i.layerKind).push(i.stroke), !0);
   }
-  function jf(i) {
+  function Vf(i) {
     var l;
     if (t === "cutout" && d.mode === "frame") {
       const u = He(), p = Yt(u);
@@ -17720,7 +17727,7 @@ async function GN(e, t, n = {}) {
           const F = Fi(Aa(((l = k.item) == null ? void 0 : l.id) || k.id || ""));
           if (!F) continue;
           const B = Qt(F);
-          if (of(F, B, i, _)) return { item: F, geom: B };
+          if (sf(F, B, i, _)) return { item: F, geom: B };
           continue;
         }
         const C = k.item;
@@ -17759,7 +17766,7 @@ async function GN(e, t, n = {}) {
       if (fn(u)) {
         const m = Qt(u);
         if (!(m != null && m.visible)) continue;
-        if (of(u, m, i)) return { item: u, geom: m };
+        if (sf(u, m, i)) return { item: u, geom: m };
         continue;
       }
       const p = Qt(u);
@@ -17809,7 +17816,7 @@ async function GN(e, t, n = {}) {
     }
     return ti(i.rotateHandle, s) <= 144 ? { kind: "rotate", cursor: "grab" } : Or(s, i.corners) ? { kind: "move", cursor: "default" } : { kind: "none", cursor: d.mode === "pano" ? "grab" : "default" };
   }
-  function Vf(i, s) {
+  function Hf(i, s) {
     return {
       x0: Math.min(Number((i == null ? void 0 : i.x) || 0), Number((s == null ? void 0 : s.x) || 0)),
       y0: Math.min(Number((i == null ? void 0 : i.y) || 0), Number((s == null ? void 0 : s.y) || 0)),
@@ -17817,27 +17824,27 @@ async function GN(e, t, n = {}) {
       y1: Math.max(Number((i == null ? void 0 : i.y) || 0), Number((s == null ? void 0 : s.y) || 0))
     };
   }
-  function Mb(i, s) {
+  function Tb(i, s) {
     return !!i && !!s && Number(s.x) >= Number(i.x0) && Number(s.x) <= Number(i.x1) && Number(s.y) >= Number(i.y0) && Number(s.y) <= Number(i.y1);
   }
-  function Pb(i, s) {
+  function Ib(i, s) {
     if (!i || !(s != null && s.visible) || !Array.isArray(s.corners)) return !1;
-    if (s.corners.some((p) => Mb(i, p))) return !0;
+    if (s.corners.some((p) => Tb(i, p))) return !0;
     const l = (Number(i.x0) + Number(i.x1)) * 0.5, u = (Number(i.y0) + Number(i.y1)) * 0.5;
     return !!Or({ x: l, y: u }, s.corners);
   }
   function _t(i) {
-    if (vb(), d.interaction) {
+    if (wb(), d.interaction) {
       d.interaction.kind === "paint_stroke" || d.interaction.kind === "paint_lasso_fill" ? Nt("none") : d.interaction.kind === "view" || d.interaction.kind === "pan_frame" || d.interaction.kind === "roll_frame" ? Nt("grabbing") : d.interaction.kind === "move" || d.interaction.kind === "move_multi" || d.interaction.kind === "move_stroke_group" || d.interaction.kind === "move_raster_object" ? Nt("move") : d.interaction.kind === "scale" || d.interaction.kind === "scale_x" || d.interaction.kind === "scale_y" || d.interaction.kind === "scale_raster_object" ? Nt(d.interaction.cursor || "nwse-resize") : d.interaction.kind === "rotate" ? Nt("grabbing") : Nt("default");
       return;
     }
-    if (Lf()) {
+    if (zf()) {
       Nt("none");
       return;
     }
     if (d.mode === "frame") {
       if (d.altModifier && !r) {
-        Nt(bN);
+        Nt(xN);
         return;
       }
       if (d.primaryTool !== "cursor") {
@@ -17856,7 +17863,7 @@ async function GN(e, t, n = {}) {
       Nt(p.cursor);
       return;
     }
-    if (d.primaryTool === "cursor" && jf(i)) {
+    if (d.primaryTool === "cursor" && Vf(i)) {
       Nt("default");
       return;
     }
@@ -17874,7 +17881,7 @@ async function GN(e, t, n = {}) {
       P.selectionMenu = { visible: !1, left: 0, top: 0, items: [] };
       return;
     }
-    const l = Io(), u = KS({
+    const l = Io(), u = XS({
       type: t,
       selected: i,
       selectedItems: s,
@@ -17887,7 +17894,7 @@ async function GN(e, t, n = {}) {
       cutoutAspectOpen: d.cutoutAspectOpen,
       isExternalSticker: Zt,
       isStickerHidden: zi,
-      canRestoreSelectedToInitial: Ag,
+      canRestoreSelectedToInitial: Eg,
       iconSet: Te
     });
     if (!u.visible) {
@@ -17925,7 +17932,7 @@ async function GN(e, t, n = {}) {
   function fi() {
     Ge.timer && (clearTimeout(Ge.timer), Ge.timer = 0), Ge.target = null, P.tooltip.visible = !1;
   }
-  function Ab(i) {
+  function Eb(i) {
     if (!nn || !i || !i.isConnected) return;
     const s = String(i.getAttribute("data-tip") || "").trim();
     if (!s) return;
@@ -17948,7 +17955,7 @@ async function GN(e, t, n = {}) {
       B = W(B, m, Math.max(m, u.width - y - m)), Z = Math.max(m, Z), P.tooltip.left = B, P.tooltip.top = Z, P.tooltip.variant = F, P.tooltip.visible = !0;
     });
   }
-  const on = Pc({
+  const on = Ac({
     getView: () => ({ yaw: d.viewYaw, pitch: d.viewPitch, fov: d.viewFov }),
     setView: (i) => {
       d.viewYaw = Ut(Number(i.yaw || 0)), d.viewPitch = W(Number(i.pitch || 0), -89.9, 89.9), d.viewFov = W(Number(i.fov || d.viewFov || 100), 35, 140);
@@ -17972,11 +17979,11 @@ async function GN(e, t, n = {}) {
       oe.backgroundDirty = !0, oe.dirty = !0;
     }
   });
-  function Cb(i, s, l = {}) {
+  function Db(i, s, l = {}) {
     var m;
     if ((i == null ? void 0 : i.kind) !== "roll_frame" || !i.shot) return;
-    i.accumulatedRad += om(s, i.lastAngle), i.lastAngle = s;
-    const u = sm(i.start.roll_deg, i.accumulatedRad, {
+    i.accumulatedRad += cm(s, i.lastAngle), i.lastAngle = s;
+    const u = fm(i.start.roll_deg, i.accumulatedRad, {
       shiftKey: l.shiftKey,
       altKey: i.altStarted ? !1 : l.altKey
     });
@@ -17984,16 +17991,16 @@ async function GN(e, t, n = {}) {
     const p = (((m = P.sidePanel) == null ? void 0 : m.params) || []).find((_) => _.key === "roll_deg");
     p && (p.value = u, p.displayValue = aa(u), p.fillPct = (u + 180) / 360 * 100), Ir(), Ul(i), be({ localOnly: !0 });
   }
-  function Tb(i, s, l = {}) {
+  function Ob(i, s, l = {}) {
     var m;
     if ((i == null ? void 0 : i.kind) !== "roll_frame" || !i.shot || !i.rollGesture) return;
-    const u = xm(i.rollGesture, s, l);
+    const u = Nm(i.rollGesture, s, l);
     if (!u) return;
     i.rollGesture = u.gesture, i.center = u.gesture.center, i.lastAngle = u.gesture.lastAngle, i.accumulatedRad = u.gesture.accumulatedRad, i.shot.roll_deg = u.rollDeg, i.changed = i.changed || Math.abs(u.gesture.accumulatedRad) > 1e-9;
     const p = (((m = P.sidePanel) == null ? void 0 : m.params) || []).find((_) => _.key === "roll_deg");
     p && (p.value = u.rollDeg, p.displayValue = aa(u.rollDeg), p.fillPct = (u.rollDeg + 180) / 360 * 100), Ir(), Ul(i), be({ localOnly: !0 });
   }
-  const Hf = (i, s) => {
+  const Uf = (i, s) => {
     const l = ci(i);
     return Math.atan2(l.y - s.y, l.x - s.x);
   };
@@ -18013,7 +18020,7 @@ async function GN(e, t, n = {}) {
     if (!s || s.locked === !0) return;
     const l = Yt(s);
     if (!l) return;
-    const u = { x: l.x + l.w * 0.5, y: l.y + l.h * 0.5 }, p = Hf(i, u);
+    const u = { x: l.x + l.w * 0.5, y: l.y + l.h * 0.5 }, p = Uf(i, u);
     d.interaction = {
       kind: "roll_frame",
       shot: s,
@@ -18027,17 +18034,17 @@ async function GN(e, t, n = {}) {
     }, (m = Ve.setPointerCapture) == null || m.call(Ve, i.pointerId), i.preventDefault(), Ir(), Ul(d.interaction), be({ localOnly: !0 });
   }), Ve == null || Ve.addEventListener("pointermove", (i) => {
     var s;
-    ((s = d.interaction) == null ? void 0 : s.kind) !== "roll_frame" || d.interaction.source !== "knob" || Cb(
+    ((s = d.interaction) == null ? void 0 : s.kind) !== "roll_frame" || d.interaction.source !== "knob" || Db(
       d.interaction,
-      Hf(i, d.interaction.center),
+      Uf(i, d.interaction.center),
       i
     );
   });
-  const Ib = () => {
+  const Fb = () => {
     const i = d.interaction;
     (i == null ? void 0 : i.kind) !== "roll_frame" || i.source !== "knob" || (i.changed && (st(), ut(), We()), d.interaction = null, fi(), Cr(), Ir(), be());
   };
-  Ve == null || Ve.addEventListener("pointerup", Ib), Ve == null || Ve.addEventListener("pointercancel", () => Ra()), Ve == null || Ve.addEventListener("lostpointercapture", () => {
+  Ve == null || Ve.addEventListener("pointerup", Fb), Ve == null || Ve.addEventListener("pointercancel", () => Ra()), Ve == null || Ve.addEventListener("lostpointercapture", () => {
     var i;
     ((i = d.interaction) == null ? void 0 : i.source) === "knob" && Ra();
   }), Ve == null || Ve.addEventListener("dblclick", (i) => {
@@ -18070,7 +18077,7 @@ async function GN(e, t, n = {}) {
     if (d.mode === "frame" && (i.altKey || i.shiftKey) && !r) {
       const y = He(), w = Yt(y);
       if (!y || y.locked === !0 || !w) return;
-      const k = _m({
+      const k = km({
         frame: w,
         point: s,
         startRollDeg: Number(y.roll_deg ?? y.rot_deg ?? 0),
@@ -18114,7 +18121,7 @@ async function GN(e, t, n = {}) {
     }
     if (V && !V.hidden)
       return;
-    if ((d.primaryTool === "paint" || d.primaryTool === "mask") && (Ff() || jl())) {
+    if ((d.primaryTool === "paint" || d.primaryTool === "mask") && (Rf() || jl())) {
       const y = d.primaryTool === "mask" ? "mask" : "paint", w = d.primaryTool === "mask" ? d.maskTool : d.paintTool, k = d.mode === "frame" && jl() ? He() : null, C = { kind: "ERP_GLOBAL" }, N = k ? Qn(s, k, performance.now()) : Zn(s, performance.now());
       if (!N) {
         _t(s);
@@ -18124,7 +18131,7 @@ async function GN(e, t, n = {}) {
         kind: w === "lasso_fill" ? "paint_lasso_fill" : "paint_stroke",
         layerKind: y,
         _livePreviewToken: oa("live"),
-        stroke: w === "lasso_fill" ? $f(y, w, [N], C) : zf(y, w, [N], C)
+        stroke: w === "lasso_fill" ? jf(y, w, [N], C) : $f(y, w, [N], C)
       }, Ui();
       const F = zn();
       if (F)
@@ -18178,7 +18185,7 @@ async function GN(e, t, n = {}) {
               const k = Qt(w);
               return k != null && k.visible ? { x: Number(((C = k.center) == null ? void 0 : C.x) || 0), y: Number(((N = k.center) == null ? void 0 : N.y) || 0) } : { x: s.x, y: s.y };
             })(),
-            centerUv: df(w)
+            centerUv: hf(w)
           }))
         }, _t(s), T.setPointerCapture(i.pointerId);
         return;
@@ -18278,7 +18285,7 @@ async function GN(e, t, n = {}) {
         return;
       }
     }
-    const m = jf(s);
+    const m = Vf(s);
     if (m) {
       const y = d.selectedId !== m.item.id;
       if (y && d.selectedId && (st(), In()), Li(m.item), t === "cutout" && y && (d.cutoutAspectOpen = !1), y && We(), rt(), be(), wn(m.item)) {
@@ -18325,10 +18332,10 @@ async function GN(e, t, n = {}) {
               l._outOfFrame = !0;
               return;
             }
-            l._outOfFrame && (l._outOfFrame = !1, kb(l));
+            l._outOfFrame && (l._outOfFrame = !1, Ab(l));
           }
         }
-        xb(l, Fe, performance.now()) && (me = !0);
+        Nb(l, Fe, performance.now()) && (me = !0);
       }), me && be({ localOnly: !0 });
       return;
     }
@@ -18345,10 +18352,10 @@ async function GN(e, t, n = {}) {
               l._outOfFrame = !0;
               return;
             }
-            l._outOfFrame && (l._outOfFrame = !1, Nb(l));
+            l._outOfFrame && (l._outOfFrame = !1, Cb(l));
           }
         }
-        Sb(l, Fe, performance.now()) && (me = !0);
+        Mb(l, Fe, performance.now()) && (me = !0);
       }), me) {
         const Oe = zn();
         Oe && d.paintEngine.updateActiveStroke(l.stroke, Oe), be({ localOnly: !0 });
@@ -18363,7 +18370,7 @@ async function GN(e, t, n = {}) {
     if (l.kind === "pan_frame") {
       const ae = $l(l.shot);
       if (!ae || !l.shot) return;
-      const me = s.x - l.last.x, Oe = s.y - l.last.y, Fe = Sm(l.shot, {
+      const me = s.x - l.last.x, Oe = s.y - l.last.y, Fe = Mm(l.shot, {
         dx: me,
         dy: Oe,
         focalPx: ae.focalPx,
@@ -18375,7 +18382,7 @@ async function GN(e, t, n = {}) {
     }
     if (l.kind === "roll_frame") {
       if (l.source === "knob") return;
-      Tb(l, s, i);
+      Ob(l, s, i);
       return;
     }
     if (l.kind === "move") {
@@ -18407,7 +18414,7 @@ async function GN(e, t, n = {}) {
       })() : Zn(s, performance.now());
       if (!ae || !l.startUv) return;
       const me = Un(Number(ae.u || 0), Number(l.startUv.u || 0)), Oe = Number(ae.v || 0) - Number(l.startUv.v || 0);
-      Uc((m = l.item) == null ? void 0 : m.actionGroupId, me, Oe, l.snapshot, (_ = l.item) == null ? void 0 : _.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
+      Bc((m = l.item) == null ? void 0 : m.actionGroupId, me, Oe, l.snapshot, (_ = l.item) == null ? void 0 : _.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
       return;
     }
     if (l.kind === "move_raster_object") {
@@ -18417,12 +18424,12 @@ async function GN(e, t, n = {}) {
       })() : Zn(s, performance.now());
       if (!ae || !l.startUv) return;
       const me = Un(Number(ae.u || 0), Number(l.startUv.u || 0)), Oe = Number(ae.v || 0) - Number(l.startUv.v || 0);
-      Gc(((y = l.item) == null ? void 0 : y.rasterObjectId) || ((w = l.item) == null ? void 0 : w.id) || "", me, Oe, l.snapshot) && (Yi(), be({ localOnly: !0 }));
+      Kc(((y = l.item) == null ? void 0 : y.rasterObjectId) || ((w = l.item) == null ? void 0 : w.id) || "", me, Oe, l.snapshot) && (Yi(), be({ localOnly: !0 }));
       return;
     }
     if (l.kind === "scale_raster_object") {
       const me = Math.max(1, Math.hypot(s.x - l.center.x, s.y - l.center.y)) / Math.max(1, Number(l.startDist || 1));
-      bg(((k = l.item) == null ? void 0 : k.rasterObjectId) || ((C = l.item) == null ? void 0 : C.id) || "", me, l.snapshot) && (Yi(), be({ localOnly: !0 }));
+      xg(((k = l.item) == null ? void 0 : k.rasterObjectId) || ((C = l.item) == null ? void 0 : C.id) || "", me, l.snapshot) && (Yi(), be({ localOnly: !0 }));
       return;
     }
     if (l.kind === "move_multi") {
@@ -18442,10 +18449,10 @@ async function GN(e, t, n = {}) {
           const di = {
             x: W((sn.x - Ht.x) / Math.max(1, Ht.w), 0, 1),
             y: W((sn.y - Ht.y) / Math.max(1, Ht.h), 0, 1)
-          }, od = Dl(At, di);
-          if (!od) continue;
-          const sd = ds(od);
-          xt.yaw_deg = sd.yaw, xt.pitch_deg = sd.pitch;
+          }, sd = Dl(At, di);
+          if (!sd) continue;
+          const ld = ds(sd);
+          xt.yaw_deg = ld.yaw, xt.pitch_deg = ld.pitch;
         } else if (d.mode === "unwrap") {
           const At = Jr(), Ht = W((sn.x - At.x) / Math.max(At.w, 1), 0, 1), di = W((sn.y - At.y) / Math.max(At.h, 1), 0, 1);
           xt.yaw_deg = Ut(Ht * 360 - 180), xt.pitch_deg = W(90 - di * 180, -90, 90);
@@ -18465,7 +18472,7 @@ async function GN(e, t, n = {}) {
         })() : Zn(xt, performance.now()), At = tt.centerUv || null;
         if (sn && At) {
           const Ht = Un(Number(sn.u || 0), Number(At.u || 0)), di = Number(sn.v || 0) - Number(At.v || 0);
-          Uc(tt.id, Ht, di, tt.snapshot, tt.layerKind, tt.frameSnapshot) && (Oe = !0, Fe = !0);
+          Bc(tt.id, Ht, di, tt.snapshot, tt.layerKind, tt.frameSnapshot) && (Oe = !0, Fe = !0);
         }
       }
       for (const tt of Array.isArray(l.rasterSnapshots) ? l.rasterSnapshots : []) {
@@ -18478,7 +18485,7 @@ async function GN(e, t, n = {}) {
         })() : Zn(xt, performance.now()), At = tt.centerUv || null;
         if (sn && At) {
           const Ht = Un(Number(sn.u || 0), Number(At.u || 0)), di = Number(sn.v || 0) - Number(At.v || 0);
-          Gc(tt.id, Ht, di, tt.snapshot) && (Oe = !0, Ee = !0);
+          Kc(tt.id, Ht, di, tt.snapshot) && (Oe = !0, Ee = !0);
         }
       }
       Oe && (Fe ? Jn({ rebuildPaintEngine: !1 }) : Ee ? Yi() : an(), be({ localOnly: !0 }));
@@ -18486,12 +18493,12 @@ async function GN(e, t, n = {}) {
     }
     if (l.kind === "scale_stroke_group") {
       const me = Math.max(1, Math.hypot(s.x - l.center.x, s.y - l.center.y)) / Math.max(1, Number(l.startDist || 1));
-      Bc((ze = l.item) == null ? void 0 : ze.actionGroupId, me, 0, l.snapshot, (Be = l.item) == null ? void 0 : Be.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
+      Gc((ze = l.item) == null ? void 0 : ze.actionGroupId, me, 0, l.snapshot, (Be = l.item) == null ? void 0 : Be.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
       return;
     }
     if (l.kind === "rotate_stroke_group") {
       let ae = (Math.atan2(s.y - l.center.y, s.x - l.center.x) - Number(l.startAng || 0)) * zr;
-      i.shiftKey && (ae = Math.round(ae / 45) * 45), Bc((it = l.item) == null ? void 0 : it.actionGroupId, 1, ae, l.snapshot, (ve = l.item) == null ? void 0 : ve.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
+      i.shiftKey && (ae = Math.round(ae / 45) * 45), Gc((it = l.item) == null ? void 0 : it.actionGroupId, 1, ae, l.snapshot, (ve = l.item) == null ? void 0 : ve.layerKind, l.frameSnapshot) && (Jn({ rebuildPaintEngine: !1 }), be({ localOnly: !0 }));
       return;
     }
     if (l.kind === "marquee_select") {
@@ -18534,18 +18541,18 @@ async function GN(e, t, n = {}) {
             B && (B.frame = null);
           }
           const F = zn();
-          F && (k ? String(((p = d.interaction.stroke) == null ? void 0 : p.toolKind) || "") === "eraser" ? (d.paintEngine.cancelActiveStroke(F), _f()) : d.paintEngine.commitActiveStroke(d.interaction.stroke, F) : d.paintEngine.cancelActiveStroke(F)), st(), In(), We(), rt(), e.setDirtyCanvas(!0, !0), be();
+          F && (k ? String(((p = d.interaction.stroke) == null ? void 0 : p.toolKind) || "") === "eraser" ? (d.paintEngine.cancelActiveStroke(F), xf()) : d.paintEngine.commitActiveStroke(d.interaction.stroke, F) : d.paintEngine.cancelActiveStroke(F)), st(), In(), We(), rt(), e.setDirtyCanvas(!0, !0), be();
         } else {
           const N = zn();
           N && d.paintEngine.cancelActiveStroke(N);
         }
       } else if (((m = d.interaction) == null ? void 0 : m.kind) === "marquee_select") {
-        const k = Vf(d.interaction.start, d.interaction.current), N = [
+        const k = Hf(d.interaction.start, d.interaction.current), N = [
           ...t === "cutout" ? El().filter((F) => !Ln(F)) : [...Rn()],
-          ...hg(),
-          ...pg()
-        ].filter((F) => Pb(k, Qt(F)));
-        _g(N, ((_ = N[N.length - 1]) == null ? void 0 : _.id) || null), t === "cutout" && N.length && (d.cutoutAspectOpen = !1), We(), rt(), be();
+          ...bg(),
+          ...yg()
+        ].filter((F) => Ib(k, Qt(F)));
+        kg(N, ((_ = N[N.length - 1]) == null ? void 0 : _.id) || null), t === "cutout" && N.length && (d.cutoutAspectOpen = !1), We(), rt(), be();
       } else if (((y = d.interaction) == null ? void 0 : y.kind) === "pan_frame" || ((w = d.interaction) == null ? void 0 : w.kind) === "roll_frame")
         d.interaction.changed && (st(), ut(), We());
       else if (d.interaction && d.interaction.kind !== "view") {
@@ -18575,8 +18582,8 @@ async function GN(e, t, n = {}) {
     Go(d.pointerPos, !1), _t(d.pointerPos), d.mode === "frame" && d.primaryTool === "cursor" && be({ localOnly: !0 });
   }, T.onwheel = (i) => {
     if (d.mode === "frame") {
-      const s = ci(i), l = Mc(i);
-      l && mb(s, l) && be({ localOnly: !0 }), i.preventDefault();
+      const s = ci(i), l = Pc(i);
+      l && vb(s, l) && be({ localOnly: !0 }), i.preventDefault();
       return;
     }
     d.mode === "pano" && (on.applyWheelEvent(i) && be({ localOnly: !0 }), i.preventDefault());
@@ -18587,26 +18594,26 @@ async function GN(e, t, n = {}) {
     if (t !== "stickers" && t !== "cutout" || r) return;
     i.preventDefault(), i.stopPropagation(), Pt.depth = 0, rn(!1);
     const l = Array.from(((u = i.dataTransfer) == null ? void 0 : u.files) || []).find((p) => Sr(p));
-    l && Af(l);
+    l && Cf(l);
   };
-  const Uf = (i) => {
+  const Bf = (i) => {
     t !== "stickers" && t !== "cutout" || r || cn(i) && (Pt.depth += 1, rn(!0), i.preventDefault());
-  }, Bf = (i) => {
-    t !== "stickers" && t !== "cutout" || r || (!Pt.active && cn(i) && rn(!0), Pt.active && i.preventDefault());
   }, Gf = (i) => {
+    t !== "stickers" && t !== "cutout" || r || (!Pt.active && cn(i) && rn(!0), Pt.active && i.preventDefault());
+  }, Kf = (i) => {
     if (t !== "stickers" && t !== "cutout" || r || !Pt.active) return;
     Pt.depth = Math.max(0, Pt.depth - 1);
     const s = Number(i.clientX) <= 0 && Number(i.clientY) <= 0;
     (Pt.depth === 0 || s) && rn(!1);
-  }, Kf = (i) => {
+  }, Wf = (i) => {
     t !== "stickers" && t !== "cutout" || r || (Pt.depth = 0, rn(!1), cn(i) && i.preventDefault());
   };
-  window.addEventListener("dragenter", Uf, !0), window.addEventListener("dragover", Bf, !0), window.addEventListener("dragleave", Gf, !0), window.addEventListener("drop", Kf, !0);
+  window.addEventListener("dragenter", Bf, !0), window.addEventListener("dragover", Gf, !0), window.addEventListener("dragleave", Kf, !0), window.addEventListener("drop", Wf, !0);
   function Bl() {
-    const { canUndo: i, canRedo: s } = Pf();
+    const { canUndo: i, canRedo: s } = Af();
     na(P.toolButtons, "value", "undo", { disabled: !i }), na(P.toolButtons, "value", "redo", { disabled: !s });
   }
-  const Wf = (i, s, l = !1) => {
+  const Yf = (i, s, l = !1) => {
     var w;
     const u = t === "cutout" && d.mode === "frame" ? He() : null, p = u || It(), m = u ? "shot" : Io();
     if (!p || m === "stroke" || wn(p)) return;
@@ -18623,7 +18630,7 @@ async function GN(e, t, n = {}) {
     if (l === "coverage-set") {
       const F = ln(s.getAttribute("data-coverage"));
       if (F === ln(b.coverage)) return;
-      b.coverage = F, d.coverage = F, h && (h.value = String(F)), o ? oe.backgroundDirty = !0 : (In(), hb({
+      b.coverage = F, d.coverage = F, h && (h.value = String(F)), o ? oe.backgroundDirty = !0 : (In(), bb({
         syncPreview: t !== "cutout",
         syncGraph: t !== "cutout"
       })), We(), rt(), be();
@@ -18638,7 +18645,7 @@ async function GN(e, t, n = {}) {
       P.sidePanel.selectionPicker.open = !1;
       const F = String(s.getAttribute("data-selection-id") || "");
       let B = null;
-      F && (t === "stickers" ? B = Rn().find((Z) => String((Z == null ? void 0 : Z.id) || "") === F) || null : B = ((m = Wc().find((Z) => {
+      F && (t === "stickers" ? B = Rn().find((Z) => String((Z == null ? void 0 : Z.id) || "") === F) || null : B = ((m = Yc().find((Z) => {
         var K;
         return String(((K = Z == null ? void 0 : Z.item) == null ? void 0 : K.id) || "") === F;
       })) == null ? void 0 : m.item) || null), Li(B || null), B && !Wt(B) && Di(
@@ -18651,7 +18658,7 @@ async function GN(e, t, n = {}) {
     if (l === "copy-state-inline") {
       const F = It(), B = Io();
       if (!F || B === "stroke" || Xn().length > 1) return;
-      const Z = JSON.stringify(t === "cutout" && B !== "image" ? ef(F) : Dg(F));
+      const Z = JSON.stringify(t === "cutout" && B !== "image" ? tf(F) : Lg(F));
       try {
         await navigator.clipboard.writeText(Z), (_ = P.sidePanel) != null && _.copyStateButton && (P.sidePanel.copyStateButton.label = "Copied", window.setTimeout(() => {
           var K;
@@ -18695,15 +18702,15 @@ async function GN(e, t, n = {}) {
       Zi();
       return;
     }
-    l === "save-close" && (fb(), Zi());
+    l === "save-close" && (mb(), Zi());
   }), Ne == null || Ne.addEventListener("input", (i) => {
     const s = i.target.closest("[data-action='param-input']");
-    s && Wf(String(s.getAttribute("data-param-key") || ""), s.value, !1);
+    s && Yf(String(s.getAttribute("data-param-key") || ""), s.value, !1);
   }), Ne == null || Ne.addEventListener("change", (i) => {
     const s = i.target.closest("[data-action='param-input']");
-    s && Wf(String(s.getAttribute("data-param-key") || ""), s.value, !0);
+    s && Yf(String(s.getAttribute("data-param-key") || ""), s.value, !0);
   });
-  const Gl = () => nf();
+  const Gl = () => rf();
   Gl(), ie.addEventListener("click", (i) => {
     var y, w, k, C;
     if ((w = (y = i.target) == null ? void 0 : y.matches) != null && w.call(y, "[data-confirm-overlay]")) {
@@ -18728,7 +18735,7 @@ async function GN(e, t, n = {}) {
       if (l.matches("[data-tool-ui-action]")) {
         const N = String(l.getAttribute("data-tool-ui-action") || "");
         if ((N === "undo" || N === "redo") && l.disabled) return;
-        N === "undo" ? Rl(-1) : N === "redo" ? Rl(1) : N === "clear" ? ab() : N === "add" || N === "add-image" ? Z0() : N === "add-or-look" && nb();
+        N === "undo" ? Rl(-1) : N === "redo" ? Rl(1) : N === "clear" ? ub() : N === "add" || N === "add-image" ? nb() : N === "add-or-look" && ob();
         return;
       }
       if (l.matches("[data-paint-tool]")) {
@@ -18743,7 +18750,7 @@ async function GN(e, t, n = {}) {
       }
       if (l.matches("[data-paint-layer-clear-current]")) {
         const N = String(l.getAttribute("data-paint-layer-clear-current") || "paint") === "mask" ? "mask" : "paint";
-        ob(N);
+        cb(N);
         return;
       }
       if (l.matches("[data-paint-color-swatch]")) {
@@ -18824,19 +18831,19 @@ async function GN(e, t, n = {}) {
       if (u === "frame-aspect-set") {
         const N = d.mode === "frame" ? He() : null;
         if (!N || N.locked === !0) return;
-        If(N, String(l.getAttribute("data-aspect") || "1:1")), P.frameRail.aspectOpen = !1, qi(), st(), ut(), Cr(), be();
+        Ef(N, String(l.getAttribute("data-aspect") || "1:1")), P.frameRail.aspectOpen = !1, qi(), st(), ut(), Cr(), be();
         return;
       }
       if (u === "frame-aspect-custom") {
         const N = d.mode === "frame" ? He() : null, F = l.getAttribute("data-custom-width"), B = l.getAttribute("data-custom-height");
-        if (!N || !lb(N, F, B)) return;
+        if (!N || !db(N, F, B)) return;
         P.frameRail.aspectOpen = !1, qi(), st(), ut(), Cr(), be();
         return;
       }
       if (u === "frame-rotate-90") {
         const N = d.mode === "frame" ? He() : null;
         if (!N || N.locked === !0) return;
-        Ef(N), P.frameRail.aspectOpen = !1, qi(), st(), ut(), Cr(), be();
+        Df(N), P.frameRail.aspectOpen = !1, qi(), st(), ut(), Cr(), be();
         return;
       }
       if (u === "aspect") {
@@ -18847,45 +18854,45 @@ async function GN(e, t, n = {}) {
         const N = It();
         if (!N) return;
         const F = String(l.getAttribute("data-aspect") || "1:1");
-        If(N, F), d.cutoutAspectOpen = !1, d.menuSize.measured = !1, qi(), st(), ut(), rt(), be();
+        Ef(N, F), d.cutoutAspectOpen = !1, d.menuSize.measured = !1, qi(), st(), ut(), rt(), be();
         return;
       }
       if (u === "rotate-90") {
         const N = It();
         if (!N) return;
-        Ef(N), d.cutoutAspectOpen = !1, d.menuSize.measured = !1, qi(), st(), ut(), rt(), be();
+        Df(N), d.cutoutAspectOpen = !1, d.menuSize.measured = !1, qi(), st(), ut(), rt(), be();
         return;
       }
       if (u === "bring-front") {
-        ub();
+        hb();
         return;
       }
       if (u === "send-back") {
-        cb();
+        pb();
         return;
       }
       if (u === "duplicate") {
-        sb();
+        fb();
         return;
       }
       if (u === "replace-image") {
-        eb();
+        ib();
         return;
       }
       if (u === "toggle-lock") {
-        vg();
+        wg();
         return;
       }
       if (u === "back-initial") {
-        Mg();
+        Tg();
         return;
       }
       if (u === "toggle-visible") {
-        Ng();
+        Cg();
         return;
       }
       if (u === "delete") {
-        Tf();
+        If();
         return;
       }
     }
@@ -18896,17 +18903,17 @@ async function GN(e, t, n = {}) {
     }
     if (u === "toggle-grid") {
       if (d.mode === "frame") return;
-      d.showGrid = !d.showGrid, $N(e == null ? void 0 : e.id, d.showGrid), Gl(), be();
+      d.showGrid = !d.showGrid, UN(e == null ? void 0 : e.id, d.showGrid), Gl(), be();
       return;
     }
     if (u === "toggle-fullscreen") {
-      i.preventDefault(), i.stopPropagation(), Ob();
+      i.preventDefault(), i.stopPropagation(), zb();
       return;
     }
     if (u === "toggle-output-preview-size") {
       i.preventDefault(), i.stopPropagation();
       const N = !d.outputPreviewExpanded;
-      d.outputPreviewExpanded = N, d.outputPreviewAnimFrom = d.outputPreviewAnim, d.outputPreviewAnimTo = N ? 1 : 0, d.outputPreviewAnimStartTs = performance.now(), Zf(), be();
+      d.outputPreviewExpanded = N, d.outputPreviewAnimFrom = d.outputPreviewAnim, d.outputPreviewAnimTo = N ? 1 : 0, d.outputPreviewAnimStartTs = performance.now(), Qf(), be();
       return;
     }
     const p = i.target.closest("[data-paint-history-index]");
@@ -18954,7 +18961,7 @@ async function GN(e, t, n = {}) {
     if (u) {
       if (u.disabled) return;
       const m = Math.max(1, Math.min(120, Math.round(Number(u.value)))), _ = Qr(d.primaryTool === "paint" ? d.paintTool : d.maskTool);
-      d.brushSizes[_] = m, Tn(), _b();
+      d.brushSizes[_] = m, Tn(), kb();
       return;
     }
     const p = i.target.closest("[data-paint-alpha-slider]");
@@ -18994,7 +19001,7 @@ async function GN(e, t, n = {}) {
   }), ie.addEventListener("pointerover", (i) => {
     const s = i.target.closest("[data-tip]");
     !s || !ie.contains(s) || Ge.target !== s && (Ge.target = s, Ge.timer && clearTimeout(Ge.timer), Ge.timer = window.setTimeout(() => {
-      Ge.target === s && Ab(s);
+      Ge.target === s && Eb(s);
     }, 220));
   }), ie.addEventListener("pointerout", (i) => {
     var u, p;
@@ -19003,17 +19010,17 @@ async function GN(e, t, n = {}) {
   }), ie.addEventListener("pointerdown", (i) => {
     i.target.closest("[data-frame-roll-knob]") || fi();
   });
-  const Eb = (i, s) => {
+  const Rb = (i, s) => {
     var y;
     if (!te) return;
     const l = te.getBoundingClientRect(), u = W((i - l.left) / Math.max(1, l.width), 0, 1), p = 1 - W((s - l.top) / Math.max(1, l.height), 0, 1), m = ku(d.customPaintColor), _ = { ...wu(m.h, u, p), a: Number(((y = d.customPaintColor) == null ? void 0 : y.a) ?? 1) };
     d.customPaintColor = $n(_), d.paintColor = $n(_), Tn();
-  }, Db = (i) => {
+  }, Lb = (i) => {
     var m;
     if (!he) return;
     const s = he.getBoundingClientRect(), l = W((i - s.left) / Math.max(1, s.width), 0, 1), u = ku(d.customPaintColor), p = { ...wu(l, u.s, u.v), a: Number(((m = d.customPaintColor) == null ? void 0 : m.a) ?? 1) };
     d.customPaintColor = $n(p), d.paintColor = $n(p), Tn();
-  }, Yf = (i, s) => {
+  }, qf = (i, s) => {
     const l = i.pointerId;
     s(i);
     const u = (m) => {
@@ -19024,9 +19031,9 @@ async function GN(e, t, n = {}) {
     window.addEventListener("pointermove", u), window.addEventListener("pointerup", p), window.addEventListener("pointercancel", p);
   };
   te && (te.onpointerdown = (i) => {
-    i.preventDefault(), i.stopPropagation(), Yf(i, (s) => Eb(s.clientX, s.clientY));
+    i.preventDefault(), i.stopPropagation(), qf(i, (s) => Rb(s.clientX, s.clientY));
   }), he && (he.onpointerdown = (i) => {
-    i.preventDefault(), i.stopPropagation(), Yf(i, (s) => Db(s.clientX));
+    i.preventDefault(), i.stopPropagation(), qf(i, (s) => Lb(s.clientX));
   }), ie.addEventListener("click", (i) => {
     var p;
     const s = i.target.closest("[data-action='confirm-cancel'], [data-action='confirm-accept']");
@@ -19034,7 +19041,7 @@ async function GN(e, t, n = {}) {
     const l = s.getAttribute("data-action") === "confirm-accept", u = (p = P.confirmDialog) == null ? void 0 : p.resolve;
     P.confirmDialog = { visible: !1, title: "", text: "", confirmLabel: "Confirm", resolve: null }, u == null || u(l);
   });
-  const qf = () => {
+  const Xf = () => {
     const i = !!d.fullscreen;
     na(P.floatingButtons, "action", "toggle-fullscreen", {
       icon: i ? Te.fullscreen_close : Te.fullscreen,
@@ -19043,48 +19050,48 @@ async function GN(e, t, n = {}) {
     });
   }, Wo = (i) => {
     const s = !!i;
-    d.fullscreen !== s && (d.fullscreen = s, ie.classList.toggle("pano-modal-fullscreen", s), s ? (d.fullscreenPrevShowGrid = !!d.showGrid, d.showGrid = !1) : d.fullscreenPrevShowGrid !== null && (d.showGrid = !!d.fullscreenPrevShowGrid, d.fullscreenPrevShowGrid = null), Gl(), qf(), Ft(), be());
-  }, Xf = () => document.fullscreenElement === se, Ob = async () => {
+    d.fullscreen !== s && (d.fullscreen = s, ie.classList.toggle("pano-modal-fullscreen", s), s ? (d.fullscreenPrevShowGrid = !!d.showGrid, d.showGrid = !1) : d.fullscreenPrevShowGrid !== null && (d.showGrid = !!d.fullscreenPrevShowGrid, d.fullscreenPrevShowGrid = null), Gl(), Xf(), Ft(), be());
+  }, Jf = () => document.fullscreenElement === se, zb = async () => {
     var i, s;
     try {
       if (!document.fullscreenEnabled) {
         Wo(!d.fullscreen);
         return;
       }
-      Xf() ? await ((s = document.exitFullscreen) == null ? void 0 : s.call(document)) : await ((i = se.requestFullscreen) == null ? void 0 : i.call(se));
+      Jf() ? await ((s = document.exitFullscreen) == null ? void 0 : s.call(document)) : await ((i = se.requestFullscreen) == null ? void 0 : i.call(se));
     } catch {
       Wo(!d.fullscreen);
     }
-  }, Jf = () => {
-    document.fullscreenEnabled && Wo(Xf());
+  }, Zf = () => {
+    document.fullscreenEnabled && Wo(Jf());
   };
-  document.addEventListener("fullscreenchange", Jf), qf();
-  const Zf = () => {
+  document.addEventListener("fullscreenchange", Zf), Xf();
+  const Qf = () => {
     const i = !!d.outputPreviewExpanded;
     P.outputPreviewToggle.icon = i ? Te.fullscreen_close : Te.fullscreen, P.outputPreviewToggle.label = i ? "Reduce Preview" : "Expand Preview", P.outputPreviewToggle.tip = i ? "Reduce preview" : "Expand preview";
   };
-  Zf();
+  Qf();
   const Kl = e.onExecuted, Wl = e.onConnectionsChange;
-  let Yl = null, ql = null, Qf = null, ed = () => {
+  let Yl = null, ql = null, ed = null, td = () => {
   };
-  !r && t === "stickers" && (Qf = (i = "sync") => {
-    tf(i);
-  }, ed = zm(e, Qf), Yl = function(...s) {
-    typeof Kl == "function" && Kl.apply(this, s), MN(Re, os), Qa(this, "executed");
+  !r && t === "stickers" && (ed = (i = "sync") => {
+    nf(i);
+  }, td = Hm(e, ed), Yl = function(...s) {
+    typeof Kl == "function" && Kl.apply(this, s), TN(Re, os), Qa(this, "executed");
   }, e.onExecuted = Yl, ql = function(...s) {
     typeof Wl == "function" && Wl.apply(this, s), Qa(this, "connections");
-  }, e.onConnectionsChange = ql), r || Hh.set(String(e.id ?? "0"), () => uf());
+  }, e.onConnectionsChange = ql), r || Kh.set(String(e.id ?? "0"), () => cf());
   let Ji = null;
   const Zi = async () => Ji || (Ji = (async () => {
     var i, s, l, u, p, m, _, y, w, k, C;
-    return Hh.delete(String(e.id ?? "0")), gb(), r || In(), document.fullscreenElement === se && ((i = document.exitFullscreen) == null || i.call(document).catch(() => {
-    })), document.removeEventListener("fullscreenchange", Jf), e.__panoLiveStateOverride = null, e.__panoLivePaintSurface = null, e.__panoFlushStateBeforeQueue === Of && (e.__panoFlushStateBeforeQueue = null), (l = (s = e.__panoDomPreview) == null ? void 0 : s.requestDraw) == null || l.call(s), (p = (u = e.graph) == null ? void 0 : u.setDirtyCanvas) == null || p.call(u, !0, !0), (y = (_ = (m = nr) == null ? void 0 : m.canvas) == null ? void 0 : _.setDirty) == null || y.call(_, !0, !0), fi(), J0(), U instanceof HTMLVideoElement && U.pause(), Le.forEach((N) => {
+    return Kh.delete(String(e.id ?? "0")), _b(), r || In(), document.fullscreenElement === se && ((i = document.exitFullscreen) == null || i.call(document).catch(() => {
+    })), document.removeEventListener("fullscreenchange", Zf), e.__panoLiveStateOverride = null, e.__panoLivePaintSurface = null, e.__panoFlushStateBeforeQueue === Ff && (e.__panoFlushStateBeforeQueue = null), (l = (s = e.__panoDomPreview) == null ? void 0 : s.requestDraw) == null || l.call(s), (p = (u = e.graph) == null ? void 0 : u.setDirtyCanvas) == null || p.call(u, !0, !0), (y = (_ = (m = nr) == null ? void 0 : m.canvas) == null ? void 0 : _.setDirty) == null || y.call(_, !0, !0), fi(), tb(), U instanceof HTMLVideoElement && U.pause(), Le.forEach((N) => {
       try {
         N();
       } catch {
       }
-    }), (w = xe == null ? void 0 : xe.dispose) == null || w.call(xe), (k = De == null ? void 0 : De.unmount) == null || k.call(De), (C = Ae == null ? void 0 : Ae.dispose) == null || C.call(Ae), rn(!1), window.removeEventListener("keydown", td, !0), window.removeEventListener("keydown", nd, !0), window.removeEventListener("keydown", Yo, !0), window.removeEventListener("keyup", Yo, !0), window.removeEventListener("blur", rd), window.removeEventListener("keydown", id, !0), window.removeEventListener("dragenter", Uf, !0), window.removeEventListener("dragover", Bf, !0), window.removeEventListener("dragleave", Gf, !0), window.removeEventListener("drop", Kf, !0), !r && t === "stickers" && (e.onExecuted === Yl && (e.onExecuted = Kl), e.onConnectionsChange === ql && (e.onConnectionsChange = Wl), ed()), G.unmount(), $.remove(), db(), Ji = null, !0;
-  })().catch((i) => (console.error("[PanoramaCutoutSync] closeEditor failed", i), Ji = null, !1)), Ji), td = (i) => {
+    }), (w = xe == null ? void 0 : xe.dispose) == null || w.call(xe), (k = De == null ? void 0 : De.unmount) == null || k.call(De), (C = Ae == null ? void 0 : Ae.dispose) == null || C.call(Ae), rn(!1), window.removeEventListener("keydown", nd, !0), window.removeEventListener("keydown", rd, !0), window.removeEventListener("keydown", Yo, !0), window.removeEventListener("keyup", Yo, !0), window.removeEventListener("blur", id), window.removeEventListener("keydown", ad, !0), window.removeEventListener("dragenter", Bf, !0), window.removeEventListener("dragover", Gf, !0), window.removeEventListener("dragleave", Kf, !0), window.removeEventListener("drop", Wf, !0), !r && t === "stickers" && (e.onExecuted === Yl && (e.onExecuted = Kl), e.onConnectionsChange === ql && (e.onConnectionsChange = Wl), td()), G.unmount(), $.remove(), gb(), Ji = null, !0;
+  })().catch((i) => (console.error("[PanoramaCutoutSync] closeEditor failed", i), Ji = null, !1)), Ji), nd = (i) => {
     var s, l, u, p, m;
     if (i.key === "Escape") {
       if (Ra()) {
@@ -19102,26 +19109,26 @@ async function GN(e, t, n = {}) {
       }
       i.preventDefault(), i.stopPropagation(), (m = i.stopImmediatePropagation) == null || m.call(i), Zi();
     }
-  }, nd = (i) => {
+  }, rd = (i) => {
     const s = String(i.key || ""), l = String(i.code || ""), u = Number(i.keyCode || 0);
     if (!(s === "Delete" || l === "Delete" || u === 46) && !(s === "Backspace" || l === "Backspace" || u === 8)) return;
     const _ = i.target, y = ((_ == null ? void 0 : _.tagName) || "").toUpperCase();
-    y === "INPUT" || y === "TEXTAREA" || _ != null && _.isContentEditable || !It() || (Tf(), i.preventDefault(), i.stopPropagation());
+    y === "INPUT" || y === "TEXTAREA" || _ != null && _.isContentEditable || !It() || (If(), i.preventDefault(), i.stopPropagation());
   }, Yo = (i) => {
     const s = !!(i.ctrlKey || i.metaKey), l = !!i.altKey;
     d.marqueeModifier === s && d.altModifier === l || (d.marqueeModifier = s, d.altModifier = l, Ir(), _t(d.pointerPos));
-  }, rd = () => {
+  }, id = () => {
     d.marqueeModifier = !1, d.altModifier = !1, Ir(), _t(d.pointerPos);
-  }, id = (i) => {
+  }, ad = (i) => {
     if (r || !i.ctrlKey && !i.metaKey) return;
     const s = String(i.key || "").toLowerCase(), l = String(i.code || "");
     if (s !== "z" && l !== "KeyZ") return;
     const u = i.target, p = ((u == null ? void 0 : u.tagName) || "").toUpperCase();
     if (p === "INPUT" || p === "TEXTAREA" || u != null && u.isContentEditable) return;
-    const { canUndo: m, canRedo: _ } = Pf();
+    const { canUndo: m, canRedo: _ } = Af();
     i.shiftKey && !_ || !i.shiftKey && !m || (Rl(i.shiftKey ? 1 : -1), i.preventDefault(), i.stopPropagation());
   };
-  window.addEventListener("keydown", td, !0), window.addEventListener("keydown", nd, !0), window.addEventListener("keydown", Yo, !0), window.addEventListener("keyup", Yo, !0), window.addEventListener("blur", rd), window.addEventListener("keydown", id, !0), se.addEventListener("pointerdown", (i) => {
+  window.addEventListener("keydown", nd, !0), window.addEventListener("keydown", rd, !0), window.addEventListener("keydown", Yo, !0), window.addEventListener("keyup", Yo, !0), window.addEventListener("blur", id), window.addEventListener("keydown", ad, !0), se.addEventListener("pointerdown", (i) => {
     i.target === se && Zi();
   });
   function or(i, s, { rollbackState: l = !1 } = {}) {
@@ -19139,16 +19146,16 @@ async function GN(e, t, n = {}) {
       P.stageWarningDetail = `boot:${i}`, console.error(`[PanoramaStickers] editor boot step "${i}" failed`, p);
     }
   }
-  or("cutout-focus", Rg), !r && t === "stickers" && or("external-sticker-sync", () => tf("open"), { rollbackState: !0 }), tb().catch((i) => {
+  or("cutout-focus", jg), !r && t === "stickers" && or("external-sticker-sync", () => nf("open"), { rollbackState: !0 }), ab().catch((i) => {
     P.stageWarningDetail = "boot:asset-migration", console.error('[PanoramaStickers] editor boot step "asset-migration" failed', i);
-  }), or("history", st), or("undo-redo", Bl), or("paint-ui", Tn), or("side-panel", We), or("look-at-frame", Nl), or("video-source", Vi), or("canvas-size", Nf), or("cursor", () => _t(d.pointerPos)), be(), oe.rafId = requestAnimationFrame(Mf);
+  }), or("history", st), or("undo-redo", Bl), or("paint-ui", Tn), or("side-panel", We), or("look-at-frame", Nl), or("video-source", Vi), or("canvas-size", Mf), or("cursor", () => _t(d.pointerPos)), be(), oe.rafId = requestAnimationFrame(Pf);
 }
-nr.registerExtension(vx({
+nr.registerExtension(wx({
   app: nr,
-  openEditor: GN,
-  attachStickers: ES,
-  attachCutout: DS,
-  attachPreview: IS,
+  openEditor: qN,
+  attachStickers: RS,
+  attachCutout: LS,
+  attachPreview: FS,
   requestFrame: requestAnimationFrame,
-  enableStickersPreview: mN
+  enableStickersPreview: vN
 }));

--- a/web_src/pano_dom_widget_lifecycle.js
+++ b/web_src/pano_dom_widget_lifecycle.js
@@ -1,4 +1,18 @@
 const trackedWidgets = new WeakSet();
+const preparedWidgets = new WeakSet();
+let domWidgetGeneration = 0;
+
+// Node 2.0 keys its WidgetDOM component by the stable node/widget identity plus
+// widget.type. Undo can replace a node with the same IDs in one Vue update, so
+// a fresh type is required to mount the replacement widget.element.
+export function assignFreshDomWidgetRenderIdentity(widget) {
+  if (!widget || typeof widget !== "object" || preparedWidgets.has(widget)) return widget;
+  const baseType = String(widget.type || "preview");
+  domWidgetGeneration += 1;
+  widget.type = `${baseType}:pano-${domWidgetGeneration}`;
+  preparedWidgets.add(widget);
+  return widget;
+}
 
 export function trackDomWidgetRemoval(widget) {
   if (!widget || typeof widget !== "object" || trackedWidgets.has(widget)) return widget;

--- a/web_src/pano_preview_previewnode.js
+++ b/web_src/pano_preview_previewnode.js
@@ -14,6 +14,7 @@ import { buildStickerRenderDescriptor } from "./pano_render_descriptors.js";
 import { buildPreviewNodeViewParams, buildStickerSceneFromState } from "./pano_gl_scene.js";
 import { installPanoSuiteStylesheet } from "./pano_styles.js";
 import {
+  assignFreshDomWidgetRenderIdentity,
   removeTrackedDomWidget,
   trackDomWidgetRemoval,
 } from "./pano_dom_widget_lifecycle.js";
@@ -438,9 +439,9 @@ class PreviewNodeRuntime {
         afterResize: () => this.requestDraw(),
       };
 
-      this.widget = trackDomWidgetRemoval(
+      this.widget = trackDomWidgetRemoval(assignFreshDomWidgetRenderIdentity(
         this.node.addDOMWidget("preview", "preview", this.root, widgetOptions),
-      );
+      ));
       if (this.widget) {
         this.widget.serialize = false;
         const prevComputeLayoutSize = typeof this.widget.computeLayoutSize === "function"

--- a/web_src/pano_preview_runtime.js
+++ b/web_src/pano_preview_runtime.js
@@ -89,6 +89,7 @@ import {
   runExternalStickerSync,
 } from "./pano_external_sticker_sync.js";
 import {
+  assignFreshDomWidgetRenderIdentity,
   removeTrackedDomWidget,
   trackDomWidgetRemoval,
 } from "./pano_dom_widget_lifecycle.js";
@@ -3291,9 +3292,9 @@ function attachPanoramaPreviewImpl(node, options = {}) {
   ].join(";");
 
   if (noPreview) {
-    const widget = trackDomWidgetRemoval(
+    const widget = trackDomWidgetRemoval(assignFreshDomWidgetRenderIdentity(
       node.addDOMWidget(getAnimPreviewWidgetName(), "preview", root, createCoreManagedDomWidgetOptions(node, null)),
-    );
+    ));
     suppressBuiltInPreviewImgs(node);
     node.__panoDomPreview = { widget, root, requestDraw: () => { } };
     node.__panoPreviewHooked = true;
@@ -3365,7 +3366,7 @@ function attachPanoramaPreviewImpl(node, options = {}) {
   let widget = null;
   try {
     armPreviewBootMinHeight(node, bootMinHeight, () => node.__panoDomPreview?.requestDraw?.());
-    widget = trackDomWidgetRemoval(node.addDOMWidget(
+    widget = trackDomWidgetRemoval(assignFreshDomWidgetRenderIdentity(node.addDOMWidget(
       getAnimPreviewWidgetName(),
       "preview",
       root,
@@ -3376,7 +3377,7 @@ function attachPanoramaPreviewImpl(node, options = {}) {
       surfaceMinHeight,
       false,
       ),
-    ));
+    )));
   } catch {
     return;
   }
@@ -4432,12 +4433,12 @@ export function attachStandalonePreviewDom(node, options = {}) {
     root.appendChild(wrap);
 
     armPreviewBootMinHeight(node, 56, () => node.__panoDomPreview?.requestDraw?.());
-    const widget = trackDomWidgetRemoval(node.addDOMWidget(
+    const widget = trackDomWidgetRemoval(assignFreshDomWidgetRenderIdentity(node.addDOMWidget(
       getAnimPreviewWidgetName(),
       "preview",
       root,
       createCoreManagedDomWidgetOptions(node, () => node.__panoDomPreview?.requestDraw?.(), 56),
-    ));
+    )));
     if (widget) widget.serialize = false;
     suppressBuiltInPreviewImgs(node);
 

--- a/web_src/pano_sticker_affordance.js
+++ b/web_src/pano_sticker_affordance.js
@@ -1,3 +1,5 @@
+export const STICKER_NODE_ROTATE_HANDLE_OFFSET_PX = 24;
+
 export function stickerSelectionAccent(item = {}) {
   if (item?.locked === true) return "#ff4d4f";
   if (String(item?.source_kind || "") === "external_image" || String(item?.id || "") === "sticker_image_1") {
@@ -69,7 +71,7 @@ export function drawStickerSelectionHandles(ctx, geometry, { accent = "#0070f3" 
   ctx.fillStyle = accent;
   geometry.corners.forEach((point) => {
     ctx.beginPath();
-    ctx.arc(point.x, point.y, 6.5, 0, Math.PI * 2);
+    ctx.arc(point.x, point.y, 5.5, 0, Math.PI * 2);
     ctx.fill();
   });
   ctx.strokeStyle = "rgba(250, 250, 250, 0.9)";
@@ -80,6 +82,6 @@ export function drawStickerSelectionHandles(ctx, geometry, { accent = "#0070f3" 
   ctx.stroke();
   ctx.fillStyle = accent;
   ctx.beginPath();
-  ctx.arc(geometry.rotateHandle.x, geometry.rotateHandle.y, 10, 0, Math.PI * 2);
+  ctx.arc(geometry.rotateHandle.x, geometry.rotateHandle.y, 8, 0, Math.PI * 2);
   ctx.fill();
 }

--- a/web_src/pano_sticker_geometry.js
+++ b/web_src/pano_sticker_geometry.js
@@ -12,7 +12,10 @@ import {
   wrapYaw,
   yawPitchToDir,
 } from "./pano_camera_math.js";
-import { hitStickerSelectionAffordance } from "./pano_sticker_affordance.js";
+import {
+  STICKER_NODE_ROTATE_HANDLE_OFFSET_PX,
+  hitStickerSelectionAffordance,
+} from "./pano_sticker_affordance.js";
 
 export { hitStickerSelectionAffordance as hitStickerGeometry } from "./pano_sticker_affordance.js";
 
@@ -135,8 +138,8 @@ export function buildStickerGeometry(item, camera, viewport) {
     boundaryEdges,
     rotateStemBase: { x: rotateStemBase.x, y: rotateStemBase.y },
     rotateHandle: {
-      x: rotateStemBase.x + (handleDx / handleLength) * 30,
-      y: rotateStemBase.y + (handleDy / handleLength) * 30,
+      x: rotateStemBase.x + (handleDx / handleLength) * STICKER_NODE_ROTATE_HANDLE_OFFSET_PX,
+      y: rotateStemBase.y + (handleDy / handleLength) * STICKER_NODE_ROTATE_HANDLE_OFFSET_PX,
     },
     visible: true,
   };


### PR DESCRIPTION
## 概要

v1.5.0のリリース準備として、ノード上UIの仕上げ、Undo復元時の安定化、READMEの更新を行います。

## 変更内容

- package versionを1.5.0へ更新
- ノード上のsticker選択ハンドルを小型化
  - ノード上のみrotation stemを短縮
  - modal UIのrotation stemは従来の長さを維持
- Node 2.0でCtrl+Z後にノード上UIが消える問題を修正
  - Undoが同一node/widget IDを再構築する場合もDOM widgetを再描画
  - Cutout、Stickers、Previewで共通のlifecycle helperを使用
- READMEへv1.5.0 demoと概要を追加
- 日本語版・簡体中国語版READMEと、3言語の切り替えshieldを追加

## 確認

- frontend tests: 188 passed
- Python tests: 157 passed
- focused post-review tests: 64 passed
- frontend build成功
- generated bundle同期確認済み
- `git diff --check` 成功
- dev ComfyUI（port 8189、Node 2.0）で実際のCtrl+Zを確認
  - Panorama Cutout
  - Panorama Stickers
  - Panorama Preview
  - 3ノードとも位置復元後にノード上UIが維持され、関連するconsole errorなし
